### PR TITLE
feat: Add ProductHunt button component to landing page

### DIFF
--- a/web/src/components/others/ProductHunt.tsx
+++ b/web/src/components/others/ProductHunt.tsx
@@ -1,0 +1,91 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router';
+
+function ProductHunt() {
+  const { t } = useTranslation('translation', { keyPrefix: 'components.productHunt' });
+
+  const productHuntUrl = 'https://www.producthunt.com/products/rote-2';
+  const scheduledDate = new Date('2025-12-25T08:01:00Z'); // December 25th, 2025 12:01 AM PST (UTC+8)
+  const isScheduled = new Date() < scheduledDate;
+
+  return (
+    <Tooltip open={true}>
+      <TooltipTrigger asChild>
+        <Link
+          to={productHuntUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="group relative inline-flex h-10 items-center rounded-md border border-[#FF6154]"
+        >
+          <svg
+            width="250"
+            height="54"
+            viewBox="0 0 250 54"
+            version="1.1"
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-full w-auto"
+            preserveAspectRatio="xMidYMid meet"
+          >
+            <g stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
+              <g transform="translate(-130.000000, -73.000000)">
+                <g transform="translate(130.000000, 73.000000)">
+                  <text
+                    fontFamily="Helvetica-Bold, Helvetica"
+                    fontSize="9"
+                    fontWeight="bold"
+                    fill="#FF6154"
+                  >
+                    <tspan x="53" y="20">
+                      {t('findUsOn')}
+                    </tspan>
+                  </text>
+                  <text
+                    fontFamily="Helvetica-Bold, Helvetica"
+                    fontSize="21"
+                    fontWeight="bold"
+                    fill="#FF6154"
+                  >
+                    <tspan x="52" y="40">
+                      Product Hunt
+                    </tspan>
+                  </text>
+                  <g transform="translate(11.000000, 12.000000)">
+                    <path
+                      d="M31,15.5 C31,24.0603917 24.0603917,31 15.5,31 C6.93960833,31 0,24.0603917 0,15.5 C0,6.93960833 6.93960833,0 15.5,0 C24.0603917,0 31,6.93960833 31,15.5"
+                      fill="#FF6154"
+                    />
+                    <path
+                      d="M17.4329412,15.9558824 L17.4329412,15.9560115 L13.0929412,15.9560115 L13.0929412,11.3060115 L17.4329412,11.3060115 L17.4329412,11.3058824 C18.7018806,11.3058824 19.7305882,12.3468365 19.7305882,13.6308824 C19.7305882,14.9149282 18.7018806,15.9558824 17.4329412,15.9558824 M17.4329412,8.20588235 L17.4329412,8.20601152 L10.0294118,8.20588235 L10.0294118,23.7058824 L13.0929412,23.7058824 L13.0929412,19.0560115 L17.4329412,19.0560115 L17.4329412,19.0558824 C20.3938424,19.0558824 22.7941176,16.6270324 22.7941176,13.6308824 C22.7941176,10.6347324 20.3938424,8.20588235 17.4329412,8.20588235"
+                      fill="#FFFFFF"
+                    />
+                  </g>
+                </g>
+              </g>
+            </g>
+          </svg>
+        </Link>
+      </TooltipTrigger>
+      {isScheduled ? (
+        <TooltipContent side="top">
+          <p className="text-sm">
+            {t('scheduledDate', {
+              date: scheduledDate.toLocaleDateString('en-US', {
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric',
+                timeZone: 'America/Los_Angeles',
+              }),
+            })}
+          </p>
+        </TooltipContent>
+      ) : (
+        <TooltipContent side="top">
+          <p className="text-sm">{t('votePrompt')}</p>
+        </TooltipContent>
+      )}
+    </Tooltip>
+  );
+}
+
+export default ProductHunt;

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1103,6 +1103,11 @@
       "selectTags": "Select tags...",
       "tagsCount": "{{count}} tags",
       "searchTags": "Search tags..."
+    },
+    "productHunt": {
+      "findUsOn": "FIND US ON",
+      "scheduledDate": "Scheduled for {{date}}",
+      "votePrompt": "Support us by voting on Product Hunt! 🥺 "
     }
   },
   "common": {

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -1103,6 +1103,11 @@
       "selectTags": "タグを選択...",
       "tagsCount": "{{count}}個のタグ",
       "searchTags": "タグを検索..."
+    },
+    "productHunt": {
+      "findUsOn": "Product Huntで見つける",
+      "scheduledDate": "予定日：{{date}}",
+      "votePrompt": "Product Huntで投票して応援してください！ 🥺"
     }
   },
   "common": {

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1097,6 +1097,11 @@
       "selectTags": "选择标签...",
       "tagsCount": "{{count}} 个标签",
       "searchTags": "搜索标签..."
+    },
+    "productHunt": {
+      "findUsOn": "在 Product Hunt 上找到我们",
+      "scheduledDate": "预定发布时间：{{date}}",
+      "votePrompt": "来一票吧，球球啦 🥺！"
     }
   },
   "common": {

--- a/web/src/pages/landing/index.tsx
+++ b/web/src/pages/landing/index.tsx
@@ -2,6 +2,7 @@ import { SlidingNumber } from '@/components/animate-ui/text/sliding-number';
 import { AppStoreIcon } from '@/components/icons/Apple';
 import LanguageSwitcher from '@/components/others/languageSwitcher';
 import Logo from '@/components/others/logo';
+import ProductHunt from '@/components/others/ProductHunt';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -226,7 +227,7 @@ function Landing() {
         </div>
 
         {/* CTA Buttons - 更优雅的按钮设计 */}
-        <div className="flex flex-row flex-wrap gap-3 px-2 pb-4">
+        <div className="flex flex-row flex-wrap items-center gap-3 px-2 pb-4">
           <Button size="lg" asChild>
             <Link
               to={isTokenValid() ? '/home' : '/login'}
@@ -273,6 +274,8 @@ function Landing() {
               <ArrowUpRight className="inline-block size-5" />
             </Link>
           </Button>
+
+          <ProductHunt />
         </div>
 
         <div className="group absolute right-10 bottom-0 flex flex-col items-center">
@@ -429,7 +432,7 @@ function Landing() {
           <p className="text-info text-lg font-light">{t('exploreMore.subtitle')}</p>
         </div>
 
-        <div className="flex flex-row flex-wrap gap-4 py-8">
+        <div className="flex flex-row flex-wrap items-center gap-4 py-8">
           {quickLinks.map((link) => (
             <div key={link.name} className="group">
               <Button variant={link.external ? 'outline' : 'default'} asChild>


### PR DESCRIPTION
- Create ProductHunt component with custom SVG design
- Add ProductHunt button to CTA buttons section on landing page
- Support scheduled launch date display (before launch)
- Add vote prompt tooltip after product launch
- Add i18n support for ProductHunt component (en, zh, ja)
- Update ProductHunt URL to product page
- Style ProductHunt button to match other CTA buttons
