### PR TITLE
OpenKey: support creating articles

### DIFF
--- a/doc/userguide/API-ENDPOINTS.md
+++ b/doc/userguide/API-ENDPOINTS.md
@@ -151,7 +151,7 @@
 | `/openkey/notes`        | POST | API Key | 创建笔记         |
 | `/openkey/notes`        | GET  | API Key | 获取笔记列表     |
 | `/openkey/notes/search` | GET  | API Key | 搜索笔记         |
-| `/openkey/articles`     | POST | API Key | 创建文章（需要 SENDARTICLE 或 SENDROTE） |
+| `/openkey/articles`     | POST | API Key | 创建文章（需要 SENDARTICLE） |
 
 鉴权：通过 `openkey` 传入（推荐）
 - GET：`?openkey=<API_KEY>`

--- a/doc/userguide/API-ENDPOINTS.md
+++ b/doc/userguide/API-ENDPOINTS.md
@@ -151,7 +151,7 @@
 | `/openkey/notes`        | POST | API Key | 创建笔记         |
 | `/openkey/notes`        | GET  | API Key | 获取笔记列表     |
 | `/openkey/notes/search` | GET  | API Key | 搜索笔记         |
-| `/openkey/articles`     | POST | API Key | 创建文章         |
+| `/openkey/articles`     | POST | API Key | 创建文章（需要 SENDARTICLE 或 SENDROTE） |
 
 鉴权：通过 `openkey` 传入（推荐）
 - GET：`?openkey=<API_KEY>`

--- a/doc/userguide/API-ENDPOINTS.md
+++ b/doc/userguide/API-ENDPOINTS.md
@@ -151,8 +151,11 @@
 | `/openkey/notes`        | POST | API Key | 创建笔记         |
 | `/openkey/notes`        | GET  | API Key | 获取笔记列表     |
 | `/openkey/notes/search` | GET  | API Key | 搜索笔记         |
+| `/openkey/articles`     | POST | API Key | 创建文章         |
 
-请求头：`Authorization: Bearer <API_KEY>`
+鉴权：通过 `openkey` 传入（推荐）
+- GET：`?openkey=<API_KEY>`
+- POST：请求体中包含 `{"openkey":"<API_KEY>"}`
 
 ### 14) 站点
 

--- a/server/json/main.json
+++ b/server/json/main.json
@@ -55,5 +55,5 @@
     "doc",
     "article"
   ],
-  "openkeyPermissions": ["SENDROTE", "GETROTE", "EDITROTE"]
+  "openkeyPermissions": ["SENDROTE", "GETROTE", "EDITROTE", "SENDARTICLE"]
 }

--- a/server/route/v2/openKeyRouter.ts
+++ b/server/route/v2/openKeyRouter.ts
@@ -51,8 +51,8 @@ router.post('/articles', isOpenKeyOk, async (c: HonoContext) => {
   ArticleCreateZod.parse(body);
 
   const openKey = c.get('openKey');
-  // New permission: SENDARTICLE. Keep SENDROTE as a fallback for older keys.
-  if (!openKey?.permissions.includes('SENDARTICLE') && !openKey?.permissions.includes('SENDROTE')) {
+  // Permission: SENDARTICLE
+  if (!openKey?.permissions.includes('SENDARTICLE')) {
     throw new Error('API key permission does not match');
   }
 

--- a/server/route/v2/openKeyRouter.ts
+++ b/server/route/v2/openKeyRouter.ts
@@ -51,7 +51,8 @@ router.post('/articles', isOpenKeyOk, async (c: HonoContext) => {
   ArticleCreateZod.parse(body);
 
   const openKey = c.get('openKey');
-  if (!openKey?.permissions.includes('SENDROTE')) {
+  // New permission: SENDARTICLE. Keep SENDROTE as a fallback for older keys.
+  if (!openKey?.permissions.includes('SENDARTICLE') && !openKey?.permissions.includes('SENDROTE')) {
     throw new Error('API key permission does not match');
   }
 


### PR DESCRIPTION
Adds OpenKey endpoint to create an article:\n- POST /v2/api/openkey/articles (body: { openkey, content })\n\nAlso aligns OpenKey docs to the actual auth mechanism ( in query/body), and allows OpenKey note creation endpoints to optionally bind an articleId/articleIds (skips link-preview parsing when bound), matching the authenticated API behavior.