### PR TITLE
feat: add S3 region configuration support

### DIFF
--- a/server/scripts/downloadr2.ts
+++ b/server/scripts/downloadr2.ts
@@ -40,9 +40,10 @@ async function initializeConfig() {
   console.log('Access Key ID:', config.accessKeyId ? '***' : 'Not set');
   console.log('Secret Access Key:', config.secretAccessKey ? '***' : 'Not set');
   console.log('Bucket:', config.bucket);
+  console.log('Region:', config.region || 'auto');
 
   s3Client = new S3Client({
-    region: 'auto',
+    region: config.region || 'auto',
     endpoint: config.endpoint,
     credentials: {
       accessKeyId: config.accessKeyId,

--- a/server/scripts/uploadr2.ts
+++ b/server/scripts/uploadr2.ts
@@ -40,9 +40,10 @@ async function initializeConfig() {
   console.log('Access Key ID:', config.accessKeyId ? '***' : 'Not set');
   console.log('Secret Access Key:', config.secretAccessKey ? '***' : 'Not set');
   console.log('Bucket:', config.bucket);
+  console.log('Region:', config.region || 'auto');
 
   s3Client = new S3Client({
-    region: 'auto',
+    region: config.region || 'auto',
     endpoint: config.endpoint,
     credentials: {
       accessKeyId: config.accessKeyId,

--- a/server/types/config.ts
+++ b/server/types/config.ts
@@ -17,6 +17,7 @@ export interface StorageConfig {
   accessKeyId: string;
   secretAccessKey: string;
   urlPrefix: string;
+  region?: string; // S3 region，默认为 'auto'
 }
 
 export interface OAuthProviderConfig {
@@ -113,6 +114,7 @@ export interface SetupRequest {
     accessKeyId: string;
     secretAccessKey: string;
     urlPrefix: string;
+    region?: string; // S3 region，默认为 'auto'
   };
   ui: {
     allowRegistration: boolean;

--- a/server/utils/configTester.ts
+++ b/server/utils/configTester.ts
@@ -19,7 +19,7 @@ export class ConfigTester {
 
       const s3Client = new S3Client({
         endpoint: config.endpoint,
-        region: 'auto',
+        region: config.region || 'auto',
         credentials: {
           accessKeyId: config.accessKeyId,
           secretAccessKey: config.secretAccessKey,

--- a/server/utils/r2.ts
+++ b/server/utils/r2.ts
@@ -15,7 +15,7 @@ function getR2Client(): { s3: S3Client; bucketName: string; urlPrefix: string } 
   const config = getGlobalConfig<StorageConfig>('storage');
   if (config && config.endpoint && config.accessKeyId && config.secretAccessKey && config.bucket) {
     const s3 = new S3Client({
-      region: 'auto',
+      region: config.region || 'auto',
       endpoint: config.endpoint,
       credentials: {
         accessKeyId: config.accessKeyId,

--- a/web/src/components/setup/SetupWizard.tsx
+++ b/web/src/components/setup/SetupWizard.tsx
@@ -458,6 +458,23 @@ export default function SetupWizard() {
             </div>
 
             <div className="space-y-2">
+              <Label htmlFor="region">{t('pages.setupWizard.labels.region')}</Label>
+              <Input
+                id="region"
+                value={config.s3Config.region}
+                onChange={(e) =>
+                  updateConfig({
+                    s3Config: { ...config.s3Config, region: e.target.value },
+                  })
+                }
+                placeholder={t('pages.setupWizard.placeholders.region')}
+              />
+              <p className="text-muted-foreground text-xs">
+                {t('pages.setupWizard.descriptions.region')}
+              </p>
+            </div>
+
+            <div className="space-y-2">
               <Label htmlFor="urlPrefix">{t('pages.setupWizard.labels.urlPrefix')}</Label>
               <Input
                 id="urlPrefix"

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -383,6 +383,7 @@
         "accessKey": "Access Key",
         "secretKey": "Secret Key",
         "bucket": "Bucket Name",
+        "region": "Region",
         "urlPrefix": "URL Prefix",
         "username": "Username",
         "email": "Email",
@@ -397,6 +398,7 @@
         "accessKey": "Enter S3 Access Key",
         "secretKey": "Enter S3 Secret Key",
         "bucket": "Enter bucket name",
+        "region": "auto",
         "urlPrefix": "https://bucket.your-domain.com",
         "adminUsername": "Enter admin username",
         "adminEmail": "Enter admin email",
@@ -405,6 +407,7 @@
       },
       "descriptions": {
         "frontendUrl": "Frontend URL is used to identify your frontend access address and will be used to generate links in RSS feeds. Please enter the complete URL (e.g., https://your-domain.com).",
+        "region": "S3 region, defaults to 'auto'",
         "s3Optional": "S3 storage configuration is optional. You can skip this step and configure it later in system settings. If skipped, the system will not be able to upload attachments, but other features will work normally."
       },
       "validation": {
@@ -472,6 +475,9 @@
         "bucket": "Bucket",
         "accessKeyId": "Access Key ID",
         "secretAccessKey": "Secret Access Key",
+        "region": "Region",
+        "regionPlaceholder": "auto",
+        "regionDescription": "S3 region, defaults to 'auto'. For storage services like Garage that require a specific region, enter the region name (e.g., 'garage')",
         "urlPrefix": "URL Prefix",
         "urlPrefixDescription": "Public URL prefix for accessing uploaded files (optional)",
         "testConnection": "Test Connection",

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -383,6 +383,7 @@
         "accessKey": "アクセスキー",
         "secretKey": "シークレットキー",
         "bucket": "バケット名",
+        "region": "リージョン",
         "urlPrefix": "URLプレフィックス",
         "username": "ユーザー名",
         "email": "メールアドレス",
@@ -397,6 +398,7 @@
         "accessKey": "S3アクセスキーを入力",
         "secretKey": "S3シークレットキーを入力",
         "bucket": "バケット名を入力",
+        "region": "auto",
         "urlPrefix": "https://bucket.your-domain.com",
         "adminUsername": "管理者ユーザー名を入力",
         "adminEmail": "管理者メールアドレスを入力",
@@ -405,6 +407,7 @@
       },
       "descriptions": {
         "frontendUrl": "フロントエンドURLは、フロントエンドアクセスアドレスを識別するために使用され、RSSフィードでリンクを生成するために使用されます。完全なURL（例：https://your-domain.com）を入力してください。",
+        "region": "S3リージョン、デフォルトは 'auto'",
         "s3Optional": "S3ストレージ設定はオプションです。このステップをスキップして、後でシステム設定で設定することもできます。スキップした場合、システムは添付ファイルをアップロードできませんが、他の機能は正常に動作します。"
       },
       "validation": {
@@ -472,6 +475,9 @@
         "bucket": "バケット",
         "accessKeyId": "アクセスキーID",
         "secretAccessKey": "シークレットアクセスキー",
+        "region": "リージョン",
+        "regionPlaceholder": "auto",
+        "regionDescription": "S3リージョン、デフォルトは 'auto'。Garage など特定のリージョンが必要なストレージサービスの場合は、リージョン名を入力してください（例：'garage'）",
         "urlPrefix": "URLプレフィックス",
         "urlPrefixDescription": "アップロードされたファイルにアクセスするための公開URLプレフィックス（オプション）",
         "testConnection": "接続テスト",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -377,6 +377,7 @@
         "accessKey": "Access Key",
         "secretKey": "Secret Key",
         "bucket": "存储桶名称",
+        "region": "区域",
         "urlPrefix": "URL 前缀",
         "username": "用户名",
         "email": "邮箱",
@@ -391,6 +392,7 @@
         "accessKey": "请输入 S3 Access Key",
         "secretKey": "请输入 S3 Secret Key",
         "bucket": "请输入存储桶名称",
+        "region": "auto",
         "urlPrefix": "https://bucket.your-domain.com",
         "adminUsername": "请输入管理员用户名",
         "adminEmail": "请输入管理员邮箱",
@@ -399,6 +401,7 @@
       },
       "descriptions": {
         "frontendUrl": "前端URL用于标识您的前端访问地址，将用于生成RSS Feed中的链接。建议填写完整的URL（如：https://your-domain.com）。",
+        "region": "S3 区域，默认为 'auto'",
         "s3Optional": "S3 存储配置是可选的。您可以跳过此步骤，稍后在系统设置中配置。如果跳过，系统将无法上传附件，但其他功能可以正常使用。"
       },
       "validation": {
@@ -466,6 +469,9 @@
         "bucket": "存储桶",
         "accessKeyId": "Access Key ID",
         "secretAccessKey": "Secret Access Key",
+        "region": "区域",
+        "regionPlaceholder": "auto",
+        "regionDescription": "S3 区域，默认为 'auto'。对于 Garage 等需要指定区域的存储服务，请填写相应的区域名称（如 'garage'）",
         "urlPrefix": "URL 前缀",
         "urlPrefixDescription": "用于访问上传文件的公共 URL 前缀（可选）",
         "testConnection": "测试连接",

--- a/web/src/pages/admin/components/StorageConfigTab.tsx
+++ b/web/src/pages/admin/components/StorageConfigTab.tsx
@@ -113,6 +113,7 @@ export default function StorageConfigTab({
                 bucket: storageConfig?.bucket || '',
                 accessKeyId: storageConfig?.accessKeyId || '',
                 secretAccessKey: storageConfig?.secretAccessKey || '',
+                region: storageConfig?.region || '',
                 urlPrefix: storageConfig?.urlPrefix || '',
               })
             }
@@ -131,6 +132,7 @@ export default function StorageConfigTab({
                 bucket: e.target.value,
                 accessKeyId: storageConfig?.accessKeyId || '',
                 secretAccessKey: storageConfig?.secretAccessKey || '',
+                region: storageConfig?.region || '',
                 urlPrefix: storageConfig?.urlPrefix || '',
               })
             }
@@ -149,6 +151,7 @@ export default function StorageConfigTab({
                 bucket: storageConfig?.bucket || '',
                 accessKeyId: e.target.value,
                 secretAccessKey: storageConfig?.secretAccessKey || '',
+                region: storageConfig?.region || '',
                 urlPrefix: storageConfig?.urlPrefix || '',
               })
             }
@@ -168,11 +171,32 @@ export default function StorageConfigTab({
                 bucket: storageConfig?.bucket || '',
                 accessKeyId: storageConfig?.accessKeyId || '',
                 secretAccessKey: e.target.value,
+                region: storageConfig?.region || '',
                 urlPrefix: storageConfig?.urlPrefix || '',
               })
             }
             placeholder="Secret Access Key"
           />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="region">{t('storage.region')}</Label>
+          <Input
+            id="region"
+            value={storageConfig?.region || ''}
+            onChange={(e) =>
+              setStorageConfig({
+                endpoint: storageConfig?.endpoint || '',
+                bucket: storageConfig?.bucket || '',
+                accessKeyId: storageConfig?.accessKeyId || '',
+                secretAccessKey: storageConfig?.secretAccessKey || '',
+                region: e.target.value,
+                urlPrefix: storageConfig?.urlPrefix || '',
+              })
+            }
+            placeholder={t('storage.regionPlaceholder')}
+          />
+          <p className="text-muted-foreground text-xs">{t('storage.regionDescription')}</p>
         </div>
 
         <div className="space-y-2">
@@ -186,6 +210,7 @@ export default function StorageConfigTab({
                 bucket: storageConfig?.bucket || '',
                 accessKeyId: storageConfig?.accessKeyId || '',
                 secretAccessKey: storageConfig?.secretAccessKey || '',
+                region: storageConfig?.region || '',
                 urlPrefix: e.target.value,
               })
             }

--- a/web/src/pages/admin/types.ts
+++ b/web/src/pages/admin/types.ts
@@ -13,6 +13,7 @@ export interface SystemConfig {
     accessKeyId: string;
     secretAccessKey: string;
     urlPrefix: string;
+    region?: string;
   };
   security?: {
     requireVerifiedEmailForExplore?: boolean;


### PR DESCRIPTION
- Add optional region field to StorageConfig and SetupRequest types
- Update all S3Client instances to use config.region || 'auto'
- Add region input field to StorageConfigTab and SetupWizard components
- Add region translations for zh, en, and ja locales
- Support Garage and other S3-compatible services that require region specification

#129 