### PR TITLE
fix: ensure VITE_API_BASE uses runtime config dynamically

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -42,9 +42,11 @@
         if (!window.__ROTE_CONFIG__) {
           window.__ROTE_CONFIG__ = {};
         }
+        // 容器启动脚本会替换此占位符为实际的 API 基础 URL
         // 如果占位符未被替换（配置注入失败），删除该属性让代码回退到构建时配置
-        if (window.__ROTE_CONFIG__.VITE_API_BASE === '__VITE_API_BASE_PLACEHOLDER__') {
-          delete window.__ROTE_CONFIG__.VITE_API_BASE;
+        var apiBase = '__VITE_API_BASE_PLACEHOLDER__';
+        if (apiBase !== '__VITE_API_BASE_PLACEHOLDER__') {
+          window.__ROTE_CONFIG__.VITE_API_BASE = apiBase;
         }
       })();
     </script>

--- a/web/src/components/experiment/exportData.tsx
+++ b/web/src/components/experiment/exportData.tsx
@@ -1,6 +1,6 @@
 import { Divider } from '@/components/ui/divider';
 import type { Statistics } from '@/types/main';
-import { API_POINT, get } from '@/utils/api';
+import { get, getApiUrl } from '@/utils/api';
 import { authService } from '@/utils/auth';
 import { useAPIGet } from '@/utils/fetcher';
 import { DownloadCloud } from 'lucide-react';
@@ -30,7 +30,8 @@ export default function ExportData() {
         throw new Error('认证token无效或已过期');
       }
 
-      const response = await fetch(`${API_POINT}/v2/api/users/me/export`, {
+      // 使用 getApiUrl() 确保获取最新的运行时配置
+      const response = await fetch(`${getApiUrl()}/users/me/export`, {
         method: 'GET',
         headers: {
           Authorization: `Bearer ${token}`,

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -2,7 +2,7 @@ import '@/styles/index.css';
 import ReactDOM from 'react-dom/client';
 import { registerSW } from 'virtual:pwa-register';
 import AppWrapper from './App';
-import { API_URL } from './utils/api';
+import { getApiUrl } from './utils/api';
 import './utils/i18n';
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
@@ -21,10 +21,11 @@ registerSW({
   },
   onRegistered(registration) {
     // Service Worker 注册成功后，发送 API URL 配置
+    // 使用 getApiUrl() 确保获取最新的运行时配置
     if (registration?.active) {
       registration.active.postMessage({
         method: 'setApiUrl',
-        apiUrl: API_URL,
+        apiUrl: getApiUrl(),
       });
     }
   },
@@ -41,11 +42,12 @@ if ('serviceWorker' in navigator) {
   });
 
   // 当 Service Worker 就绪时，发送 API URL
+  // 使用 getApiUrl() 确保获取最新的运行时配置
   navigator.serviceWorker.ready.then((registration) => {
     if (registration?.active) {
       registration.active.postMessage({
         method: 'setApiUrl',
-        apiUrl: API_URL,
+        apiUrl: getApiUrl(),
       });
     }
   });


### PR DESCRIPTION
- Convert getApiPoint and getApiUrl to functions that read config on each call
- Set baseURL dynamically in axios request interceptor instead of at instance creation
- Update main.tsx and exportData.tsx to use getApiUrl() function
- Add placeholder in index.html for docker-entrypoint.sh to replace
- This ensures all API requests use the latest runtime configuration even if config injection happens after module loading

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make API base URL read from runtime on each call, set axios baseURL per-request, and propagate the URL to SW and export download.
> 
> - **API utils (`web/src/utils/api.ts`)**:
>   - Convert `getApiPoint()`/`getApiUrl()` to functions that re-read runtime config; export `API_URL` via `getApiUrl()`.
>   - Remove static axios `baseURL`; set `config.baseURL = getApiUrl()` in request interceptor.
>   - Use dynamic URL in token refresh: `axios.post(`${getApiUrl()}/auth/refresh`, ...)`.
> - **Runtime config injection (`web/index.html`)**:
>   - Add placeholder handling to set `window.__ROTE_CONFIG__.VITE_API_BASE` when replaced at container startup.
> - **Frontend updates**:
>   - `web/src/main.tsx`: send `apiUrl: getApiUrl()` to Service Worker on register/ready.
>   - `web/src/components/experiment/exportData.tsx`: use `getApiUrl()` for export download endpoint.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e14044f3c48e138a3827abdfe1334af4203d446. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->