### PR TITLE
Develop

### DIFF
--- a/web/src/components/article/ArticleViewerModal.tsx
+++ b/web/src/components/article/ArticleViewerModal.tsx
@@ -66,7 +66,7 @@ export function ArticleViewerModal({
       <Skeleton className="h-[50vh] w-full" />
     </div>
   ) : article ? (
-    <div className="prose prose-sm dark:prose-invert noScrollBar max-w-none flex-1 overflow-y-auto py-6">
+    <div className="prose prose-sm dark:prose-invert noScrollBar max-h-[80vh] max-w-none flex-1 overflow-scroll overflow-y-auto py-6">
       <ReactMarkdown remarkPlugins={[remarkGfm]}>{article.content}</ReactMarkdown>
     </div>
   ) : (
@@ -77,7 +77,7 @@ export function ArticleViewerModal({
     <>
       <Dialog open={open} onOpenChange={onOpenChange}>
         <DialogTitle className="hidden px-6 pt-4 text-lg font-semibold">{t('title')}</DialogTitle>
-        <DialogContent className="max-w-screen rounded-none sm:max-w-3xl md:h-[90vh]">
+        <DialogContent className="max-w-screen rounded-none sm:max-w-3xl">
           {editable && article && (
             <div className="absolute right-12 bottom-12 z-1">
               <Button

--- a/web/src/components/editor/RoteEditor.tsx
+++ b/web/src/components/editor/RoteEditor.tsx
@@ -566,7 +566,7 @@ function RoteEditor({ roteAtom, callback }: { roteAtom: RoteAtomType; callback?:
         ))}
       </div>
 
-      <div className="noScrollBar flex flex-wrap items-center gap-2 overflow-x-scroll">
+      <div className="noScrollBar flex flex-wrap items-center gap-1 overflow-x-scroll sm:gap-2">
         <TagSelector
           tags={rote.tags}
           setTags={updateTags}

--- a/web/src/components/others/TagSelector.tsx
+++ b/web/src/components/others/TagSelector.tsx
@@ -86,7 +86,7 @@ export function TagSelector({
           variant="outline"
           role="combobox"
           aria-expanded={open}
-          className="w-[120px] justify-between overflow-hidden sm:w-[160px]"
+          className="w-25 justify-between overflow-hidden sm:w-40"
           style={{ textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
         >
           <span className="flex-1 overflow-hidden text-left text-ellipsis whitespace-nowrap">
@@ -95,7 +95,7 @@ export function TagSelector({
           <ChevronsUpDown className="ml-2 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="h-50 w-[140px] p-0">
+      <PopoverContent className="h-50 w-35 p-0">
         <Command>
           <CommandInput
             placeholder={t('searchTags')}
@@ -106,10 +106,20 @@ export function TagSelector({
           <CommandList>
             <CommandGroup>
               {availableTags?.map((tag) => (
-                <CommandItem key={tag} value={tag} onSelect={() => handleTagSelect(tag)}>
-                  {tag}
+                <CommandItem
+                  key={tag}
+                  value={tag}
+                  onSelect={() => handleTagSelect(tag)}
+                  className="flex flex-1"
+                >
+                  <div className="inline-block max-w-40 overflow-hidden text-ellipsis whitespace-nowrap">
+                    {tag}
+                  </div>
                   <Check
-                    className={cn('ml-auto', tags.includes(tag) ? 'opacity-100' : 'opacity-0')}
+                    className={cn(
+                      'ml-auto shrink-0',
+                      tags.includes(tag) ? 'opacity-100' : 'opacity-0'
+                    )}
                   />
                 </CommandItem>
               ))}


### PR DESCRIPTION
This pull request focuses on improving the layout and usability of several UI components, particularly around tag selection and article viewing. The main changes involve refining spacing, sizing, and overflow handling to provide a more consistent and user-friendly interface across different screen sizes.

**UI/UX improvements for Tag Selector:**

* Adjusted the width of the Tag Selector button and its popover for better alignment and responsiveness, using Tailwind's `w-25` and `w-40` classes instead of fixed pixel widths. [[1]](diffhunk://#diff-3a4266fbe285e6911622de4a012569ce0f8e577ce08216677532a9b59b0d25dbL89-R89) [[2]](diffhunk://#diff-3a4266fbe285e6911622de4a012569ce0f8e577ce08216677532a9b59b0d25dbL98-R98)
* Enhanced the tag display inside the popover by adding a container with `max-w-40` and text truncation to prevent overflow, and improved the alignment and shrinking behavior of the checkmark icon.

**Layout and overflow adjustments:**

* Modified the article viewer modal's content area to have a maximum height (`max-h-[80vh]`) and use `overflow-scroll` for better handling of large articles.
* Removed the fixed height (`md:h-[90vh]`) from the `DialogContent` in the article viewer modal to allow for more flexible content sizing.
* Reduced the gap between tag elements in the `RoteEditor` for a denser layout, especially on smaller screens, by changing from `gap-2` to `gap-1` and adding a responsive `sm:gap-2`.