### PR TITLE
Improve build chunk size

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -37,6 +37,63 @@ export default defineConfig({
     // 只暴露必要的环境变量，避免安全风险
     'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development'),
   },
+  build: {
+    // 优化构建配置，避免 chunk 过大警告
+    chunkSizeWarningLimit: 1000,
+    rollupOptions: {
+      output: {
+        // 手动分割代码块，优化加载性能
+        // 注意：检查顺序很重要，先检查具体的库，再检查通用的
+        manualChunks: (id) => {
+          // 国际化库（先检查，避免被 react 匹配）
+          if (id.includes('i18next') || id.includes('react-i18next')) {
+            return 'i18n-vendor';
+          }
+          // 数据获取库
+          if (id.includes('swr')) {
+            return 'data-vendor';
+          }
+          // 工具库
+          if (id.includes('lodash')) {
+            return 'utils-vendor';
+          }
+          // 日期处理库（moment 较大，单独分割）
+          if (id.includes('moment')) {
+            return 'date-vendor';
+          }
+          // 动画库
+          if (id.includes('motion') || id.includes('framer-motion')) {
+            return 'animation-vendor';
+          }
+          // 图标库
+          if (id.includes('lucide-react')) {
+            return 'icons-vendor';
+          }
+          // 拖拽库
+          if (id.includes('@dnd-kit')) {
+            return 'dnd-vendor';
+          }
+          // Radix UI 组件库
+          if (id.includes('@radix-ui')) {
+            return 'ui-vendor';
+          }
+          // React 核心库（放在后面，避免匹配到其他 react-* 包）
+          // 匹配 react、react-dom 和 react-router 系列
+          if (
+            (id.includes('node_modules/react/') && !id.includes('react-')) ||
+            id.includes('node_modules/react-dom/') ||
+            id.includes('node_modules/react-router')
+          ) {
+            return 'react-vendor';
+          }
+          // node_modules 中的其他依赖
+          if (id.includes('node_modules')) {
+            return 'vendor';
+          }
+        },
+      },
+    },
+  },
   preview: {
     host: true,
     port: 3001,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds Vite build config to manually split vendor chunks and raises chunk size warning limit.
> 
> - **Build (Vite)** in `web/vite.config.ts`:
>   - Set `build.chunkSizeWarningLimit` to `1000`.
>   - Add Rollup `output.manualChunks` to split vendors:
>     - `i18n-vendor` (`i18next`, `react-i18next`)
>     - `data-vendor` (`swr`)
>     - `utils-vendor` (`lodash`)
>     - `date-vendor` (`moment`)
>     - `animation-vendor` (`motion`, `framer-motion`)
>     - `icons-vendor` (`lucide-react`)
>     - `dnd-vendor` (`@dnd-kit`)
>     - `ui-vendor` (`@radix-ui`)
>     - `react-vendor` (`react`, `react-dom`, `react-router*`)
>     - Fallback `vendor` for other `node_modules`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72ab7a7b05392ffffb9b2dcb8335c29a101eee29. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->