### PR TITLE
Fix admin storage settings payload

### DIFF
--- a/web/src/pages/admin/components/StorageConfigTab.tsx
+++ b/web/src/pages/admin/components/StorageConfigTab.tsx
@@ -70,7 +70,7 @@ export default function StorageConfigTab({
     }
     setIsSaving(true);
     try {
-      await put('/admin/settings', { storage: storageConfig });
+      await put('/admin/settings', { group: 'storage', config: storageConfig });
       await onMutate();
       toast.success(t('saveSuccess'));
     } catch (error: any) {


### PR DESCRIPTION
This pull request makes a small but important update to the way storage configuration is saved in the admin settings. The change ensures that the storage settings are properly grouped and formatted when sent to the backend. 

* Updated the payload in the `StorageConfigTab` component's save handler to include `group: 'storage'` and `config: storageConfig` when making a PUT request to `/admin/settings`, improving clarity and consistency in backend configuration management.