### PR TITLE
feat: extend scroll position management to all pages with path exclusion

### DIFF
--- a/web/src/components/ScrollPositionManager.tsx
+++ b/web/src/components/ScrollPositionManager.tsx
@@ -1,0 +1,13 @@
+import { useSaveScrollPosition } from '@/hooks/useSaveScrollPosition';
+
+/**
+ * 全局滚动位置管理组件
+ * 在全局层面统一管理所有页面的滚动位置
+ * 不需要保存滚动位置的页面会在 useSaveScrollPosition 中被排除
+ */
+function ScrollPositionManager() {
+  useSaveScrollPosition();
+  return null;
+}
+
+export default ScrollPositionManager;

--- a/web/src/hooks/useSaveScrollPosition.ts
+++ b/web/src/hooks/useSaveScrollPosition.ts
@@ -4,10 +4,33 @@ import { debounce } from 'lodash';
 import { useEffect, useLayoutEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 
+/**
+ * 不需要保存滚动位置的路径列表（黑名单）
+ * 这些路径每次访问都会从顶部开始
+ */
+const EXCLUDED_PATHS = ['/landing', '/login', '/setup', '/doc/', '/app/', '/404'];
+
+/**
+ * 检查路径是否在排除列表中
+ * 支持前缀匹配，例如 '/doc/' 会匹配所有以 '/doc/' 开头的路径
+ */
+function isPathExcluded(pathname: string): boolean {
+  return EXCLUDED_PATHS.some((excludedPath) => {
+    // 精确匹配
+    if (pathname === excludedPath) return true;
+    // 前缀匹配（以 '/' 结尾的路径）
+    if (excludedPath.endsWith('/') && pathname.startsWith(excludedPath)) return true;
+    return false;
+  });
+}
+
 export function useSaveScrollPosition() {
   const { pathname } = useLocation();
   // write-only setter to avoid subscribing/re-rendering on each update
   const setScrollPositions = useSetAtom(scrollPositionAtom);
+
+  // 检查当前路径是否被排除
+  const isExcluded = isPathExcluded(pathname);
 
   // Read initial value directly from localStorage to avoid atom subscription
   function getInitialScrollPosition(route: string): number {
@@ -24,10 +47,21 @@ export function useSaveScrollPosition() {
 
   // restore position before paint to avoid initial jump
   useLayoutEffect(() => {
-    window.scrollTo({ top: getInitialScrollPosition(pathname), behavior: 'auto' });
-  }, [pathname]);
+    if (isExcluded) {
+      // 如果路径被排除，始终滚动到顶部
+      window.scrollTo({ top: 0, behavior: 'auto' });
+    } else {
+      // 否则恢复保存的滚动位置
+      window.scrollTo({ top: getInitialScrollPosition(pathname), behavior: 'auto' });
+    }
+  }, [pathname, isExcluded]);
 
   useEffect(() => {
+    // 如果路径被排除，不添加滚动监听器
+    if (isExcluded) {
+      return;
+    }
+
     let ticking = false;
     const saveDebounced = debounce(
       (y: number) => {
@@ -65,5 +99,5 @@ export function useSaveScrollPosition() {
       saveDebounced.flush?.();
       saveDebounced.cancel?.();
     };
-  }, [pathname, setScrollPositions]);
+  }, [pathname, setScrollPositions, isExcluded]);
 }

--- a/web/src/layout/dashboard/index.tsx
+++ b/web/src/layout/dashboard/index.tsx
@@ -7,7 +7,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-import { useSaveScrollPosition } from '@/hooks/useSaveScrollPosition';
 import { loadProfileAtom, profileAtom } from '@/state/profile';
 import { tagsAtom } from '@/state/tags';
 import { authService } from '@/utils/auth';
@@ -83,7 +82,6 @@ export const tabsData: IconType[][] = [
 ];
 
 function LayoutDashboard() {
-  useSaveScrollPosition();
   const location = useLocation();
   const loadProfile = useSetAtom(loadProfileAtom);
   const setProfile = useSetAtom(profileAtom);

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -2,7 +2,8 @@
   "pages": {
     "landing": {
       "poem": "",
-      "headingPrefix": "A note repository like ",
+      "headingBefore": "A note repository like",
+      "headingAfter": " 🤔",
       "linksItems": ["Login", "", "GitHub"],
       "dashboard": "Dashboard",
       "star": "Stars",

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -2,7 +2,8 @@
   "pages": {
     "landing": {
       "poem": "",
-      "headingPrefix": "のようなノートリポジトリ",
+      "headingBefore": "",
+      "headingAfter": " のようなノートリポジトリ 🤔",
       "linksItems": ["ログイン", "", "GitHub"],
       "dashboard": "ダッシュボード",
       "star": "スター",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -2,7 +2,8 @@
   "pages": {
     "landing": {
       "poem": "采菊东篱下，悠然见南山",
-      "headingPrefix": "一个看起来不太一样的",
+      "headingBefore": "一个看起来不太一样的",
+      "headingAfter": " 🤔",
       "linksItems": ["登录", "", "GitHub"],
       "dashboard": "仪表盘",
       "star": "Stars",

--- a/web/src/pages/landing/index.tsx
+++ b/web/src/pages/landing/index.tsx
@@ -213,13 +213,13 @@ function Landing() {
         {/* Main heading - 更克制的设计 */}
         <div className="space-y-2 divide-y-[0.5px] px-2">
           <h1 className="text-foreground text-3xl leading-tight font-bold tracking-tight sm:text-4xl lg:text-5xl">
-            {t('headingPrefix')}
+            {t('headingBefore')}
             <br className="block sm:hidden" />
             <span className="text-theme inline-block">
               {typewriterText}
               <span className="animate-pulse font-thin">|</span>
             </span>
-            🤔
+            {t('headingAfter')}
           </h1>
 
           {/* 副标题 - 更清晰的层次 */}

--- a/web/src/route/main.tsx
+++ b/web/src/route/main.tsx
@@ -1,6 +1,7 @@
+import ScrollPositionManager from '@/components/ScrollPositionManager';
 import LayoutDashboard from '@/layout/dashboard';
 import { isTokenValid } from '@/utils/main';
-import { createBrowserRouter, Navigate, RouterProvider } from 'react-router-dom';
+import { createBrowserRouter, Navigate, Outlet, RouterProvider } from 'react-router-dom';
 import { ProtectedRoute } from './protectedRoute';
 
 import ErrorPage from '@/pages/404';
@@ -20,143 +21,153 @@ import SingleRotePage from '@/pages/rote/:roteid';
 import SetupPage from '@/pages/setup';
 import UserPage from '@/pages/user/:username';
 
+/**
+ * 根路由组件，用于在 RouterProvider 内部渲染 ScrollPositionManager
+ */
+function RootLayout() {
+  return (
+    <>
+      <ScrollPositionManager />
+      <Outlet />
+    </>
+  );
+}
+
 export default function GlobalRouterProvider() {
   const isIosLogin = new URLSearchParams(window.location.search).get('type') === 'ioslogin';
 
   const router = createBrowserRouter([
     {
-      path: 'landing',
-      element: <Landing />,
-      errorElement: <ErrorPage />,
-    },
-    {
-      path: 'login',
-      element: isTokenValid() && !isIosLogin ? <Navigate to="/home" /> : <Login />,
-      errorElement: <ErrorPage />,
-    },
-    {
-      path: '404',
-      element: <ErrorPage />,
-    },
-    {
-      path: 'setup',
-      element: <SetupPage />,
-      errorElement: <ErrorPage />,
-    },
-    {
-      path: 'app',
+      element: <RootLayout />,
       errorElement: <ErrorPage />,
       children: [
         {
-          path: 'privacy',
-          element: <PrivacyPolicyPage />,
+          path: 'landing',
+          element: <Landing />,
         },
         {
-          path: 'terms',
-          element: <TermsOfServicePage />,
-        },
-      ],
-    },
-    {
-      path: 'doc',
-      errorElement: <ErrorPage />,
-      children: [
-        {
-          path: 'selfhosted',
-          element: <SelfhostedGuidePage />,
-        },
-      ],
-    },
-    {
-      path: '',
-      element: isTokenValid() ? <Navigate to="/home" /> : <Navigate to="/landing" />,
-      errorElement: <ErrorPage />,
-      children: [],
-    },
-    {
-      path: '/',
-      element: <LayoutDashboard />,
-      children: [
-        {
-          path: 'home',
-          element: (
-            <ProtectedRoute>
-              <HomePage />
-            </ProtectedRoute>
-          ),
-          errorElement: <ErrorPage />,
+          path: 'login',
+          element: isTokenValid() && !isIosLogin ? <Navigate to="/home" /> : <Login />,
         },
         {
-          path: 'filter',
-          element: (
-            <ProtectedRoute>
-              <MineFilter />
-            </ProtectedRoute>
-          ),
-          errorElement: <ErrorPage />,
+          path: '404',
+          element: <ErrorPage />,
         },
         {
-          path: 'profile',
-          element: (
-            <ProtectedRoute>
-              <ProfilePage />
-            </ProtectedRoute>
-          ),
-          errorElement: <ErrorPage />,
+          path: 'setup',
+          element: <SetupPage />,
         },
         {
-          path: 'explore',
-          element: <ExplorePage />,
-          errorElement: <ErrorPage />,
-        },
-        {
-          path: 'admin',
-          errorElement: <ErrorPage />,
-          element: (
-            <ProtectedRoute>
-              <AdminDashboard />
-            </ProtectedRoute>
-          ),
-        },
-        {
-          path: 'rote',
-          errorElement: <ErrorPage />,
+          path: 'app',
           children: [
             {
-              path: ':roteid',
-              element: <SingleRotePage />,
+              path: 'privacy',
+              element: <PrivacyPolicyPage />,
+            },
+            {
+              path: 'terms',
+              element: <TermsOfServicePage />,
             },
           ],
         },
         {
-          path: 'archived',
-          errorElement: <ErrorPage />,
-          element: (
-            <ProtectedRoute>
-              <ArchivedPage />
-            </ProtectedRoute>
-          ),
+          path: 'doc',
+          children: [
+            {
+              path: 'selfhosted',
+              element: <SelfhostedGuidePage />,
+            },
+          ],
         },
         {
-          path: 'experiment',
-          errorElement: <ErrorPage />,
-          element: (
-            <ProtectedRoute>
-              <ExperimentPage />
-            </ProtectedRoute>
-          ),
+          path: '',
+          element: isTokenValid() ? <Navigate to="/home" /> : <Navigate to="/landing" />,
         },
-
         {
-          path: ':username',
-          element: <UserPage />,
-          errorElement: <ErrorPage />,
+          path: '/',
+          element: <LayoutDashboard />,
+          children: [
+            {
+              path: 'home',
+              element: (
+                <ProtectedRoute>
+                  <HomePage />
+                </ProtectedRoute>
+              ),
+              errorElement: <ErrorPage />,
+            },
+            {
+              path: 'filter',
+              element: (
+                <ProtectedRoute>
+                  <MineFilter />
+                </ProtectedRoute>
+              ),
+              errorElement: <ErrorPage />,
+            },
+            {
+              path: 'profile',
+              element: (
+                <ProtectedRoute>
+                  <ProfilePage />
+                </ProtectedRoute>
+              ),
+              errorElement: <ErrorPage />,
+            },
+            {
+              path: 'explore',
+              element: <ExplorePage />,
+              errorElement: <ErrorPage />,
+            },
+            {
+              path: 'admin',
+              errorElement: <ErrorPage />,
+              element: (
+                <ProtectedRoute>
+                  <AdminDashboard />
+                </ProtectedRoute>
+              ),
+            },
+            {
+              path: 'rote',
+              errorElement: <ErrorPage />,
+              children: [
+                {
+                  path: ':roteid',
+                  element: <SingleRotePage />,
+                },
+              ],
+            },
+            {
+              path: 'archived',
+              errorElement: <ErrorPage />,
+              element: (
+                <ProtectedRoute>
+                  <ArchivedPage />
+                </ProtectedRoute>
+              ),
+            },
+            {
+              path: 'experiment',
+              errorElement: <ErrorPage />,
+              element: (
+                <ProtectedRoute>
+                  <ExperimentPage />
+                </ProtectedRoute>
+              ),
+            },
+            {
+              path: ':username',
+              element: <UserPage />,
+              errorElement: <ErrorPage />,
+            },
+          ],
+        },
+        {
+          path: '*',
+          element: <ErrorPage />,
         },
       ],
-    },
-    {
-      path: '*',
-      element: <ErrorPage />,
     },
   ]);
 


### PR DESCRIPTION
- Add ScrollPositionManager component for global scroll position management
- Implement path exclusion list (blacklist) in useSaveScrollPosition hook
- Exclude paths: /landing, /login, /setup, /doc/*, /app/*, /404
- Excluded paths always scroll to top and don't save scroll position
- Integrate ScrollPositionManager in GlobalRouterProvider via RootLayout
- Remove duplicate useSaveScrollPosition call from LayoutDashboard
- Fix issue where landing page navigation to selfhosted page didn't scroll to top