### PR TITLE
OpenKey: fix permissions dialog labels + update Postman

### DIFF
--- a/postman/collections/Project API.postman_collection.json
+++ b/postman/collections/Project API.postman_collection.json
@@ -1772,18 +1772,50 @@
       "name": "OpenKey API",
       "item": [
         {
+          "name": "Create Article (POST)",
+          "id": "2c52cc81-b6a0-455e-a461-7ec882b455b2",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"openkey\": \"{{openkey}}\",\n  \"content\": \"My article content\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/v2/api/openkey/articles?openkey={{openkey}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "v2",
+                "api",
+                "openkey",
+                "articles"
+              ],
+              "query": [
+                {
+                  "key": "openkey",
+                  "value": "{{openkey}}"
+                }
+              ]
+            },
+            "description": "Create an article using OpenKey. Requires SENDARTICLE permission."
+          },
+          "response": []
+        },
+        {
           "name": "Create Note (GET)",
           "id": "46560546-39b8-480c-b95d-c84b8dc609d3",
           "request": {
             "method": "GET",
-            "header": [
-              {
-                "key": "X-API-Key",
-                "value": "{{api_key}}"
-              }
-            ],
+            "header": [],
             "url": {
-              "raw": "{{base_url}}/v2/api/openkey/notes/create?content=My note content&state=private&type=rote&title=My Title&tag=tag1&tag=tag2",
+              "raw": "{{base_url}}/v2/api/openkey/notes/create?content=My note content&state=private&type=rote&title=My Title&tag=tag1&tag=tag2&openkey={{openkey}}",
               "host": [
                 "{{base_url}}"
               ],
@@ -1795,6 +1827,10 @@
                 "create"
               ],
               "query": [
+                {
+                  "key": "openkey",
+                  "value": "{{openkey}}"
+                },
                 {
                   "key": "content",
                   "value": "My note content"
@@ -1834,18 +1870,14 @@
               {
                 "key": "Content-Type",
                 "value": "application/json"
-              },
-              {
-                "key": "X-API-Key",
-                "value": "{{api_key}}"
               }
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"content\": \"My note content\",\n  \"title\": \"My Title\",\n  \"state\": \"private\",\n  \"type\": \"rote\",\n  \"tags\": [\"tag1\", \"tag2\"],\n  \"pin\": false\n}"
+              "raw": "{\n  \"openkey\": \"{{openkey}}\",\n  \"content\": \"My note content\",\n  \"title\": \"My Title\",\n  \"state\": \"private\",\n  \"type\": \"rote\",\n  \"tags\": [\n    \"tag1\",\n    \"tag2\"\n  ],\n  \"pin\": false\n}"
             },
             "url": {
-              "raw": "{{base_url}}/v2/api/openkey/notes/create",
+              "raw": "{{base_url}}/v2/api/openkey/notes/create?openkey={{openkey}}",
               "host": [
                 "{{base_url}}"
               ],
@@ -1855,6 +1887,12 @@
                 "openkey",
                 "notes",
                 "create"
+              ],
+              "query": [
+                {
+                  "key": "openkey",
+                  "value": "{{openkey}}"
+                }
               ]
             },
             "description": "Create a note using API key (POST to /create endpoint). Requires SENDROTE permission."
@@ -1870,18 +1908,14 @@
               {
                 "key": "Content-Type",
                 "value": "application/json"
-              },
-              {
-                "key": "X-API-Key",
-                "value": "{{api_key}}"
               }
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"content\": \"My note content\",\n  \"title\": \"My Title\",\n  \"state\": \"private\",\n  \"type\": \"rote\",\n  \"tags\": [\"tag1\", \"tag2\"],\n  \"pin\": false\n}"
+              "raw": "{\n  \"openkey\": \"{{openkey}}\",\n  \"content\": \"My note content\",\n  \"title\": \"My Title\",\n  \"state\": \"private\",\n  \"type\": \"rote\",\n  \"tags\": [\n    \"tag1\",\n    \"tag2\"\n  ],\n  \"pin\": false\n}"
             },
             "url": {
-              "raw": "{{base_url}}/v2/api/openkey/notes",
+              "raw": "{{base_url}}/v2/api/openkey/notes?openkey={{openkey}}",
               "host": [
                 "{{base_url}}"
               ],
@@ -1890,6 +1924,12 @@
                 "api",
                 "openkey",
                 "notes"
+              ],
+              "query": [
+                {
+                  "key": "openkey",
+                  "value": "{{openkey}}"
+                }
               ]
             },
             "description": "Create a note using API key (RESTful POST). Requires SENDROTE permission."
@@ -1901,14 +1941,9 @@
           "id": "bbe79daa-5036-4772-a300-0a068c93026a",
           "request": {
             "method": "GET",
-            "header": [
-              {
-                "key": "X-API-Key",
-                "value": "{{api_key}}"
-              }
-            ],
+            "header": [],
             "url": {
-              "raw": "{{base_url}}/v2/api/openkey/notes?skip=0&limit=20&archived=false",
+              "raw": "{{base_url}}/v2/api/openkey/notes?skip=0&limit=20&archived=false&openkey={{openkey}}",
               "host": [
                 "{{base_url}}"
               ],
@@ -1919,6 +1954,10 @@
                 "notes"
               ],
               "query": [
+                {
+                  "key": "openkey",
+                  "value": "{{openkey}}"
+                },
                 {
                   "key": "skip",
                   "value": "0"
@@ -1942,14 +1981,9 @@
           "id": "1b6807e3-442b-40fb-b5b8-0534e715df30",
           "request": {
             "method": "GET",
-            "header": [
-              {
-                "key": "X-API-Key",
-                "value": "{{api_key}}"
-              }
-            ],
+            "header": [],
             "url": {
-              "raw": "{{base_url}}/v2/api/openkey/notes/search?keyword=search term&skip=0&limit=20",
+              "raw": "{{base_url}}/v2/api/openkey/notes/search?keyword=search term&skip=0&limit=20&openkey={{openkey}}",
               "host": [
                 "{{base_url}}"
               ],
@@ -1961,6 +1995,10 @@
                 "search"
               ],
               "query": [
+                {
+                  "key": "openkey",
+                  "value": "{{openkey}}"
+                },
                 {
                   "key": "keyword",
                   "value": "search term"
@@ -1981,7 +2019,7 @@
         }
       ],
       "id": "a91403fe-9fe7-45b1-be6a-a948a8281c55",
-      "description": "OpenKey API endpoints for programmatic access using API keys."
+      "description": "OpenKey API endpoints for programmatic access using API keys.\n\nAuth: pass the key via `openkey` (query for GET, JSON body for POST)."
     },
     {
       "name": "Subscriptions",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -4,7 +4,11 @@
       "poem": "",
       "headingBefore": "A note repository like",
       "headingAfter": " 🤔",
-      "linksItems": ["Login", "", "GitHub"],
+      "linksItems": [
+        "Login",
+        "",
+        "GitHub"
+      ],
       "dashboard": "Dashboard",
       "star": "Stars",
       "fork": "Forks",
@@ -675,7 +679,8 @@
       "permissions": {
         "SENDROTE": "Create Rote",
         "GETROTE": "Get Rote",
-        "EDITROTE": "Edit Rote (Including Delete)"
+        "EDITROTE": "Edit Rote (Including Delete)",
+        "SENDARTICLE": "Create Article"
       }
     },
     "sidebarSearch": {

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -4,7 +4,11 @@
       "poem": "",
       "headingBefore": "",
       "headingAfter": " のようなノートリポジトリ 🤔",
-      "linksItems": ["ログイン", "", "GitHub"],
+      "linksItems": [
+        "ログイン",
+        "",
+        "GitHub"
+      ],
       "dashboard": "ダッシュボード",
       "star": "スター",
       "fork": "フォーク",
@@ -675,7 +679,8 @@
       "permissions": {
         "SENDROTE": "Rote を作成",
         "GETROTE": "Rote を取得",
-        "EDITROTE": "Rote を編集（削除を含む）"
+        "EDITROTE": "Rote を編集（削除を含む）",
+        "SENDARTICLE": "記事を作成"
       }
     },
     "sidebarSearch": {

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -4,7 +4,11 @@
       "poem": "采菊东篱下，悠然见南山",
       "headingBefore": "一个看起来不太一样的",
       "headingAfter": " 🤔",
-      "linksItems": ["登录", "", "GitHub"],
+      "linksItems": [
+        "登录",
+        "",
+        "GitHub"
+      ],
       "dashboard": "仪表盘",
       "star": "Stars",
       "fork": "Forks",
@@ -48,7 +52,13 @@
         "error": "检测到后端错误，正在跳转到设置页面",
         "notInitialized": "系统未初始化，正在跳转到设置页面"
       },
-      "typewriterTexts": ["个人笔记库", "碎碎念本子", "私人朋友圈", "个人频道", "微型博客"],
+      "typewriterTexts": [
+        "个人笔记库",
+        "碎碎念本子",
+        "私人朋友圈",
+        "个人频道",
+        "微型博客"
+      ],
       "subtitle": "开放API，记录的姿势不止一种🤩，支持Self-Hosted，对自己的数据掌握主动权，来去自由，没有数据绑架🙅🏻",
       "iosAppTooltip": {
         "title": "想要加入 iOS 测试版吗？",
@@ -669,7 +679,8 @@
       "permissions": {
         "SENDROTE": "创建Rote",
         "GETROTE": "获取Rote",
-        "EDITROTE": "编辑Rote（包括删除）"
+        "EDITROTE": "编辑Rote（包括删除）",
+        "SENDARTICLE": "创建文章"
       }
     },
     "sidebarSearch": {


### PR DESCRIPTION
Fixes two follow-ups after merging OpenKey article support:\n\n1) Frontend OpenKey permissions edit dialog: add i18n labels for the new permission  (en/zh/ja).\n2) Postman collection: update OpenKey requests to use  (query/body) auth instead of X-API-Key header, and add .