### PR TITLE
Feature/cleanup invalid subscriptions

### DIFF
--- a/server/route/v2/subscription.ts
+++ b/server/route/v2/subscription.ts
@@ -4,6 +4,7 @@ import { authenticateJWT } from '../../middleware/jwtAuth';
 import type { HonoContext, HonoVariables } from '../../types/hono';
 import {
   addSubScriptionToUser,
+  deleteInactiveSubscriptions,
   deleteSubScription,
   findSubScriptionToUser,
   findSubScriptionToUserByendpoint,
@@ -61,6 +62,13 @@ subscriptionsRouter.delete('/:id', authenticateJWT, async (c: HonoContext) => {
   }
 
   const data = await deleteSubScription(id);
+  return c.json(createResponse(data), 200);
+});
+
+// 清理所有失效订阅
+subscriptionsRouter.delete('/inactive/all', authenticateJWT, async (c: HonoContext) => {
+  const user = c.get('user') as User;
+  const data = await deleteInactiveSubscriptions(user.id);
   return c.json(createResponse(data), 200);
 });
 

--- a/server/utils/dbMethods/subscription.ts
+++ b/server/utils/dbMethods/subscription.ts
@@ -1,4 +1,4 @@
-import { eq, sql } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 import { userSwSubscriptions } from '../../drizzle/schema';
 import db from '../drizzle';
 import { DatabaseError } from './common';
@@ -199,5 +199,19 @@ export async function updateSubScription(
       throw error;
     }
     throw new DatabaseError(`Failed to update subscription: ${subId}`, error);
+  }
+}
+
+export async function deleteInactiveSubscriptions(userId: string): Promise<any> {
+  try {
+    const result = await db
+      .delete(userSwSubscriptions)
+      .where(
+        and(eq(userSwSubscriptions.userid, userId), eq(userSwSubscriptions.status, 'inactive'))
+      )
+      .returning();
+    return result;
+  } catch (error) {
+    throw new DatabaseError(`Failed to delete inactive subscriptions for user: ${userId}`, error);
   }
 }

--- a/web/src/components/experiment/SubList.tsx
+++ b/web/src/components/experiment/SubList.tsx
@@ -88,7 +88,7 @@ export default function SubList() {
           action:
             failedCount > 0
               ? {
-                  label: t('clearInvalid'),
+                  label: t('messages.clearInvalid'),
                   onClick: () => handleClearInvalidEndpoints(failedCount),
                 }
               : undefined,

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -354,7 +354,12 @@
           "deleteSuccess": "Subscription deleted successfully",
           "deleteFailed": "Delete failed: {{error}}",
           "testNotificationSent": "Test notification sent",
-          "confirmDelete": "Are you sure you want to delete this subscription?"
+          "confirmDelete": "Are you sure you want to delete this subscription?",
+          "clearInvalid": "Clear Invalid Endpoints",
+          "clearingInvalid": "Clearing...",
+          "clearSuccess": "Cleared successfully! {{count}} invalid endpoints removed.",
+          "clearFailed": "Clear failed: {{error}}",
+          "clearConfirm": "Found {{count}} invalid endpoints. Clear them?"
         },
         "noSubscriptions": "No subscribed notification endpoints"
       }

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -354,7 +354,12 @@
           "deleteSuccess": "購読を削除しました",
           "deleteFailed": "削除に失敗しました：{{error}}",
           "testNotificationSent": "テスト通知を送信しました",
-          "confirmDelete": "この購読を削除してもよろしいですか？"
+          "confirmDelete": "この購読を削除してもよろしいですか？",
+          "clearInvalid": "無効なエンドポイントを削除",
+          "clearingInvalid": "削除中...",
+          "clearSuccess": "削除完了！{{count}} 個の無効なエンドポイントを削除しました。",
+          "clearFailed": "削除失敗: {{error}}",
+          "clearConfirm": "{{count}} 個の無効なエンドポイントが見つかりました。削除しますか？"
         },
         "noSubscriptions": "購読済み通知エンドポイントがありません"
       }

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -348,7 +348,12 @@
           "deleteSuccess": "订阅删除成功",
           "deleteFailed": "删除失败: {{error}}",
           "testNotificationSent": "测试通知已发送",
-          "confirmDelete": "确定要删除这个订阅吗？"
+          "confirmDelete": "确定要删除这个订阅吗？",
+          "clearInvalid": "清理无效端点",
+          "clearingInvalid": "清理中...",
+          "clearSuccess": "清理成功！共清理了 {{count}} 个无效端点",
+          "clearFailed": "清理失败: {{error}}",
+          "clearConfirm": "测试发现 {{count}} 个无效端点，是否清理？"
         },
         "noSubscriptions": "没有订阅的通知端点"
       }


### PR DESCRIPTION
This pull request introduces a new feature that allows users to clear all their inactive (invalid) notification subscriptions in bulk. It includes backend API changes, database logic, frontend UI improvements, and localization updates to support this feature. Additionally, there are improvements to subscription testing and the service worker's VAPID key handling.

**Backend: Inactive Subscription Cleanup**

- Added a new API endpoint (`DELETE /subscriptions/inactive/all`) that allows authenticated users to delete all their inactive subscriptions at once. This is implemented in the router and supported by a new `deleteInactiveSubscriptions` database method. [[1]](diffhunk://#diff-bdfa9dab6dcff93ab6a067be9f9c05102678954475d5ebe124c6afe935b0277bR7) [[2]](diffhunk://#diff-bdfa9dab6dcff93ab6a067be9f9c05102678954475d5ebe124c6afe935b0277bR68-R74) [[3]](diffhunk://#diff-bf141e77aa2eab9305906732be273be08dfc8f38e4d9a3fe34da9686c64b5afdR204-R217)

**Frontend: UI/UX Enhancements for Subscription Management**

- Updated the subscription list UI so that after testing all endpoints, if there are failed (invalid) endpoints, the user is prompted with an action to clear them. The clear action triggers the new API and shows success/error feedback, including the number of endpoints removed. [[1]](diffhunk://#diff-538c4db1076066931f7a976dd5b096f82d6ecab8eb102ff4f057e80ca2a5f663R79-R95) [[2]](diffhunk://#diff-538c4db1076066931f7a976dd5b096f82d6ecab8eb102ff4f057e80ca2a5f663R111-R134)
- Improved the endpoint display style for better readability.

**Localization**

- Added new translation strings for clearing invalid endpoints and related user prompts in English, Chinese, and Japanese locale files. [[1]](diffhunk://#diff-7c3ddd710e34360b7b5261271001cf82fecd1ec1ba35a11816dc72043188935bL357-R362) [[2]](diffhunk://#diff-509ac1d8b074db2a28d921921fe3209108e42da94c5f030764de1df249ebed34L351-R356) [[3]](diffhunk://#diff-b479507489e9a261c081e98dc637df63793cda3004cb100730869e06cb3fb066L357-R362)

**Service Worker: VAPID Key Handling**

- Enhanced the service worker logic to check if the current push subscription's VAPID key matches the latest key. If they match, the existing subscription is reused; if not, it unsubscribes and resubscribes with the new key, preventing unnecessary re-subscriptions and related errors.