### PR TITLE
feat: support video attachments

### DIFF
--- a/server/route/v2/admin.ts
+++ b/server/route/v2/admin.ts
@@ -234,14 +234,25 @@ adminRouter.post('/setup', async (c: HonoContext) => {
     if (
       setupData.ui.allowRegistration === undefined ||
       setupData.ui.allowUploadFile === undefined ||
+      setupData.ui.allowUserVideoUpload === undefined ||
       !setupData.ui.defaultUserRole ||
-      setupData.ui.apiRateLimit === undefined
+      setupData.ui.apiRateLimit === undefined ||
+      setupData.ui.maxVideoUploadSizeMB === undefined
     ) {
       return c.json(createResponse(null, 'UI configuration is incomplete'), 400);
     }
     // 验证 apiRateLimit 必须 >= 10
     if (typeof setupData.ui.apiRateLimit !== 'number' || setupData.ui.apiRateLimit < 10) {
       return c.json(createResponse(null, 'API rate limit must be a number and at least 10'), 400);
+    }
+    if (
+      typeof setupData.ui.maxVideoUploadSizeMB !== 'number' ||
+      setupData.ui.maxVideoUploadSizeMB < 1
+    ) {
+      return c.json(
+        createResponse(null, 'Video upload size limit must be a number and at least 1 MB'),
+        400
+      );
     }
     // 验证 defaultUserRole 必须是有效角色
     if (!['user', 'moderator'].includes(setupData.ui.defaultUserRole)) {
@@ -445,6 +456,15 @@ adminRouter.put('/settings', authenticateJWT, requireAdmin, async (c: HonoContex
         (typeof config.apiRateLimit !== 'number' || config.apiRateLimit < 10)
       ) {
         return c.json(createResponse(null, 'API rate limit must be a number and at least 10'), 400);
+      }
+      if (
+        config.maxVideoUploadSizeMB !== undefined &&
+        (typeof config.maxVideoUploadSizeMB !== 'number' || config.maxVideoUploadSizeMB < 1)
+      ) {
+        return c.json(
+          createResponse(null, 'Video upload size limit must be a number and at least 1 MB'),
+          400
+        );
       }
       // 验证 defaultUserRole 必须是有效角色
       if (config.defaultUserRole && !['user', 'moderator'].includes(config.defaultUserRole)) {

--- a/server/route/v2/attachment.ts
+++ b/server/route/v2/attachment.ts
@@ -262,7 +262,14 @@ attachmentsRouter.post(
       }
     }
 
-    const hasVideo = attachments.some((a) => isVideoContentType(a.mimetype));
+    const hasVideo = attachments.some(
+      (a) =>
+        inferAttachmentMediaKind({
+          mimetype: a.mimetype,
+          compressedKey: a.compressedKey,
+          key: a.originalKey,
+        }) === 'video'
+    );
     if (hasVideo && !canAlwaysUploadVideo(user.role) && !canRegularUserUploadVideo(uiConfig)) {
       return c.json(
         createResponse(null, 'Video upload is currently disabled for regular users'),
@@ -275,7 +282,11 @@ attachmentsRouter.post(
     const validAttachments: typeof attachments = [];
 
     for (const a of attachments) {
-      const mediaKind = getMediaKindFromContentType(a.mimetype);
+      const mediaKind = inferAttachmentMediaKind({
+        mimetype: a.mimetype,
+        compressedKey: a.compressedKey,
+        key: a.originalKey,
+      });
 
       // 1. 验证原图文件是否存在
       const originalExists = await checkObjectExists(a.originalKey);

--- a/server/route/v2/attachment.ts
+++ b/server/route/v2/attachment.ts
@@ -10,14 +10,21 @@ import { getConfig, getGlobalConfig } from '../../utils/config';
 import {
   deleteAttachment,
   deleteAttachments,
+  getAttachmentDetailsByRoteId,
   updateAttachmentsSortOrder,
   upsertAttachmentsByOriginalKey,
 } from '../../utils/dbMethods';
 import {
+  DEFAULT_MAX_VIDEO_UPLOAD_SIZE_MB,
   MAX_BATCH_SIZE,
   MAX_FILES,
+  getMediaKindFromContentType,
+  inferAttachmentMediaKind,
+  isVideoContentType,
+  mergeUniqueRoteAttachmentDetails,
   validateContentType,
   validateFileSize,
+  validateRoteAttachmentDetails,
 } from '../../utils/fileValidation';
 import { createResponse, isValidUUID } from '../../utils/main';
 import { checkObjectExists, presignPutUrl } from '../../utils/r2';
@@ -25,6 +32,40 @@ import { AttachmentPresignZod } from '../../utils/zod';
 
 // 附件相关路由
 const attachmentsRouter = new Hono<{ Variables: HonoVariables }>();
+
+const canAlwaysUploadVideo = (role?: string | null) => role === 'admin' || role === 'super_admin';
+
+const canRegularUserUploadVideo = (uiConfig?: UiConfig | null) =>
+  uiConfig?.allowUserVideoUpload === true;
+
+const getMaxVideoUploadSizeMB = (uiConfig?: UiConfig | null) => {
+  const configured = uiConfig?.maxVideoUploadSizeMB;
+  return typeof configured === 'number' && configured > 0
+    ? configured
+    : DEFAULT_MAX_VIDEO_UPLOAD_SIZE_MB;
+};
+
+const getExt = (filename?: string, contentType?: string) => {
+  if (filename && filename.includes('.')) return `.${filename.split('.').pop()}`;
+  if (!contentType) return '';
+
+  const map: Record<string, string> = {
+    'image/jpeg': '.jpg',
+    'image/jpg': '.jpg',
+    'image/png': '.png',
+    'image/webp': '.webp',
+    'image/gif': '.gif',
+    'image/heic': '.heic',
+    'image/heif': '.heif',
+    'image/avif': '.avif',
+    'image/svg+xml': '.svg',
+    'video/mp4': '.mp4',
+    'video/webm': '.webm',
+    'video/quicktime': '.mov',
+  };
+
+  return map[contentType] || '';
+};
 
 // 删除单个附件
 attachmentsRouter.delete('/:id', authenticateJWT, async (c: HonoContext) => {
@@ -120,46 +161,29 @@ attachmentsRouter.post(
       throw new Error(`Maximum ${MAX_FILES} files allowed`);
     }
 
-    // 严格验证每个文件的内容类型和大小
-    for (const f of files) {
-      // 验证 contentType 必须提供且符合允许的类型
-      // validateContentType 内部会检查 contentType 是否存在
-      validateContentType(f.contentType);
-
-      // 验证文件大小必须提供且不能超过限制
-      validateFileSize(f.size);
+    const hasVideo = files.some((f) => isVideoContentType(f.contentType));
+    if (hasVideo && !canAlwaysUploadVideo(user.role) && !canRegularUserUploadVideo(uiConfig)) {
+      return c.json(
+        createResponse(null, 'Video upload is currently disabled for regular users'),
+        403
+      );
     }
 
-    const getExt = (filename?: string, contentType?: string) => {
-      if (filename && filename.includes('.')) return `.${filename.split('.').pop()}`;
-      if (!contentType) return '';
-      const map: Record<string, string> = {
-        'image/jpeg': '.jpg',
-        'image/jpg': '.jpg',
-        'image/png': '.png',
-        'image/webp': '.webp',
-        'image/gif': '.gif',
-        'image/heic': '.heic',
-        'image/heif': '.heif',
-        'image/avif': '.avif',
-        'image/svg+xml': '.svg',
-      };
-      return map[contentType] || '';
-    };
+    // 严格验证每个文件的内容类型和大小
+    for (const f of files) {
+      validateContentType(f.contentType);
+      validateFileSize(f.size, f.contentType, getMaxVideoUploadSizeMB(uiConfig));
+    }
 
     const results = await Promise.all(
       files.map(async (f) => {
         const uuid = randomUUID();
         const ext = getExt(f.filename, f.contentType);
         const originalKey = `users/${user.id}/uploads/${uuid}${ext}`;
-        const compressedKey = `users/${user.id}/compressed/${uuid}.webp`;
+        const mediaKind = getMediaKindFromContentType(f.contentType);
+        const original = await presignPutUrl(originalKey, f.contentType || undefined, 15 * 60);
 
-        const [original, compressed] = await Promise.all([
-          presignPutUrl(originalKey, f.contentType || undefined, 15 * 60),
-          presignPutUrl(compressedKey, 'image/webp', 15 * 60),
-        ]);
-
-        return {
+        const result: Record<string, any> = {
           uuid,
           original: {
             key: originalKey,
@@ -167,13 +191,20 @@ attachmentsRouter.post(
             url: original.url,
             contentType: f.contentType,
           },
-          compressed: {
+        };
+
+        if (mediaKind === 'image') {
+          const compressedKey = `users/${user.id}/compressed/${uuid}.webp`;
+          const compressed = await presignPutUrl(compressedKey, 'image/webp', 15 * 60);
+          result.compressed = {
             key: compressedKey,
             putUrl: compressed.putUrl,
             url: compressed.url,
             contentType: 'image/webp',
-          },
-        };
+          };
+        }
+
+        return result;
       })
     );
 
@@ -188,6 +219,7 @@ attachmentsRouter.post(
   requireStorageConfig,
   async (c: HonoContext) => {
     const user = c.get('user') as User;
+    const uiConfig = await getConfig<UiConfig>('ui');
     const body = await c.req.json();
     const { attachments, noteId } = body as {
       attachments: Array<{
@@ -213,7 +245,11 @@ attachmentsRouter.post(
 
     // 简单的所有权校验：Key 必须在当前用户前缀下
     const prefix = `users/${user.id}/`;
-    const invalid = attachments.find((a) => !a.originalKey?.startsWith(prefix));
+    const invalid = attachments.find(
+      (a) =>
+        !a.originalKey?.startsWith(prefix) ||
+        (a.compressedKey !== undefined && !a.compressedKey.startsWith(prefix))
+    );
     if (invalid) {
       throw new Error('Invalid object key');
     }
@@ -222,7 +258,16 @@ attachmentsRouter.post(
     for (const a of attachments) {
       if (a.mimetype) {
         validateContentType(a.mimetype);
+        validateFileSize(a.size, a.mimetype, getMaxVideoUploadSizeMB(uiConfig));
       }
+    }
+
+    const hasVideo = attachments.some((a) => isVideoContentType(a.mimetype));
+    if (hasVideo && !canAlwaysUploadVideo(user.role) && !canRegularUserUploadVideo(uiConfig)) {
+      return c.json(
+        createResponse(null, 'Video upload is currently disabled for regular users'),
+        403
+      );
     }
 
     // 验证文件存在性和 UUID 一致性
@@ -230,6 +275,8 @@ attachmentsRouter.post(
     const validAttachments: typeof attachments = [];
 
     for (const a of attachments) {
+      const mediaKind = getMediaKindFromContentType(a.mimetype);
+
       // 1. 验证原图文件是否存在
       const originalExists = await checkObjectExists(a.originalKey);
       if (!originalExists) {
@@ -238,7 +285,14 @@ attachmentsRouter.post(
       }
 
       // 2. 如果提供了 compressedKey，验证压缩图是否存在
-      if (a.compressedKey) {
+      if (mediaKind === 'video' && a.compressedKey) {
+        validationErrors.push(
+          `Videos cannot include compressedKey: ${a.originalKey} (uuid: ${a.uuid})`
+        );
+        continue;
+      }
+
+      if (mediaKind === 'image' && a.compressedKey) {
         const compressedExists = await checkObjectExists(a.compressedKey);
         if (!compressedExists) {
           validationErrors.push(`Compressed file not found: ${a.compressedKey} (uuid: ${a.uuid})`);
@@ -313,14 +367,38 @@ attachmentsRouter.post(
       );
     }
 
+    if (noteId) {
+      const currentAttachments = await getAttachmentDetailsByRoteId(noteId);
+      const pendingAttachments = validAttachments.map((a) => ({
+        details: {
+          key: a.originalKey,
+          mimetype: a.mimetype || null,
+          mediaKind: inferAttachmentMediaKind({
+            mimetype: a.mimetype || null,
+            compressedKey: a.compressedKey,
+          }),
+          compressKey: a.compressedKey,
+        },
+      }));
+      validateRoteAttachmentDetails(
+        mergeUniqueRoteAttachmentDetails(currentAttachments, pendingAttachments)
+      );
+    }
+
     const uploads: UploadResult[] = validAttachments.map((a) => {
       const storageConfig = getGlobalConfig<StorageConfig>('storage');
       const urlPrefix = storageConfig?.urlPrefix;
       const oUrl = `${urlPrefix}/${a.originalKey}`;
-      const cUrl = a.compressedKey ? `${urlPrefix}/${a.compressedKey}` : null;
+      const mediaKind = inferAttachmentMediaKind({
+        mimetype: a.mimetype || null,
+        compressedKey: a.compressedKey,
+      });
+      const cUrl =
+        mediaKind === 'image' && a.compressedKey ? `${urlPrefix}/${a.compressedKey}` : null;
       const baseDetails: any = {
         size: a.size || 0,
         mimetype: a.mimetype || null,
+        mediaKind,
         mtime: new Date().toISOString(),
         key: a.originalKey,
       };

--- a/server/route/v2/openKeyRouter.ts
+++ b/server/route/v2/openKeyRouter.ts
@@ -24,8 +24,10 @@ import {
   findArticleById,
   findMyRote,
   findRoteById,
+  getAttachmentDetailsByRoteId,
   getMyProfile,
   getNoteByArticleId,
+  oneUser,
   removeReaction,
   searchMyRotes,
   setNoteArticleId,
@@ -33,10 +35,16 @@ import {
   upsertAttachmentsByOriginalKey,
 } from '../../utils/dbMethods';
 import {
+  DEFAULT_MAX_VIDEO_UPLOAD_SIZE_MB,
   MAX_BATCH_SIZE,
   MAX_FILES,
+  getMediaKindFromContentType,
+  inferAttachmentMediaKind,
+  isVideoContentType,
+  mergeUniqueRoteAttachmentDetails,
   validateContentType,
   validateFileSize,
+  validateRoteAttachmentDetails,
 } from '../../utils/fileValidation';
 import { extractUrlsFromContent, parseAndStoreRoteLinkPreviews } from '../../utils/linkPreview';
 import { createResponse, isOpenKeyOk, isValidUUID } from '../../utils/main';
@@ -53,6 +61,40 @@ import {
 } from '../../utils/zod';
 
 const router = new Hono<{ Variables: HonoVariables }>();
+
+const canAlwaysUploadVideo = (role?: string | null) => role === 'admin' || role === 'super_admin';
+
+const canRegularUserUploadVideo = (uiConfig?: UiConfig | null) =>
+  uiConfig?.allowUserVideoUpload === true;
+
+const getMaxVideoUploadSizeMB = (uiConfig?: UiConfig | null) => {
+  const configured = uiConfig?.maxVideoUploadSizeMB;
+  return typeof configured === 'number' && configured > 0
+    ? configured
+    : DEFAULT_MAX_VIDEO_UPLOAD_SIZE_MB;
+};
+
+const getExt = (filename?: string, contentType?: string) => {
+  if (filename && filename.includes('.')) return `.${filename.split('.').pop()}`;
+  if (!contentType) return '';
+
+  const map: Record<string, string> = {
+    'image/jpeg': '.jpg',
+    'image/jpg': '.jpg',
+    'image/png': '.png',
+    'image/webp': '.webp',
+    'image/gif': '.gif',
+    'image/heic': '.heic',
+    'image/heif': '.heif',
+    'image/avif': '.avif',
+    'image/svg+xml': '.svg',
+    'video/mp4': '.mp4',
+    'video/webm': '.webm',
+    'video/quicktime': '.mov',
+  };
+
+  return map[contentType] || '';
+};
 
 function requireOpenKeyPerm(...perms: string[]) {
   return async (c: HonoContext, next: () => Promise<void>) => {
@@ -696,42 +738,30 @@ router.post(
       throw new Error(`Maximum ${MAX_FILES} files allowed`);
     }
 
+    const owner = await oneUser(openKey.userid);
+    const hasVideo = files.some((f) => isVideoContentType(f.contentType));
+    if (hasVideo && !canAlwaysUploadVideo(owner?.role) && !canRegularUserUploadVideo(uiConfig)) {
+      return c.json(
+        createResponse(null, 'Video upload is currently disabled for regular users'),
+        403
+      );
+    }
+
     // Strict validation
     for (const f of files) {
       validateContentType(f.contentType);
-      validateFileSize(f.size);
+      validateFileSize(f.size, f.contentType, getMaxVideoUploadSizeMB(uiConfig));
     }
-
-    const getExt = (filename?: string, contentType?: string) => {
-      if (filename && filename.includes('.')) return `.${filename.split('.').pop()}`;
-      if (!contentType) return '';
-      const map: Record<string, string> = {
-        'image/jpeg': '.jpg',
-        'image/jpg': '.jpg',
-        'image/png': '.png',
-        'image/webp': '.webp',
-        'image/gif': '.gif',
-        'image/heic': '.heic',
-        'image/heif': '.heif',
-        'image/avif': '.avif',
-        'image/svg+xml': '.svg',
-      };
-      return map[contentType] || '';
-    };
 
     const results = await Promise.all(
       files.map(async (f) => {
         const uuid = randomUUID();
         const ext = getExt(f.filename, f.contentType);
         const originalKey = `users/${openKey.userid}/uploads/${uuid}${ext}`;
-        const compressedKey = `users/${openKey.userid}/compressed/${uuid}.webp`;
+        const mediaKind = getMediaKindFromContentType(f.contentType);
+        const original = await presignPutUrl(originalKey, f.contentType || undefined, 15 * 60);
 
-        const [original, compressed] = await Promise.all([
-          presignPutUrl(originalKey, f.contentType || undefined, 15 * 60),
-          presignPutUrl(compressedKey, 'image/webp', 15 * 60),
-        ]);
-
-        return {
+        const result: Record<string, any> = {
           uuid,
           original: {
             key: originalKey,
@@ -739,13 +769,20 @@ router.post(
             url: original.url,
             contentType: f.contentType,
           },
-          compressed: {
+        };
+
+        if (mediaKind === 'image') {
+          const compressedKey = `users/${openKey.userid}/compressed/${uuid}.webp`;
+          const compressed = await presignPutUrl(compressedKey, 'image/webp', 15 * 60);
+          result.compressed = {
             key: compressedKey,
             putUrl: compressed.putUrl,
             url: compressed.url,
             contentType: 'image/webp',
-          },
-        };
+          };
+        }
+
+        return result;
       })
     );
 
@@ -761,6 +798,7 @@ router.post(
   requireStorageConfig,
   async (c: HonoContext) => {
     const openKey = c.get('openKey')!;
+    const uiConfig = await getConfig<UiConfig>('ui');
     const body = await c.req.json();
     const { attachments, noteId } = body as {
       attachments: Array<{
@@ -797,20 +835,39 @@ router.post(
     for (const a of attachments) {
       if (a.mimetype) {
         validateContentType(a.mimetype);
+        validateFileSize(a.size, a.mimetype, getMaxVideoUploadSizeMB(uiConfig));
       }
+    }
+
+    const owner = await oneUser(openKey.userid);
+    const hasVideo = attachments.some((a) => isVideoContentType(a.mimetype));
+    if (hasVideo && !canAlwaysUploadVideo(owner?.role) && !canRegularUserUploadVideo(uiConfig)) {
+      return c.json(
+        createResponse(null, 'Video upload is currently disabled for regular users'),
+        403
+      );
     }
 
     const validationErrors: string[] = [];
     const validAttachments: typeof attachments = [];
 
     for (const a of attachments) {
+      const mediaKind = getMediaKindFromContentType(a.mimetype);
+
       const originalExists = await checkObjectExists(a.originalKey);
       if (!originalExists) {
         validationErrors.push(`Original file not found: ${a.originalKey} (uuid: ${a.uuid})`);
         continue;
       }
 
-      if (a.compressedKey) {
+      if (mediaKind === 'video' && a.compressedKey) {
+        validationErrors.push(
+          `Videos cannot include compressedKey: ${a.originalKey} (uuid: ${a.uuid})`
+        );
+        continue;
+      }
+
+      if (mediaKind === 'image' && a.compressedKey) {
         const compressedExists = await checkObjectExists(a.compressedKey);
         if (!compressedExists) {
           validationErrors.push(`Compressed file not found: ${a.compressedKey} (uuid: ${a.uuid})`);
@@ -868,14 +925,38 @@ router.post(
       );
     }
 
+    if (noteId) {
+      const currentAttachments = await getAttachmentDetailsByRoteId(noteId);
+      const pendingAttachments = validAttachments.map((a) => ({
+        details: {
+          key: a.originalKey,
+          mimetype: a.mimetype || null,
+          mediaKind: inferAttachmentMediaKind({
+            mimetype: a.mimetype || null,
+            compressedKey: a.compressedKey,
+          }),
+          compressKey: a.compressedKey,
+        },
+      }));
+      validateRoteAttachmentDetails(
+        mergeUniqueRoteAttachmentDetails(currentAttachments, pendingAttachments)
+      );
+    }
+
     const uploads: UploadResult[] = validAttachments.map((a) => {
       const storageConfig = getGlobalConfig<StorageConfig>('storage');
       const urlPrefix = storageConfig?.urlPrefix;
       const oUrl = `${urlPrefix}/${a.originalKey}`;
-      const cUrl = a.compressedKey ? `${urlPrefix}/${a.compressedKey}` : null;
+      const mediaKind = inferAttachmentMediaKind({
+        mimetype: a.mimetype || null,
+        compressedKey: a.compressedKey,
+      });
+      const cUrl =
+        mediaKind === 'image' && a.compressedKey ? `${urlPrefix}/${a.compressedKey}` : null;
       const baseDetails: any = {
         size: a.size || 0,
         mimetype: a.mimetype || null,
+        mediaKind,
         mtime: new Date().toISOString(),
         key: a.originalKey,
       };

--- a/server/route/v2/openKeyRouter.ts
+++ b/server/route/v2/openKeyRouter.ts
@@ -840,7 +840,14 @@ router.post(
     }
 
     const owner = await oneUser(openKey.userid);
-    const hasVideo = attachments.some((a) => isVideoContentType(a.mimetype));
+    const hasVideo = attachments.some(
+      (a) =>
+        inferAttachmentMediaKind({
+          mimetype: a.mimetype,
+          compressedKey: a.compressedKey,
+          key: a.originalKey,
+        }) === 'video'
+    );
     if (hasVideo && !canAlwaysUploadVideo(owner?.role) && !canRegularUserUploadVideo(uiConfig)) {
       return c.json(
         createResponse(null, 'Video upload is currently disabled for regular users'),
@@ -852,7 +859,11 @@ router.post(
     const validAttachments: typeof attachments = [];
 
     for (const a of attachments) {
-      const mediaKind = getMediaKindFromContentType(a.mimetype);
+      const mediaKind = inferAttachmentMediaKind({
+        mimetype: a.mimetype,
+        compressedKey: a.compressedKey,
+        key: a.originalKey,
+      });
 
       const originalExists = await checkObjectExists(a.originalKey);
       if (!originalExists) {

--- a/server/route/v2/site.ts
+++ b/server/route/v2/site.ts
@@ -133,6 +133,8 @@ siteRouter.get('/status', async (c: HonoContext) => {
       ui: {
         allowRegistration: uiConfig?.allowRegistration ?? true,
         allowUploadFile: uiConfig?.allowUploadFile ?? true,
+        allowUserVideoUpload: uiConfig?.allowUserVideoUpload ?? false,
+        maxVideoUploadSizeMB: uiConfig?.maxVideoUploadSizeMB ?? 300,
       },
 
       // OAuth 配置（用于前端判断是否显示 OAuth 登录按钮）

--- a/server/scripts/README.md
+++ b/server/scripts/README.md
@@ -105,7 +105,9 @@ Test data is defined in `testConfig.json`:
       "allowRegistration": true,
       "defaultUserRole": "user",
       "apiRateLimit": 100,
-      "allowUploadFile": true
+      "allowUploadFile": true,
+      "allowUserVideoUpload": false,
+      "maxVideoUploadSizeMB": 300
     },
     "admin": {
       "username": "testadmin",

--- a/server/scripts/testConfig.json
+++ b/server/scripts/testConfig.json
@@ -23,7 +23,9 @@
       "allowRegistration": true,
       "defaultUserRole": "user",
       "apiRateLimit": 100,
-      "allowUploadFile": true
+      "allowUploadFile": true,
+      "allowUserVideoUpload": false,
+      "maxVideoUploadSizeMB": 300
     },
     "admin": {
       "username": "testadmin",
@@ -35,7 +37,12 @@
   "expectedResults": {
     "systemStatus": {
       "initialized": false,
-      "missingConfigs": ["site", "storage", "security", "ui"],
+      "missingConfigs": [
+        "site",
+        "storage",
+        "security",
+        "ui"
+      ],
       "databaseConnected": true,
       "hasAdminUser": false
     },

--- a/server/tests/fileValidation.test.ts
+++ b/server/tests/fileValidation.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  DEFAULT_MAX_VIDEO_UPLOAD_SIZE_MB,
+  MAX_FILES,
+  getMaxVideoUploadSizeBytes,
+  getMediaKindFromFilename,
+  inferAttachmentMediaKind,
+  mergeUniqueRoteAttachmentDetails,
+  validateFileSize,
+  validateRoteAttachmentDetails,
+} from '../utils/fileValidation';
+
+describe('fileValidation', () => {
+  it('allows a single video attachment', () => {
+    expect(() =>
+      validateRoteAttachmentDetails([
+        {
+          details: {
+            mediaKind: 'video',
+            mimetype: 'video/mp4',
+          },
+        },
+      ])
+    ).not.toThrow();
+  });
+
+  it('rejects mixed image and video attachments', () => {
+    expect(() =>
+      validateRoteAttachmentDetails([
+        {
+          details: {
+            mediaKind: 'image',
+            mimetype: 'image/png',
+          },
+        },
+        {
+          details: {
+            mediaKind: 'video',
+            mimetype: 'video/mp4',
+          },
+        },
+      ])
+    ).toThrow('Images and videos cannot be uploaded together in the same Rote');
+  });
+
+  it('rejects more than one video', () => {
+    expect(() =>
+      validateRoteAttachmentDetails([
+        {
+          details: {
+            mediaKind: 'video',
+            mimetype: 'video/mp4',
+          },
+        },
+        {
+          details: {
+            mediaKind: 'video',
+            mimetype: 'video/webm',
+          },
+        },
+      ])
+    ).toThrow('Only one video can be uploaded to a Rote');
+  });
+
+  it('rejects more than the max number of images', () => {
+    const attachments = Array.from({ length: MAX_FILES + 1 }, () => ({
+      details: {
+        mediaKind: 'image',
+        mimetype: 'image/png',
+      },
+    }));
+
+    expect(() => validateRoteAttachmentDetails(attachments)).toThrow(
+      `Maximum ${MAX_FILES} images can be uploaded to a Rote`
+    );
+  });
+
+  it('uses configured video upload size limit', () => {
+    const maxVideoSizeMB = DEFAULT_MAX_VIDEO_UPLOAD_SIZE_MB + 50;
+    const allowedSize = getMaxVideoUploadSizeBytes(maxVideoSizeMB);
+
+    expect(() => validateFileSize(allowedSize, 'video/mp4', maxVideoSizeMB)).not.toThrow();
+    expect(() => validateFileSize(allowedSize + 1, 'video/mp4', maxVideoSizeMB)).toThrow(
+      `Video file size exceeds limit: ${allowedSize} bytes`
+    );
+  });
+
+  it('treats attachments with compressed keys as images when mimetype is missing', () => {
+    expect(
+      inferAttachmentMediaKind({
+        compressedKey: 'users/test/compressed/example.webp',
+      })
+    ).toBe('image');
+
+    expect(() =>
+      validateRoteAttachmentDetails([
+        {
+          details: {
+            key: 'users/test/uploads/example.png',
+            compressKey: 'users/test/compressed/example.webp',
+          },
+        },
+      ])
+    ).not.toThrow();
+  });
+
+  it('infers legacy attachment media kind from the stored key extension', () => {
+    expect(getMediaKindFromFilename('users/test/uploads/example.mp4')).toBe('video');
+    expect(getMediaKindFromFilename('users/test/uploads/example.png')).toBe('image');
+
+    expect(
+      inferAttachmentMediaKind({
+        key: 'users/test/uploads/example.mp4',
+      })
+    ).toBe('video');
+
+    expect(() =>
+      validateRoteAttachmentDetails([
+        {
+          details: {
+            key: 'users/test/uploads/example.mp4',
+          },
+        },
+      ])
+    ).not.toThrow();
+  });
+
+  it('ignores duplicate attachment keys when merging retry payloads', () => {
+    const merged = mergeUniqueRoteAttachmentDetails(
+      [
+        {
+          details: {
+            key: 'users/test/uploads/video.mp4',
+            mediaKind: 'video',
+            mimetype: 'video/mp4',
+          },
+        },
+      ],
+      [
+        {
+          details: {
+            key: 'users/test/uploads/video.mp4',
+            mediaKind: 'video',
+            mimetype: 'video/mp4',
+          },
+        },
+      ]
+    );
+
+    expect(merged).toHaveLength(1);
+    expect(() => validateRoteAttachmentDetails(merged)).not.toThrow();
+  });
+});

--- a/server/tests/fileValidation.test.ts
+++ b/server/tests/fileValidation.test.ts
@@ -125,6 +125,15 @@ describe('fileValidation', () => {
     ).not.toThrow();
   });
 
+  it('prefers original key extension over compressed key when inferring media kind', () => {
+    expect(
+      inferAttachmentMediaKind({
+        key: 'users/test/uploads/example.mp4',
+        compressedKey: 'users/test/compressed/example.webp',
+      })
+    ).toBe('video');
+  });
+
   it('ignores duplicate attachment keys when merging retry payloads', () => {
     const merged = mergeUniqueRoteAttachmentDetails(
       [

--- a/server/types/config.ts
+++ b/server/types/config.ts
@@ -67,6 +67,8 @@ export interface UiConfig {
   defaultUserRole: string;
   apiRateLimit: number;
   allowUploadFile: boolean;
+  allowUserVideoUpload: boolean;
+  maxVideoUploadSizeMB: number;
 }
 
 export interface SystemConfig {
@@ -126,6 +128,8 @@ export interface SetupRequest {
     defaultUserRole: string;
     apiRateLimit: number;
     allowUploadFile: boolean;
+    allowUserVideoUpload: boolean;
+    maxVideoUploadSizeMB: number;
   };
   admin: {
     username: string;

--- a/server/utils/dbMethods/attachment.ts
+++ b/server/utils/dbMethods/attachment.ts
@@ -1,6 +1,7 @@
 import { and, desc, eq, inArray, isNull, or, sql } from 'drizzle-orm';
 import { attachments, rotes } from '../../drizzle/schema';
 import { UploadResult } from '../../types/main';
+import { validateRoteAttachmentDetails } from '../fileValidation';
 import db from '../drizzle';
 import { r2deletehandler } from '../r2';
 import { createRoteChange } from './change';
@@ -154,6 +155,19 @@ export async function upsertAttachmentsByOriginalKey(
   }
 }
 
+export async function getAttachmentDetailsByRoteId(
+  roteid: string
+): Promise<Array<{ details: any }>> {
+  try {
+    return await db
+      .select({ details: attachments.details })
+      .from(attachments)
+      .where(eq(attachments.roteid, roteid));
+  } catch (error) {
+    throw new DatabaseError(`Failed to get attachment details for rote: ${roteid}`, error);
+  }
+}
+
 // 将预上传且未绑定的附件绑定到笔记
 export async function bindAttachmentsToRote(
   userid: string,
@@ -168,7 +182,7 @@ export async function bindAttachmentsToRote(
     const result = await db.transaction(async (tx) => {
       // 先严格校验：必须都是当前用户、且尚未绑定
       const candidates = await tx
-        .select({ id: attachments.id })
+        .select({ id: attachments.id, details: attachments.details })
         .from(attachments)
         .where(
           and(
@@ -183,6 +197,13 @@ export async function bindAttachmentsToRote(
           'Some attachments cannot be bound (not found, not owned by user, or already bound)'
         );
       }
+
+      const existingAttachments = await tx
+        .select({ details: attachments.details })
+        .from(attachments)
+        .where(eq(attachments.roteid, roteid));
+
+      validateRoteAttachmentDetails([...existingAttachments, ...candidates]);
 
       // 按照 attachmentIds 的顺序逐个更新，设置对应的 sortIndex
       const updateResults = await Promise.all(

--- a/server/utils/fileValidation.ts
+++ b/server/utils/fileValidation.ts
@@ -107,13 +107,13 @@ export function inferAttachmentMediaKind(input?: UploadLike | null): MediaKind |
     return mediaKind;
   }
 
-  if (input.compressedKey || input.compressKey) {
-    return 'image';
-  }
-
   const mediaKindFromKey = getMediaKindFromFilename(input.key);
   if (mediaKindFromKey) {
     return mediaKindFromKey;
+  }
+
+  if (input.compressedKey || input.compressKey) {
+    return 'image';
   }
 
   return null;

--- a/server/utils/fileValidation.ts
+++ b/server/utils/fileValidation.ts
@@ -1,5 +1,4 @@
-// 允许的图片 MIME 类型
-export const ALLOWED_MIME_TYPES = [
+export const ALLOWED_IMAGE_MIME_TYPES = [
   'image/jpeg',
   'image/jpg',
   'image/png',
@@ -11,7 +10,10 @@ export const ALLOWED_MIME_TYPES = [
   'image/svg+xml',
 ];
 
-// 允许的文件扩展名
+export const ALLOWED_VIDEO_MIME_TYPES = ['video/mp4', 'video/webm', 'video/quicktime'];
+
+export const ALLOWED_MIME_TYPES = [...ALLOWED_IMAGE_MIME_TYPES, ...ALLOWED_VIDEO_MIME_TYPES];
+
 export const ALLOWED_EXTENSIONS = [
   '.jpg',
   '.jpeg',
@@ -22,13 +24,107 @@ export const ALLOWED_EXTENSIONS = [
   '.heif',
   '.avif',
   '.svg',
+  '.mp4',
+  '.webm',
+  '.mov',
 ];
 
-/**
- * 验证内容类型（用于 presign 接口）
- * @param contentType 内容类型字符串
- * @throws Error 如果内容类型无效
- */
+export const MAX_IMAGE_FILE_SIZE = 20 * 1024 * 1024;
+export const DEFAULT_MAX_VIDEO_UPLOAD_SIZE_MB = 300;
+export const MAX_FILES = 9;
+export const MAX_BATCH_SIZE = 100;
+
+export type MediaKind = 'image' | 'video';
+
+type AttachmentLike = {
+  details?: {
+    mediaKind?: MediaKind | null;
+    mimetype?: string | null;
+    contentType?: string | null;
+    compressKey?: string | null;
+    key?: string | null;
+  } | null;
+};
+
+type UploadLike = {
+  mediaKind?: MediaKind | null;
+  mimetype?: string | null;
+  contentType?: string | null;
+  compressedKey?: string | null;
+  compressKey?: string | null;
+  key?: string | null;
+};
+
+const IMAGE_EXTENSION_SET = new Set([
+  '.jpg',
+  '.jpeg',
+  '.png',
+  '.webp',
+  '.gif',
+  '.heic',
+  '.heif',
+  '.avif',
+  '.svg',
+]);
+const VIDEO_EXTENSION_SET = new Set(['.mp4', '.webm', '.mov']);
+
+export function getMediaKindFromFilename(name?: string | null): MediaKind | null {
+  if (!name) return null;
+
+  const normalizedName = name.split('?')[0].toLowerCase();
+  const ext = normalizedName.includes('.') ? `.${normalizedName.split('.').pop()}` : '';
+
+  if (IMAGE_EXTENSION_SET.has(ext)) return 'image';
+  if (VIDEO_EXTENSION_SET.has(ext)) return 'video';
+  return null;
+}
+
+export function isImageContentType(contentType?: string | null): boolean {
+  return !!contentType && ALLOWED_IMAGE_MIME_TYPES.includes(contentType);
+}
+
+export function isVideoContentType(contentType?: string | null): boolean {
+  return !!contentType && ALLOWED_VIDEO_MIME_TYPES.includes(contentType);
+}
+
+export function getMediaKindFromContentType(contentType?: string | null): MediaKind | null {
+  if (isImageContentType(contentType)) return 'image';
+  if (isVideoContentType(contentType)) return 'video';
+  return null;
+}
+
+export function inferAttachmentMediaKind(input?: UploadLike | null): MediaKind | null {
+  if (!input || typeof input !== 'object') {
+    return null;
+  }
+
+  if (input.mediaKind === 'image' || input.mediaKind === 'video') {
+    return input.mediaKind;
+  }
+
+  const mediaKind = getMediaKindFromContentType(input.mimetype || input.contentType);
+  if (mediaKind) {
+    return mediaKind;
+  }
+
+  if (input.compressedKey || input.compressKey) {
+    return 'image';
+  }
+
+  const mediaKindFromKey = getMediaKindFromFilename(input.key);
+  if (mediaKindFromKey) {
+    return mediaKindFromKey;
+  }
+
+  return null;
+}
+
+export function getMaxVideoUploadSizeBytes(
+  maxVideoUploadSizeMB = DEFAULT_MAX_VIDEO_UPLOAD_SIZE_MB
+) {
+  return Math.max(1, maxVideoUploadSizeMB) * 1024 * 1024;
+}
+
 export function validateContentType(contentType?: string): void {
   if (!contentType) {
     throw new Error('Content type is required');
@@ -39,24 +135,106 @@ export function validateContentType(contentType?: string): void {
   }
 }
 
-// 文件上传限制常量
-export const MAX_FILE_SIZE = 20 * 1024 * 1024; // 20MB
-export const MAX_FILES = 9;
-export const MAX_BATCH_SIZE = 100; // 批量操作最大数量限制
-
-/**
- * 验证文件大小（用于 presign 接口）
- * @param size 文件大小（字节）
- * @throws Error 如果文件大小无效
- */
-export function validateFileSize(size: number | undefined | null): void {
+export function validateImageFileSize(size: number | undefined | null): void {
   if (size === undefined || size === null) {
     throw new Error('File size (size) is required');
   }
   if (size <= 0) {
     throw new Error('File size must be greater than 0');
   }
-  if (size > MAX_FILE_SIZE) {
-    throw new Error(`File size exceeds limit: ${MAX_FILE_SIZE} bytes`);
+  if (size > MAX_IMAGE_FILE_SIZE) {
+    throw new Error(`Image file size exceeds limit: ${MAX_IMAGE_FILE_SIZE} bytes`);
   }
+}
+
+export function validateVideoFileSize(
+  size: number | undefined | null,
+  maxVideoUploadSizeMB = DEFAULT_MAX_VIDEO_UPLOAD_SIZE_MB
+): void {
+  if (size === undefined || size === null) {
+    throw new Error('File size (size) is required');
+  }
+  if (size <= 0) {
+    throw new Error('File size must be greater than 0');
+  }
+
+  const maxVideoSize = getMaxVideoUploadSizeBytes(maxVideoUploadSizeMB);
+  if (size > maxVideoSize) {
+    throw new Error(`Video file size exceeds limit: ${maxVideoSize} bytes`);
+  }
+}
+
+export function validateFileSize(
+  size: number | undefined | null,
+  contentType?: string | null,
+  maxVideoUploadSizeMB = DEFAULT_MAX_VIDEO_UPLOAD_SIZE_MB
+): void {
+  const mediaKind = getMediaKindFromContentType(contentType);
+
+  if (mediaKind === 'video') {
+    validateVideoFileSize(size, maxVideoUploadSizeMB);
+    return;
+  }
+
+  validateImageFileSize(size);
+}
+
+export function getAttachmentMediaKind(details?: any): MediaKind | null {
+  if (!details || typeof details !== 'object') {
+    return null;
+  }
+
+  return inferAttachmentMediaKind(details);
+}
+
+export function getAttachmentStorageKey(item?: AttachmentLike | null): string | null {
+  const key = item?.details?.key;
+  return typeof key === 'string' && key.length > 0 ? key : null;
+}
+
+export function mergeUniqueRoteAttachmentDetails<T extends AttachmentLike>(
+  currentItems: T[],
+  pendingItems: T[]
+): T[] {
+  const existingKeys = new Set(
+    currentItems.map((item) => getAttachmentStorageKey(item)).filter((key): key is string => !!key)
+  );
+
+  const uniquePendingItems = pendingItems.filter((item) => {
+    const key = getAttachmentStorageKey(item);
+    return !key || !existingKeys.has(key);
+  });
+
+  return [...currentItems, ...uniquePendingItems];
+}
+
+export function validateRoteMediaKinds(mediaKinds: MediaKind[]): void {
+  if (mediaKinds.length === 0) return;
+
+  const imageCount = mediaKinds.filter((kind) => kind === 'image').length;
+  const videoCount = mediaKinds.filter((kind) => kind === 'video').length;
+
+  if (imageCount > 0 && videoCount > 0) {
+    throw new Error('Images and videos cannot be uploaded together in the same Rote');
+  }
+
+  if (videoCount > 1) {
+    throw new Error('Only one video can be uploaded to a Rote');
+  }
+
+  if (imageCount > MAX_FILES) {
+    throw new Error(`Maximum ${MAX_FILES} images can be uploaded to a Rote`);
+  }
+}
+
+export function validateRoteAttachmentDetails(items: Array<{ details?: any }>): void {
+  const mediaKinds = items
+    .map((item) => getAttachmentMediaKind(item.details))
+    .filter((kind): kind is MediaKind => kind !== null);
+
+  if (mediaKinds.length !== items.length) {
+    throw new Error('Unsupported attachment media type');
+  }
+
+  validateRoteMediaKinds(mediaKinds);
 }

--- a/web/src/components/editor/AttachmentItem.tsx
+++ b/web/src/components/editor/AttachmentItem.tsx
@@ -1,49 +1,108 @@
 import type { Attachment } from '@/types/main';
+import { getAttachmentMediaKind } from '@/utils/directUpload';
 import { X } from 'lucide-react';
 import { PhotoView } from 'react-photo-view';
+import { useEffect, useMemo } from 'react';
 
 interface AttachmentItemProps {
   attachment: File | Attachment;
   index: number;
   isUploading: boolean;
+  uploadProgress?: number;
   onDelete: (_index: number) => void;
 }
 
-function AttachmentItem({ attachment, index, isUploading, onDelete }: AttachmentItemProps) {
+function AttachmentItem({
+  attachment,
+  index,
+  isUploading,
+  uploadProgress,
+  onDelete,
+}: AttachmentItemProps) {
+  const mediaKind = getAttachmentMediaKind(attachment);
+  const objectUrl = useMemo(
+    () => (attachment instanceof File ? URL.createObjectURL(attachment) : null),
+    [attachment]
+  );
+
+  useEffect(() => (objectUrl ? () => URL.revokeObjectURL(objectUrl) : undefined), [objectUrl]);
+
   const thumbSrc =
-    attachment instanceof File
-      ? URL.createObjectURL(attachment)
-      : attachment.compressUrl || attachment.url;
-  const previewSrc = attachment instanceof File ? thumbSrc : attachment.url;
+    objectUrl || (!(attachment instanceof File) ? attachment.compressUrl || attachment.url : '');
+  const previewSrc = objectUrl || (!(attachment instanceof File) ? attachment.url : '');
+  const progressValue =
+    typeof uploadProgress === 'number' ? Math.max(0, Math.min(100, uploadProgress)) : 0;
 
   return (
     <div
-      className="bg-background relative h-20 w-20 overflow-hidden rounded-lg"
+      className={`bg-background relative overflow-hidden ${
+        mediaKind === 'video'
+          ? 'aspect-video w-full rounded-2xl border border-white/10 bg-black'
+          : 'h-20 w-20 rounded-lg'
+      }`}
       key={'attachments_' + index}
     >
-      <PhotoView src={previewSrc}>
-        <img
-          className={`h-full w-full object-cover ${isUploading ? 'opacity-80' : ''}`}
-          height={80}
-          width={80}
-          src={thumbSrc}
-          alt="uploaded"
-        />
-      </PhotoView>
+      {mediaKind === 'video' ? (
+        <>
+          <video
+            className={`h-full w-full ${isUploading ? 'object-cover opacity-55' : 'object-contain'}`}
+            src={previewSrc}
+            controls={!isUploading}
+            muted={isUploading}
+            playsInline
+            preload="metadata"
+            onPointerDown={(e) => e.stopPropagation()}
+            onClick={(e) => e.stopPropagation()}
+          />
 
-      {/* 上传中遮罩与小型 spinner */}
-      {isUploading && (
+          {isUploading && (
+            <>
+              <div className="pointer-events-none absolute inset-0 bg-black/20" />
+              <div className="pointer-events-none absolute inset-0 animate-pulse bg-white/10" />
+              <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+                <div className="text-sm font-medium text-white sm:text-base">{progressValue}%</div>
+              </div>
+              <div className="pointer-events-none absolute right-0 bottom-0 left-0 px-3 py-3">
+                <div className="h-1.5 overflow-hidden rounded-full bg-white/20">
+                  <div
+                    className="h-full rounded-full bg-white transition-[width] duration-150"
+                    style={{ width: `${progressValue}%` }}
+                  />
+                </div>
+              </div>
+            </>
+          )}
+        </>
+      ) : (
+        <PhotoView src={previewSrc}>
+          <img
+            className={`h-full w-full object-cover ${isUploading ? 'opacity-80' : ''}`}
+            height={80}
+            width={80}
+            src={thumbSrc}
+            alt="uploaded"
+          />
+        </PhotoView>
+      )}
+
+      {isUploading && mediaKind !== 'video' && (
         <div className="absolute inset-0 grid place-items-center bg-black/30">
           <div className="h-5 w-5 animate-spin rounded-full border-2 border-white/60 border-t-transparent" />
         </div>
       )}
 
-      <div
-        onClick={() => onDelete(index)}
-        className="absolute top-1 right-1 flex cursor-pointer items-center justify-center rounded-md bg-[#00000080] p-2 backdrop-blur-xl duration-300 hover:scale-95"
+      <button
+        type="button"
+        onPointerDown={(e) => e.stopPropagation()}
+        onClick={(e) => {
+          e.stopPropagation();
+          onDelete(index);
+        }}
+        className="absolute top-1.5 right-1.5 z-10 flex cursor-pointer items-center justify-center rounded-md bg-[#00000080] p-2 backdrop-blur-xl duration-300 hover:scale-95"
+        aria-label="Delete attachment"
       >
         <X className="size-3 text-white" />
-      </div>
+      </button>
     </div>
   );
 }

--- a/web/src/components/editor/AttachmentList.tsx
+++ b/web/src/components/editor/AttachmentList.tsx
@@ -1,5 +1,6 @@
 import FileSelector from '@/components/others/uploader';
 import type { Attachment } from '@/types/main';
+import { getAttachmentMediaKind } from '@/utils/directUpload';
 import {
   closestCenter,
   DndContext,
@@ -25,6 +26,7 @@ interface SortableAttachmentItemProps {
   index: number;
   isUploading: boolean;
   onDelete: (_index: number) => void;
+  uploadProgress?: number;
   id: string;
 }
 
@@ -34,6 +36,7 @@ function SortableAttachmentItem({
   index,
   isUploading,
   onDelete,
+  uploadProgress,
   id,
 }: SortableAttachmentItemProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
@@ -46,12 +49,21 @@ function SortableAttachmentItem({
     opacity: isDragging ? 0.5 : 1,
   };
 
+  const mediaKind = getAttachmentMediaKind(attachment);
+
   return (
-    <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={mediaKind === 'video' ? 'w-full' : undefined}
+      {...attributes}
+      {...listeners}
+    >
       <AttachmentItem
         attachment={attachment}
         index={index}
         isUploading={isUploading}
+        uploadProgress={uploadProgress}
         onDelete={onDelete}
       />
     </div>
@@ -66,6 +78,9 @@ interface AttachmentListProps {
   onFileAdd: (_files: File[]) => void;
   roteId?: string;
   disabled?: boolean;
+  accept?: string;
+  canAddMore?: boolean;
+  uploadProgress?: Map<File, number>;
 }
 
 function AttachmentList({
@@ -76,6 +91,9 @@ function AttachmentList({
   onFileAdd,
   roteId,
   disabled,
+  accept,
+  canAddMore = true,
+  uploadProgress,
 }: AttachmentListProps) {
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -112,6 +130,8 @@ function AttachmentList({
           <SortableContext items={attachmentIds} strategy={rectSortingStrategy}>
             {attachments.map((attachment, index) => {
               const isUploading = attachment instanceof File && uploadingFiles.has(attachment);
+              const progress =
+                attachment instanceof File ? uploadProgress?.get(attachment) : undefined;
               return (
                 <SortableAttachmentItem
                   key={`attachment-${index}`}
@@ -120,17 +140,19 @@ function AttachmentList({
                   index={index}
                   isUploading={isUploading}
                   onDelete={onDelete}
+                  uploadProgress={progress}
                 />
               );
             })}
           </SortableContext>
         </DndContext>
 
-        {attachments.length < 9 && (
+        {canAddMore && (
           <FileSelector
             id={roteId || 'rote-editor-file-selector'}
             disabled={disabled}
             callback={onFileAdd}
+            accept={accept}
           />
         )}
       </div>

--- a/web/src/components/editor/RoteEditor.tsx
+++ b/web/src/components/editor/RoteEditor.tsx
@@ -12,8 +12,19 @@ import {
 } from '@/utils/directUpload';
 // 压缩与并发工具
 import { useSiteStatus } from '@/hooks/useSiteStatus';
+import { useAuthState } from '@/state/profile';
 
-import { maybeCompressToWebp, qualityForSize, runConcurrency } from '@/utils/uploadHelpers';
+import { getAttachmentMediaKind } from '@/utils/directUpload';
+import {
+  DEFAULT_MAX_VIDEO_UPLOAD_SIZE_MB,
+  IMAGE_ACCEPT,
+  VIDEO_ACCEPT,
+  isImageFile,
+  isVideoFile,
+  maybeCompressToWebp,
+  qualityForSize,
+  runConcurrency,
+} from '@/utils/uploadHelpers';
 import { useAtom, type PrimitiveAtom } from 'jotai';
 import debounce from 'lodash/debounce';
 import { Archive, BookOpen, Globe2, Globe2Icon, PinIcon, Send, X } from 'lucide-react';
@@ -37,14 +48,35 @@ function RoteEditor({ roteAtom, callback }: { roteAtom: RoteAtomType; callback?:
 
   const [submiting, setSubmitting] = useState(false);
   const [uploadingFiles, setUploadingFiles] = useState<Set<File>>(new Set());
+  const [uploadProgress, setUploadProgress] = useState<Map<File, number>>(new Map());
   const [rote, setRote] = useAtom(roteAtom);
   const { data: siteStatus } = useSiteStatus();
+  const { profile } = useAuthState();
   const roteMaxLetter = siteStatus?.frontendConfig?.roteMaxLetter;
   const canUpload =
     !!siteStatus?.storage?.r2Configured && siteStatus?.ui?.allowUploadFile !== false;
+  const canAlwaysUploadVideo = profile?.role === 'admin' || profile?.role === 'super_admin';
+  const canUploadVideo =
+    canUpload && (canAlwaysUploadVideo || siteStatus?.ui?.allowUserVideoUpload === true);
+  const maxVideoUploadSizeMB =
+    siteStatus?.ui?.maxVideoUploadSizeMB || DEFAULT_MAX_VIDEO_UPLOAD_SIZE_MB;
+  const maxVideoUploadSizeBytes = maxVideoUploadSizeMB * 1024 * 1024;
 
   const [localContent, setLocalContent] = useState(rote.content);
   const [articleSelectionOpen, setArticleSelectionOpen] = useState(false);
+
+  const attachmentMediaKinds = useMemo(
+    () => rote.attachments.map((attachment) => getAttachmentMediaKind(attachment)).filter(Boolean),
+    [rote.attachments]
+  );
+  const hasVideoAttachment = attachmentMediaKinds.includes('video');
+  const imageAttachmentCount = attachmentMediaKinds.filter((kind) => kind === 'image').length;
+  const canAddMoreAttachments = !hasVideoAttachment && imageAttachmentCount < 9;
+  const uploadAccept = hasVideoAttachment
+    ? VIDEO_ACCEPT
+    : canUploadVideo
+      ? `${IMAGE_ACCEPT},${VIDEO_ACCEPT}`
+      : IMAGE_ACCEPT;
 
   // 选中的文章 ID（一对一，只能有一个）
 
@@ -74,9 +106,7 @@ function RoteEditor({ roteAtom, callback }: { roteAtom: RoteAtomType; callback?:
     setRote(emptyRote);
     setLocalContent('');
     setUploadingFiles(new Set());
-    setRote(emptyRote);
-    setLocalContent('');
-    setUploadingFiles(new Set());
+    setUploadProgress(new Map());
   }, [setRote]);
 
   useEffect(() => {
@@ -137,6 +167,14 @@ function RoteEditor({ roteAtom, callback }: { roteAtom: RoteAtomType; callback?:
         attachments: prevRote.attachments.filter((_, index) => index !== indexToRemove),
       }));
 
+      if (item instanceof File) {
+        setUploadProgress((prev) => {
+          const next = new Map(prev);
+          next.delete(item);
+          return next;
+        });
+      }
+
       // 异步静默请求后端删除（仅对已上传的附件）
       if (!(item instanceof File)) {
         void del(`/attachments/${item.id}`).catch(() => {});
@@ -148,10 +186,58 @@ function RoteEditor({ roteAtom, callback }: { roteAtom: RoteAtomType; callback?:
   const uploadFiles = useCallback(
     async (files: File[]) => {
       if (!files?.length) return;
+
+      const fileKinds = files.map((file) => {
+        if (isImageFile(file)) return 'image';
+        if (isVideoFile(file)) return 'video';
+        return null;
+      });
+      const hasUnsupportedFile = fileKinds.some((kind) => kind === null);
+      const hasImageSelection = fileKinds.includes('image');
+      const hasVideoSelection = fileKinds.includes('video');
+
+      if (hasUnsupportedFile) {
+        toast.error(t('unsupportedFileType'));
+        return;
+      }
+      if (hasImageSelection && hasVideoSelection) {
+        toast.error(t('mixedMediaNotAllowed'));
+        return;
+      }
+      if (hasVideoSelection && !canUploadVideo) {
+        toast.error(t('videoUploadDisabled'));
+        return;
+      }
+      if (hasVideoSelection && imageAttachmentCount > 0) {
+        toast.error(t('mixedMediaNotAllowed'));
+        return;
+      }
+      if (hasImageSelection && hasVideoAttachment) {
+        toast.error(t('mixedMediaNotAllowed'));
+        return;
+      }
+      if (hasVideoSelection && (files.length > 1 || hasVideoAttachment)) {
+        toast.error(t('singleVideoOnly'));
+        return;
+      }
+      if (hasImageSelection && imageAttachmentCount + files.length > 9) {
+        toast.error(t('imageLimitExceeded', { count: 9 }));
+        return;
+      }
+      if (hasVideoSelection && files.some((file) => file.size > maxVideoUploadSizeBytes)) {
+        toast.error(t('videoTooLarge', { size: maxVideoUploadSizeMB }));
+        return;
+      }
+
       setRote((prev) => ({ ...prev, attachments: [...prev.attachments, ...files] }));
       setUploadingFiles((prev) => {
         const next = new Set(prev);
         files.forEach((f) => next.add(f));
+        return next;
+      });
+      setUploadProgress((prev) => {
+        const next = new Map(prev);
+        files.forEach((f) => next.set(f, 0));
         return next;
       });
 
@@ -191,11 +277,17 @@ function RoteEditor({ roteAtom, callback }: { roteAtom: RoteAtomType; callback?:
             });
 
             // 原图上传（必须成功）
-            await uploadToSignedUrl(item.original.putUrl, file);
+            await uploadToSignedUrl(item.original.putUrl, file, (progress) => {
+              setUploadProgress((prev) => {
+                const next = new Map(prev);
+                next.set(file, progress);
+                return next;
+              });
+            });
 
             // 压缩图上传（可选，失败不影响原图）
             let compressedKey: string | undefined;
-            if (compressedBlob) {
+            if (compressedBlob && item.compressed) {
               try {
                 await uploadToSignedUrl(item.compressed.putUrl, compressedBlob);
                 // 只有上传成功才记录 compressedKey
@@ -280,9 +372,23 @@ function RoteEditor({ roteAtom, callback }: { roteAtom: RoteAtomType; callback?:
           files.forEach((f) => next.delete(f));
           return next;
         });
+        setUploadProgress((prev) => {
+          const next = new Map(prev);
+          files.forEach((f) => next.delete(f));
+          return next;
+        });
       }
     },
-    [rote.id, setRote, t]
+    [
+      canUploadVideo,
+      hasVideoAttachment,
+      imageAttachmentCount,
+      maxVideoUploadSizeBytes,
+      maxVideoUploadSizeMB,
+      rote.id,
+      setRote,
+      t,
+    ]
   );
 
   const submit = useCallback(() => {
@@ -408,10 +514,7 @@ function RoteEditor({ roteAtom, callback }: { roteAtom: RoteAtomType; callback?:
       const files = e.dataTransfer.files;
 
       if (files.length > 0) {
-        const imageFiles = Array.from(files).filter((file) => file.type.startsWith('image/'));
-        if (imageFiles.length > 0) {
-          uploadFiles(imageFiles);
-        }
+        uploadFiles(Array.from(files));
       }
     },
     [uploadFiles]
@@ -500,11 +603,14 @@ function RoteEditor({ roteAtom, callback }: { roteAtom: RoteAtomType; callback?:
         <AttachmentList
           attachments={rote.attachments}
           uploadingFiles={uploadingFiles}
+          uploadProgress={uploadProgress}
           onDelete={deleteFile}
           onReorder={handleAttachmentReorder}
           onFileAdd={handleFileAdd}
           roteId={rote.id}
           disabled={submiting}
+          accept={uploadAccept}
+          canAddMore={canAddMoreAttachments}
         />
       )}
 

--- a/web/src/components/others/uploader.tsx
+++ b/web/src/components/others/uploader.tsx
@@ -5,9 +5,15 @@ interface FileSelectorProps {
   callback: (_files: File[]) => void;
   id: string;
   disabled?: boolean;
+  accept?: string;
 }
 
-export default function FileSelector({ callback, id, disabled }: FileSelectorProps) {
+export default function FileSelector({
+  callback,
+  id,
+  disabled,
+  accept = 'image/*',
+}: FileSelectorProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   return (
     <div>
@@ -25,13 +31,14 @@ export default function FileSelector({ callback, id, disabled }: FileSelectorPro
         type="file"
         id={`file-${id}`}
         multiple
-        accept="image/*"
+        accept={accept}
         disabled={disabled}
-        onInput={() => {
+        onInput={(e) => {
           if (fileInputRef.current?.files) {
             const files = Array.from(fileInputRef.current.files);
             callback(files);
           }
+          e.currentTarget.value = '';
         }}
         title="Attachments Uploader"
       />

--- a/web/src/components/rote/AttachmentsGrid.tsx
+++ b/web/src/components/rote/AttachmentsGrid.tsx
@@ -1,4 +1,5 @@
 import type { Attachment } from '@/types/main';
+import { getAttachmentMediaKind } from '@/utils/directUpload';
 import { PhotoProvider, PhotoView } from 'react-photo-view';
 import 'react-photo-view/dist/react-photo-view.css';
 
@@ -12,13 +13,28 @@ interface AttachmentsGridProps {
  * 支持1-9张图片的自适应布局
  */
 export default function AttachmentsGrid({ attachments, withTimeStamp }: AttachmentsGridProps) {
+  const sortedAttachments = [...attachments].sort((a, b) => (a.sortIndex > b.sortIndex ? 1 : -1));
+  const hasVideo = sortedAttachments.some(
+    (attachment) => getAttachmentMediaKind(attachment) === 'video'
+  );
+
   return (
     attachments.length > 0 && (
       <div className="my-2 flex w-fit flex-wrap gap-1 overflow-hidden rounded-2xl">
-        <PhotoProvider>
-          {attachments
-            .sort((a, b) => (a.sortIndex > b.sortIndex ? 1 : -1))
-            .map((file: any, index: any) => (
+        {hasVideo ? (
+          sortedAttachments.map((file, index) => (
+            <video
+              key={`files_${index}`}
+              className="bg-foreground/3 w-full max-w-[500px] rounded-2xl border-[0.5px]"
+              src={file.url}
+              controls
+              playsInline
+              preload="metadata"
+            />
+          ))
+        ) : (
+          <PhotoProvider>
+            {sortedAttachments.map((file, index) => (
               <PhotoView key={`files_${index}`} src={file.url}>
                 <img
                   className={`${
@@ -36,7 +52,8 @@ export default function AttachmentsGrid({ attachments, withTimeStamp }: Attachme
                 />
               </PhotoView>
             ))}
-        </PhotoProvider>
+          </PhotoProvider>
+        )}
       </div>
     )
   );

--- a/web/src/components/setup/SetupWizard.tsx
+++ b/web/src/components/setup/SetupWizard.tsx
@@ -259,6 +259,8 @@ export default function SetupWizard() {
           defaultUserRole: 'user',
           apiRateLimit: 100,
           allowUploadFile: true,
+          allowUserVideoUpload: false,
+          maxVideoUploadSizeMB: 300,
         },
         admin: {
           username: config.admin.username,

--- a/web/src/hooks/useSiteStatus.ts
+++ b/web/src/hooks/useSiteStatus.ts
@@ -45,6 +45,8 @@ interface SiteStatusData {
   ui: {
     allowRegistration: boolean;
     allowUploadFile: boolean;
+    allowUserVideoUpload: boolean;
+    maxVideoUploadSizeMB: number;
   };
   oauth?: {
     enabled: boolean;

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -4,7 +4,11 @@
       "poem": "",
       "headingBefore": "A note repository like",
       "headingAfter": " 🤔",
-      "linksItems": ["Login", "", "GitHub"],
+      "linksItems": [
+        "Login",
+        "",
+        "GitHub"
+      ],
       "dashboard": "Dashboard",
       "star": "Stars",
       "fork": "Forks",
@@ -625,7 +629,11 @@
           "moderator": "Moderator"
         },
         "apiRateLimit": "API Rate Limit",
-        "apiRateLimitDescription": "Maximum number of requests per second allowed per user or IP address. Used to prevent API abuse. Minimum is 10, default is 100 requests/second."
+        "apiRateLimitDescription": "Maximum number of requests per second allowed per user or IP address. Used to prevent API abuse. Minimum is 10, default is 100 requests/second.",
+        "allowUserVideoUpload": "Allow Video Upload for Regular Users",
+        "allowUserVideoUploadDesc": "Video upload is an advanced feature. Administrators can always use it; this switch controls whether regular users can upload videos.",
+        "maxVideoUploadSizeMB": "Video Size Limit (MB)",
+        "maxVideoUploadSizeMBDesc": "Maximum upload size per video. Minimum 1MB, default 300MB."
       },
       "security": {
         "title": "Security Configuration",
@@ -810,7 +818,13 @@
       },
       "error": {
         "emptyContent": "Content cannot be empty"
-      }
+      },
+      "videoUploadDisabled": "Video upload is not enabled for regular users on this site",
+      "mixedMediaNotAllowed": "Images and videos cannot be uploaded together",
+      "singleVideoOnly": "Only one video can be uploaded per Rote",
+      "imageLimitExceeded": "You can upload up to {{count}} images",
+      "unsupportedFileType": "Unsupported file type included",
+      "videoTooLarge": "Video must be {{size}}MB or smaller"
     },
     "roteItem": {
       "details": "Details",

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -4,7 +4,11 @@
       "poem": "",
       "headingBefore": "",
       "headingAfter": " のようなノートリポジトリ 🤔",
-      "linksItems": ["ログイン", "", "GitHub"],
+      "linksItems": [
+        "ログイン",
+        "",
+        "GitHub"
+      ],
       "dashboard": "ダッシュボード",
       "star": "スター",
       "fork": "フォーク",
@@ -625,7 +629,11 @@
           "moderator": "モデレーター"
         },
         "apiRateLimit": "API レート制限",
-        "apiRateLimitDescription": "ユーザーまたはIPアドレスごとに許可される1秒あたりの最大リクエスト数。APIの悪用を防ぐために使用されます。最小値は10、デフォルトは100リクエスト/秒です。"
+        "apiRateLimitDescription": "ユーザーまたはIPアドレスごとに許可される1秒あたりの最大リクエスト数。APIの悪用を防ぐために使用されます。最小値は10、デフォルトは100リクエスト/秒です。",
+        "allowUserVideoUpload": "一般ユーザーに動画アップロードを許可",
+        "allowUserVideoUploadDesc": "動画アップロードは高度な機能です。管理者は常に利用でき、このスイッチは一般ユーザーの利用可否を制御します。",
+        "maxVideoUploadSizeMB": "動画サイズ上限（MB）",
+        "maxVideoUploadSizeMBDesc": "動画1件あたりの最大アップロードサイズ。最小1MB、既定値は300MBです。"
       },
       "security": {
         "title": "セキュリティ設定",
@@ -810,7 +818,13 @@
       },
       "error": {
         "emptyContent": "コンテンツは空にできません"
-      }
+      },
+      "videoUploadDisabled": "このサイトでは一般ユーザーの動画アップロードが無効です",
+      "mixedMediaNotAllowed": "画像と動画は同時にアップロードできません",
+      "singleVideoOnly": "1つの Rote には動画を 1 本だけアップロードできます",
+      "imageLimitExceeded": "{{count}} 枚まで画像をアップロードできます",
+      "unsupportedFileType": "未対応のファイル形式が含まれています",
+      "videoTooLarge": "動画サイズは {{size}}MB 以下にしてください"
     },
     "roteItem": {
       "details": "詳細",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -4,7 +4,11 @@
       "poem": "采菊东篱下，悠然见南山",
       "headingBefore": "一个看起来不太一样的",
       "headingAfter": " 🤔",
-      "linksItems": ["登录", "", "GitHub"],
+      "linksItems": [
+        "登录",
+        "",
+        "GitHub"
+      ],
       "dashboard": "仪表盘",
       "star": "Stars",
       "fork": "Forks",
@@ -48,7 +52,13 @@
         "error": "检测到后端错误，正在跳转到设置页面",
         "notInitialized": "系统未初始化，正在跳转到设置页面"
       },
-      "typewriterTexts": ["个人笔记库", "碎碎念本子", "私人朋友圈", "个人频道", "微型博客"],
+      "typewriterTexts": [
+        "个人笔记库",
+        "碎碎念本子",
+        "私人朋友圈",
+        "个人频道",
+        "微型博客"
+      ],
       "subtitle": "开放API，记录的姿势不止一种🤩，支持Self-Hosted，对自己的数据掌握主动权，来去自由，没有数据绑架🙅🏻",
       "iosAppTooltip": {
         "title": "想要加入 iOS 测试版吗？",
@@ -619,7 +629,11 @@
           "moderator": "版主"
         },
         "apiRateLimit": "API 速率限制",
-        "apiRateLimitDescription": "每个用户或 IP 地址每秒允许的最大请求数。用于防止 API 滥用。最小值为 10，默认值为 100 请求/秒。"
+        "apiRateLimitDescription": "每个用户或 IP 地址每秒允许的最大请求数。用于防止 API 滥用。最小值为 10，默认值为 100 请求/秒。",
+        "allowUserVideoUpload": "向普通用户开放视频上传",
+        "allowUserVideoUploadDesc": "视频上传属于高级功能。管理员始终可用，此开关决定普通用户是否可以上传视频。",
+        "maxVideoUploadSizeMB": "视频大小上限（MB）",
+        "maxVideoUploadSizeMBDesc": "单个视频允许上传的最大大小，最小值为 1MB，默认值为 300MB。"
       },
       "security": {
         "title": "安全配置",
@@ -804,7 +818,13 @@
       },
       "error": {
         "emptyContent": "内容不能为空"
-      }
+      },
+      "videoUploadDisabled": "当前站点未向普通用户开放视频上传",
+      "mixedMediaNotAllowed": "图片和视频不能同时上传",
+      "singleVideoOnly": "一个动态最多只能上传 1 个视频",
+      "imageLimitExceeded": "最多只能上传 {{count}} 张图片",
+      "unsupportedFileType": "包含不支持的文件类型",
+      "videoTooLarge": "视频大小不能超过 {{size}}MB"
     },
     "roteItem": {
       "details": "详情",

--- a/web/src/pages/admin/components/UIConfigTab.tsx
+++ b/web/src/pages/admin/components/UIConfigTab.tsx
@@ -53,6 +53,15 @@ export default function UIConfigTab({
       toast.error(t('saveFailed', { error: 'API rate limit must be a number and at least 10' }));
       return;
     }
+    if (
+      uiConfig.maxVideoUploadSizeMB !== undefined &&
+      (typeof uiConfig.maxVideoUploadSizeMB !== 'number' || uiConfig.maxVideoUploadSizeMB < 1)
+    ) {
+      toast.error(
+        t('saveFailed', { error: 'Video upload size limit must be a number and at least 1 MB' })
+      );
+      return;
+    }
     // 验证 defaultUserRole 必须是有效角色
     if (uiConfig.defaultUserRole && !['user', 'moderator'].includes(uiConfig.defaultUserRole)) {
       toast.error(
@@ -128,6 +137,19 @@ export default function UIConfigTab({
 
         <div className="flex items-center justify-between">
           <div className="space-y-0.5">
+            <Label>{t('ui.allowUserVideoUpload')}</Label>
+            <p className="text-muted-foreground text-sm">{t('ui.allowUserVideoUploadDesc')}</p>
+          </div>
+          <Switch
+            checked={uiConfig?.allowUserVideoUpload ?? false}
+            onCheckedChange={(checked) =>
+              setUiConfig({ ...(uiConfig || {}), allowUserVideoUpload: checked })
+            }
+          />
+        </div>
+
+        <div className="flex items-center justify-between">
+          <div className="space-y-0.5">
             <Label>{t('security.requireVerifiedEmailForExplore')}</Label>
             <p className="text-muted-foreground text-sm">
               {t('security.requireVerifiedEmailForExploreDesc')}
@@ -182,6 +204,27 @@ export default function UIConfigTab({
             }}
           />
           <p className="text-muted-foreground text-xs">{t('ui.apiRateLimitDescription')}</p>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="maxVideoUploadSizeMB">{t('ui.maxVideoUploadSizeMB')}</Label>
+          <Input
+            id="maxVideoUploadSizeMB"
+            type="number"
+            min="1"
+            value={uiConfig?.maxVideoUploadSizeMB || 300}
+            onChange={(e) => {
+              const value = parseInt(e.target.value);
+              if (!isNaN(value) && value >= 1) {
+                setUiConfig({ ...(uiConfig || {}), maxVideoUploadSizeMB: value });
+              } else if (!isNaN(value) && value < 1) {
+                setUiConfig({ ...(uiConfig || {}), maxVideoUploadSizeMB: 1 });
+              } else if (e.target.value === '') {
+                setUiConfig({ ...(uiConfig || {}), maxVideoUploadSizeMB: undefined as any });
+              }
+            }}
+          />
+          <p className="text-muted-foreground text-xs">{t('ui.maxVideoUploadSizeMBDesc')}</p>
         </div>
 
         <Button onClick={handleSave} disabled={isSaving} className="w-full">

--- a/web/src/pages/admin/index.tsx
+++ b/web/src/pages/admin/index.tsx
@@ -62,8 +62,10 @@ export default function AdminDashboard() {
         configs.ui || {
           allowRegistration: true,
           allowUploadFile: true,
+          allowUserVideoUpload: false,
           defaultUserRole: 'user',
           apiRateLimit: 100,
+          maxVideoUploadSizeMB: 300,
         }
       );
       setSecurityConfig(

--- a/web/src/pages/admin/types.ts
+++ b/web/src/pages/admin/types.ts
@@ -34,5 +34,7 @@ export interface SystemConfig {
     defaultUserRole?: string;
     apiRateLimit?: number;
     allowUploadFile?: boolean;
+    allowUserVideoUpload?: boolean;
+    maxVideoUploadSizeMB?: number;
   };
 }

--- a/web/src/pages/profile/utils/avatarUpload.ts
+++ b/web/src/pages/profile/utils/avatarUpload.ts
@@ -85,7 +85,7 @@ export async function uploadAvatar(
 
   // 上传压缩图（可选，失败不影响原图）
   let compressedKey: string | undefined;
-  if (compressedBlob) {
+  if (compressedBlob && item.compressed) {
     try {
       await uploadToSignedUrl(item.compressed.putUrl, compressedBlob);
       // 只有上传成功才记录 compressedKey
@@ -144,7 +144,7 @@ export async function uploadCover(file: File): Promise<string> {
 
   // 上传压缩图（可选，失败不影响原图）
   let compressedKey: string | undefined;
-  if (compressedBlob) {
+  if (compressedBlob && item.compressed) {
     try {
       await uploadToSignedUrl(item.compressed.putUrl, compressedBlob);
       // 只有上传成功才记录 compressedKey

--- a/web/src/types/main.ts
+++ b/web/src/types/main.ts
@@ -66,25 +66,29 @@ export type Attachment = {
   sortIndex: number;
   storage: string;
   details: {
-    fieldname: string;
-    originalname: string;
-    encoding: string;
-    mimetype: string;
-    size: number;
-    bucket: string;
-    key: string;
-    acl: string;
-    contentType: string;
-    contentDisposition: string | null;
-    contentEncoding: string | null;
-    storageClass: string;
-    serverSideEncryption: string | null;
-    metadata: {
-      fieldName: string;
+    fieldname?: string;
+    originalname?: string;
+    encoding?: string;
+    mimetype?: string | null;
+    mediaKind?: 'image' | 'video';
+    size?: number;
+    bucket?: string;
+    key?: string;
+    compressKey?: string;
+    acl?: string;
+    contentType?: string;
+    contentDisposition?: string | null;
+    contentEncoding?: string | null;
+    storageClass?: string;
+    serverSideEncryption?: string | null;
+    metadata?: {
+      fieldName?: string;
     };
-    location: string;
-    etag: string;
-    versionId: string;
+    location?: string;
+    etag?: string;
+    versionId?: string;
+    mtime?: string;
+    hash?: string;
   };
   createdAt: string;
   updatedAt: string;

--- a/web/src/utils/directUpload.ts
+++ b/web/src/utils/directUpload.ts
@@ -1,12 +1,14 @@
-import axios from 'axios';
+import type { Attachment } from '@/types/main';
+import axios, { type AxiosProgressEvent } from 'axios';
 import { post } from './api';
 
 export type PresignFile = { filename?: string; contentType?: string; size?: number };
+export type MediaKind = 'image' | 'video';
 
 export type PresignItem = {
   uuid: string;
   original: { key: string; putUrl: string; url: string; contentType?: string };
-  compressed: { key: string; putUrl: string; url: string; contentType: 'image/webp' };
+  compressed?: { key: string; putUrl: string; url: string; contentType: 'image/webp' };
 };
 
 export interface PresignResponse {
@@ -23,7 +25,13 @@ export async function presign(files: PresignFile[]) {
   return res.data.items as PresignItem[];
 }
 
-export async function uploadToSignedUrl(putUrl: string, blob: Blob) {
+export type UploadProgressCallback = (_progress: number) => void;
+
+export async function uploadToSignedUrl(
+  putUrl: string,
+  blob: Blob,
+  onProgress?: UploadProgressCallback
+) {
   if (!(blob instanceof Blob) || blob.size === 0) {
     throw new Error('Empty upload payload');
   }
@@ -37,6 +45,16 @@ export async function uploadToSignedUrl(putUrl: string, blob: Blob) {
       transformRequest: [(data) => data as Blob],
       transitional: { clarifyTimeoutError: true },
       validateStatus: () => true,
+      onUploadProgress: (progressEvent: AxiosProgressEvent) => {
+        if (!onProgress) return;
+        const total = progressEvent.total ?? blob.size;
+        if (!total) return;
+        const progress = Math.min(
+          100,
+          Math.max(0, Math.round((progressEvent.loaded / total) * 100))
+        );
+        onProgress(progress);
+      },
     });
   } catch (err: any) {
     // axios throws on network-level failures (CORS blocked, DNS, offline, etc.)
@@ -58,6 +76,8 @@ export async function uploadToSignedUrl(putUrl: string, blob: Blob) {
     const bodyText = typeof resp.data === 'string' ? resp.data : JSON.stringify(resp.data || {});
     throw new Error(`Upload failed: HTTP ${resp.status} ${reqId} ${bodyText}`.trim());
   }
+
+  onProgress?.(100);
 }
 
 /**
@@ -116,4 +136,16 @@ export async function finalize(attachments: FinalizeAttachment[], noteId?: strin
   const res = (await post('/attachments/finalize', { attachments, noteId })) as Record<string, any>;
   if (res.code !== 0) throw new Error(res.message || 'finalize failed');
   return (res.data as any[]) || [];
+}
+
+export function getAttachmentMediaKind(attachment: File | Attachment): MediaKind | null {
+  const mimetype = attachment instanceof File ? attachment.type : attachment.details?.mimetype;
+  const mediaKind = attachment instanceof File ? undefined : attachment.details?.mediaKind;
+
+  if (mediaKind === 'image' || mediaKind === 'video') {
+    return mediaKind;
+  }
+  if (mimetype?.startsWith('image/')) return 'image';
+  if (mimetype?.startsWith('video/')) return 'video';
+  return null;
 }

--- a/web/src/utils/uploadHelpers.ts
+++ b/web/src/utils/uploadHelpers.ts
@@ -1,7 +1,14 @@
 import imageCompression from 'browser-image-compression';
 
+export const IMAGE_ACCEPT = 'image/*';
+export const VIDEO_ACCEPT = 'video/mp4,video/webm,video/quicktime';
+export const DEFAULT_MAX_VIDEO_UPLOAD_SIZE_MB = 300;
+
 export const shouldCompress = (f: File) =>
   f.type.startsWith('image/') && !f.type.startsWith('image/gif');
+
+export const isVideoFile = (file: File) => file.type.startsWith('video/');
+export const isImageFile = (file: File) => file.type.startsWith('image/');
 
 // 检查文件是否为 HEIC 格式（不支持）
 export const isHeicFile = (file: File): boolean => {


### PR DESCRIPTION
## Summary
- add video upload support to attachment presign/finalize flows and admin UI settings
- render and validate image/video attachments correctly in the editor and display components
- preserve compatibility for legacy attachments by inferring media kind from stored keys

## Validation
- cd server && bun run lint
- cd server && bun run build
- cd server && bun test ./tests/fileValidation.test.ts
- cd web && bun run lint
- cd web && bun run build