### PR TITLE
Show link previews only when no attachments exist

### DIFF
--- a/web/src/components/rote/roteItem.tsx
+++ b/web/src/components/rote/roteItem.tsx
@@ -228,7 +228,10 @@ function RoteItem({
           </div>
         )}
 
-        {!rote.articleId && !rote.article && (rote.linkPreviews?.length || 0) > 0 && (
+        {!rote.articleId &&
+          !rote.article &&
+          (rote.attachments?.length || 0) === 0 &&
+          (rote.linkPreviews?.length || 0) > 0 && (
           <div className="flex flex-col gap-2">
             {rote.linkPreviews?.map((preview) => (
               <LinkPreviewCard key={preview.id} preview={preview} />

--- a/web/src/components/rote/roteItem.tsx
+++ b/web/src/components/rote/roteItem.tsx
@@ -232,12 +232,12 @@ function RoteItem({
           !rote.article &&
           (rote.attachments?.length || 0) === 0 &&
           (rote.linkPreviews?.length || 0) > 0 && (
-          <div className="flex flex-col gap-2">
-            {rote.linkPreviews?.map((preview) => (
-              <LinkPreviewCard key={preview.id} preview={preview} />
-            ))}
-          </div>
-        )}
+            <div className="flex flex-col gap-2">
+              {rote.linkPreviews?.map((preview) => (
+                <LinkPreviewCard key={preview.id} preview={preview} />
+              ))}
+            </div>
+          )}
 
         {/* Attachments */}
         {rote.attachments?.length > 0 && (


### PR DESCRIPTION
This pull request makes a small but important change to the rendering logic in the `RoteItem` component. Now, link previews will only be displayed if there are no attachments present, in addition to the previous conditions. This prevents link previews from showing up when attachments exist, which likely improves the clarity of the UI.

- Updated the conditional rendering in `RoteItem` (`roteItem.tsx`) so that link previews are only shown if there are no attachments, ensuring attachments take precedence in the UI.