### PR TITLE
feat(openkey): add permissions query and reactions endpoints

### DIFF
--- a/server/json/main.json
+++ b/server/json/main.json
@@ -55,5 +55,12 @@
     "doc",
     "article"
   ],
-  "openkeyPermissions": ["SENDROTE", "GETROTE", "EDITROTE", "SENDARTICLE"]
+  "openkeyPermissions": [
+    "SENDROTE",
+    "GETROTE",
+    "EDITROTE",
+    "SENDARTICLE",
+    "ADDREACTION",
+    "DELETEREACTION"
+  ]
 }

--- a/server/route/v2/openKeyRouter.ts
+++ b/server/route/v2/openKeyRouter.ts
@@ -6,15 +6,23 @@
 import { Hono } from 'hono';
 import type { HonoContext, HonoVariables } from '../../types/hono';
 import {
+  addReaction,
   createArticle,
   createRote,
   findMyRote,
+  findRoteById,
+  removeReaction,
   searchMyRotes,
   setNoteArticleId,
 } from '../../utils/dbMethods';
 import { parseAndStoreRoteLinkPreviews } from '../../utils/linkPreview';
-import { createResponse, isOpenKeyOk } from '../../utils/main';
-import { ArticleCreateZod, NoteCreateZod, SearchKeywordZod } from '../../utils/zod';
+import { createResponse, isOpenKeyOk, isValidUUID } from '../../utils/main';
+import {
+  ArticleCreateZod,
+  NoteCreateZod,
+  ReactionCreateZod,
+  SearchKeywordZod,
+} from '../../utils/zod';
 
 const router = new Hono<{ Variables: HonoVariables }>();
 
@@ -339,5 +347,90 @@ router.get('/notes/search', isOpenKeyOk, requireOpenKeyPerm('GETROTE'), async (c
 
   return c.json(createResponse(rotes), 200);
 });
+
+// Query current OpenKey permissions
+router.get('/permissions', isOpenKeyOk, async (c: HonoContext) => {
+  const openKey = c.get('openKey')!;
+  return c.json(
+    createResponse({
+      permissions: openKey.permissions || [],
+    }),
+    200
+  );
+});
+
+// Add reaction using API key
+router.post(
+  '/reactions',
+  isOpenKeyOk,
+  requireOpenKeyPerm('ADDREACTION'),
+  async (c: HonoContext) => {
+    const body = await c.req.json();
+    const { type, roteid, metadata } = body;
+
+    // Validate required fields
+    if (!type || !roteid) {
+      throw new Error('Type and rote ID are required');
+    }
+
+    // Validate input using zod
+    ReactionCreateZod.parse({ type, roteid });
+
+    // Validate roteid format
+    if (!isValidUUID(roteid)) {
+      throw new Error('Invalid rote ID format');
+    }
+
+    // Check if note exists
+    const rote = await findRoteById(roteid);
+    if (!rote) {
+      throw new Error('Rote not found');
+    }
+
+    const openKey = c.get('openKey')!;
+
+    // Build reaction data with OpenKey user
+    const reactionData = {
+      type,
+      roteid,
+      userid: openKey.userid,
+      metadata,
+    };
+
+    const reaction = await addReaction(reactionData);
+    return c.json(createResponse(reaction), 201);
+  }
+);
+
+// Remove reaction using API key
+router.delete(
+  '/reactions/:roteid/:type',
+  isOpenKeyOk,
+  requireOpenKeyPerm('DELETEREACTION'),
+  async (c: HonoContext) => {
+    const roteid = c.req.param('roteid');
+    const type = c.req.param('type');
+
+    if (!type || !roteid) {
+      throw new Error('Type and rote ID are required');
+    }
+
+    // Validate roteid format
+    if (!isValidUUID(roteid)) {
+      throw new Error('Invalid rote ID format');
+    }
+
+    const openKey = c.get('openKey')!;
+
+    // Remove reaction for this OpenKey user
+    const result = await removeReaction({
+      type,
+      roteid,
+      userid: openKey.userid,
+    });
+
+    return c.json(createResponse(result), 200);
+  }
+);
 
 export default router;

--- a/web/src/components/openKey/openKey.tsx
+++ b/web/src/components/openKey/openKey.tsx
@@ -104,8 +104,8 @@ function OpenKeyItem({ openKey, mutate }: { openKey: OpenKey; mutate?: KeyedMuta
           <DropdownMenuContent align="end">{actionsMenu()}</DropdownMenuContent>
         </DropdownMenu>
       </div>
-      <div className="">
-        {t('permissions')}：{openKey.permissions.join(',')}
+      <div className="font-mono text-sm break-all">
+        {t('permissions')}：{openKey.permissions.join(', ')}
       </div>
       <div className="text-primary/30">
         {t('example')}：

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -676,7 +676,9 @@
         "SENDROTE": "Create Rote",
         "GETROTE": "Get Rote",
         "EDITROTE": "Edit Rote (Including Delete)",
-        "SENDARTICLE": "Create Article"
+        "SENDARTICLE": "Create Article",
+        "ADDREACTION": "Add Reaction",
+        "DELETEREACTION": "Delete Reaction"
       }
     },
     "sidebarSearch": {

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -676,7 +676,9 @@
         "SENDROTE": "Rote を作成",
         "GETROTE": "Rote を取得",
         "EDITROTE": "Rote を編集（削除を含む）",
-        "SENDARTICLE": "記事を作成"
+        "SENDARTICLE": "記事を作成",
+        "ADDREACTION": "リアクションを追加",
+        "DELETEREACTION": "リアクションを削除"
       }
     },
     "sidebarSearch": {

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -670,7 +670,9 @@
         "SENDROTE": "创建Rote",
         "GETROTE": "获取Rote",
         "EDITROTE": "编辑Rote（包括删除）",
-        "SENDARTICLE": "创建文章"
+        "SENDARTICLE": "创建文章",
+        "ADDREACTION": "添加反应",
+        "DELETEREACTION": "删除反应"
       }
     },
     "sidebarSearch": {


### PR DESCRIPTION
- Add ADDREACTION and DELETEREACTION permission types
- Add GET /openkey/permissions endpoint to query current permissions
- Add POST /openkey/reactions endpoint to add reactions via API key
- Add DELETE /openkey/reactions/:roteid/:type endpoint to remove reactions
- Add i18n labels for new permissions (en/zh/ja)
- Fix permissions overflow in openKey component
