### PR TITLE
fix(i18n): add missing admin.storage save and required keys

### DIFF
--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -564,10 +564,13 @@
         "testSuccess": "Storage connection test successful!",
         "testFailed": "Connection test failed: {{error}}",
         "seeConsole": "See console for details.",
-        "fillAllRequired": "Please fill in all required fields",
-        "save": "Save",
-        "saving": "Saving..."
-      },
+      "fillAllRequired": "Please fill in all required fields",
+      "required": "Required",
+      "save": "Save",
+      "saving": "Saving...",
+      "saveSuccess": "Saved successfully",
+      "saveFailed": "Save failed: {{error}}"
+    },
       "ui": {
         "title": "UI Configuration",
         "description": "Configure user interface settings",

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -564,10 +564,13 @@
         "testSuccess": "ストレージ接続テスト成功！",
         "testFailed": "接続テストに失敗しました：{{error}}",
         "seeConsole": "詳細はコンソールを確認してください。",
-        "fillAllRequired": "すべての必須フィールドを入力してください",
-        "save": "保存",
-        "saving": "保存中..."
-      },
+      "fillAllRequired": "すべての必須フィールドを入力してください",
+      "required": "必須",
+      "save": "保存",
+      "saving": "保存中...",
+      "saveSuccess": "保存に成功しました",
+      "saveFailed": "保存に失敗しました：{{error}}"
+    },
       "ui": {
         "title": "UI設定",
         "description": "ユーザーインターフェース設定を構成",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -558,10 +558,13 @@
         "testSuccess": "存储连接测试成功！",
         "testFailed": "连接测试失败: {{error}}",
         "seeConsole": "详细信息请查看控制台。",
-        "fillAllRequired": "请填写所有必填字段",
-        "save": "保存",
-        "saving": "保存中..."
-      },
+      "fillAllRequired": "请填写所有必填字段",
+      "required": "必填",
+      "save": "保存",
+      "saving": "保存中...",
+      "saveSuccess": "保存成功",
+      "saveFailed": "保存失败: {{error}}"
+    },
       "ui": {
         "title": "界面配置",
         "description": "配置用户界面相关设置",


### PR DESCRIPTION
This pull request adds and improves save-related status messages in the localization files for English, Japanese, and Chinese. The updates enhance user feedback for saving actions and required fields.

Localization updates for save actions and required fields:

* Added translations for "Required" and improved save status messages, including "Saved successfully" and "Save failed: {{error}}", in `en.json`, `ja.json`, and `zh.json` to provide clearer user feedback. [[1]](diffhunk://#diff-7c3ddd710e34360b7b5261271001cf82fecd1ec1ba35a11816dc72043188935bR568-R572) [[2]](diffhunk://#diff-b479507489e9a261c081e98dc637df63793cda3004cb100730869e06cb3fb066R568-R572) [[3]](diffhunk://#diff-509ac1d8b074db2a28d921921fe3209108e42da94c5f030764de1df249ebed34R562-R566)