### PR TITLE
feat: support video posters on web and server

### DIFF
--- a/server/drizzle/migrations/0012_video_poster_support.sql
+++ b/server/drizzle/migrations/0012_video_poster_support.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "attachments" ADD COLUMN "posterUrl" text DEFAULT '';

--- a/server/drizzle/migrations/meta/0012_snapshot.json
+++ b/server/drizzle/migrations/meta/0012_snapshot.json
@@ -1,0 +1,1733 @@
+{
+  "id": "e772df06-da0d-42a9-b756-c8e3989e28ee",
+  "prevId": "0e984fdf-66ea-42db-9013-4ff1672dab9f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.articles": {
+      "name": "articles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorId": {
+          "name": "authorId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "articles_authorId_idx": {
+          "name": "articles_authorId_idx",
+          "columns": [
+            {
+              "expression": "authorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "articles_authorId_users_id_fk": {
+          "name": "articles_authorId_users_id_fk",
+          "tableFrom": "articles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "authorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attachments": {
+      "name": "attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compressUrl": {
+          "name": "compressUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "posterUrl": {
+          "name": "posterUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roteid": {
+          "name": "roteid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage": {
+          "name": "storage",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sortIndex": {
+          "name": "sortIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "attachments_userid_idx": {
+          "name": "attachments_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attachments_roteid_idx": {
+          "name": "attachments_roteid_idx",
+          "columns": [
+            {
+              "expression": "roteid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attachments_roteid_sortIndex_idx": {
+          "name": "attachments_roteid_sortIndex_idx",
+          "columns": [
+            {
+              "expression": "roteid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sortIndex",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attachments_userid_users_id_fk": {
+          "name": "attachments_userid_users_id_fk",
+          "tableFrom": "attachments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "attachments_roteid_rotes_id_fk": {
+          "name": "attachments_roteid_rotes_id_fk",
+          "tableFrom": "attachments",
+          "tableTo": "rotes",
+          "columnsFrom": [
+            "roteid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.open_key_usage_logs": {
+      "name": "open_key_usage_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "openKeyId": {
+          "name": "openKeyId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientIp": {
+          "name": "clientIp",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statusCode": {
+          "name": "statusCode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responseTime": {
+          "name": "responseTime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "open_key_usage_logs_openKeyId_idx": {
+          "name": "open_key_usage_logs_openKeyId_idx",
+          "columns": [
+            {
+              "expression": "openKeyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "open_key_usage_logs_createdAt_idx": {
+          "name": "open_key_usage_logs_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "open_key_usage_logs_openKeyId_user_open_keys_id_fk": {
+          "name": "open_key_usage_logs_openKeyId_user_open_keys_id_fk",
+          "tableFrom": "open_key_usage_logs",
+          "tableTo": "user_open_keys",
+          "columnsFrom": [
+            "openKeyId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reactions": {
+      "name": "reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visitorId": {
+          "name": "visitorId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visitorInfo": {
+          "name": "visitorInfo",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roteid": {
+          "name": "roteid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reactions_roteid_type_idx": {
+          "name": "reactions_roteid_type_idx",
+          "columns": [
+            {
+              "expression": "roteid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reactions_userid_idx": {
+          "name": "reactions_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reactions_visitorId_idx": {
+          "name": "reactions_visitorId_idx",
+          "columns": [
+            {
+              "expression": "visitorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reactions_roteid_rotes_id_fk": {
+          "name": "reactions_roteid_rotes_id_fk",
+          "tableFrom": "reactions",
+          "tableTo": "rotes",
+          "columnsFrom": [
+            "roteid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "reactions_userid_users_id_fk": {
+          "name": "reactions_userid_users_id_fk",
+          "tableFrom": "reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_reaction": {
+          "name": "unique_reaction",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userid",
+            "visitorId",
+            "roteid",
+            "type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rote_changes": {
+      "name": "rote_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "originid": {
+          "name": "originid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roteid": {
+          "name": "roteid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CREATE'"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rote_changes_originid_createdAt_idx": {
+          "name": "rote_changes_originid_createdAt_idx",
+          "columns": [
+            {
+              "expression": "originid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rote_changes_originid_action_idx": {
+          "name": "rote_changes_originid_action_idx",
+          "columns": [
+            {
+              "expression": "originid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rote_changes_roteid_createdAt_idx": {
+          "name": "rote_changes_roteid_createdAt_idx",
+          "columns": [
+            {
+              "expression": "roteid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rote_changes_userid_idx": {
+          "name": "rote_changes_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rote_changes_roteid_action_idx": {
+          "name": "rote_changes_roteid_action_idx",
+          "columns": [
+            {
+              "expression": "roteid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rote_changes_roteid_rotes_id_fk": {
+          "name": "rote_changes_roteid_rotes_id_fk",
+          "tableFrom": "rote_changes",
+          "tableTo": "rotes",
+          "columnsFrom": [
+            "roteid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rote_link_previews": {
+      "name": "rote_link_previews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "roteid": {
+          "name": "roteid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "siteName": {
+          "name": "siteName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentExcerpt": {
+          "name": "contentExcerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rote_link_previews_roteid_idx": {
+          "name": "rote_link_previews_roteid_idx",
+          "columns": [
+            {
+              "expression": "roteid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rote_link_previews_roteid_rotes_id_fk": {
+          "name": "rote_link_previews_roteid_rotes_id_fk",
+          "tableFrom": "rote_link_previews",
+          "tableTo": "rotes",
+          "columnsFrom": [
+            "roteid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "rote_link_previews_roteid_url_unique": {
+          "name": "rote_link_previews_roteid_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "roteid",
+            "url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rotes": {
+      "name": "rotes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Rote'"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "authorid": {
+          "name": "authorid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "articleId": {
+          "name": "articleId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pin": {
+          "name": "pin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "editor": {
+          "name": "editor",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'normal'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rotes_authorid_state_idx": {
+          "name": "rotes_authorid_state_idx",
+          "columns": [
+            {
+              "expression": "authorid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rotes_authorid_archived_idx": {
+          "name": "rotes_authorid_archived_idx",
+          "columns": [
+            {
+              "expression": "authorid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rotes_authorid_created_at_idx": {
+          "name": "rotes_authorid_created_at_idx",
+          "columns": [
+            {
+              "expression": "authorid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rotes_tags_idx": {
+          "name": "rotes_tags_idx",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "rotes_articleId_idx": {
+          "name": "rotes_articleId_idx",
+          "columns": [
+            {
+              "expression": "articleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rotes_authorid_users_id_fk": {
+          "name": "rotes_authorid_users_id_fk",
+          "tableFrom": "rotes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "authorid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "rotes_articleId_articles_id_fk": {
+          "name": "rotes_articleId_articles_id_fk",
+          "tableFrom": "rotes",
+          "tableTo": "articles",
+          "columnsFrom": [
+            "articleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group": {
+          "name": "group",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isRequired": {
+          "name": "isRequired",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isInitialized": {
+          "name": "isInitialized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isSystem": {
+          "name": "isSystem",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "settings_isRequired_idx": {
+          "name": "settings_isRequired_idx",
+          "columns": [
+            {
+              "expression": "isRequired",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "settings_isInitialized_idx": {
+          "name": "settings_isInitialized_idx",
+          "columns": [
+            {
+              "expression": "isInitialized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "settings_isSystem_idx": {
+          "name": "settings_isSystem_idx",
+          "columns": [
+            {
+              "expression": "isSystem",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "settings_group_unique": {
+          "name": "settings_group_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_oauth_bindings": {
+      "name": "user_oauth_bindings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerUsername": {
+          "name": "providerUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_oauth_bindings_userid_idx": {
+          "name": "user_oauth_bindings_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_oauth_bindings_provider_idx": {
+          "name": "user_oauth_bindings_provider_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_oauth_bindings_providerId_idx": {
+          "name": "user_oauth_bindings_providerId_idx",
+          "columns": [
+            {
+              "expression": "providerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_oauth_bindings_userid_users_id_fk": {
+          "name": "user_oauth_bindings_userid_users_id_fk",
+          "tableFrom": "user_oauth_bindings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_provider": {
+          "name": "unique_user_provider",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userid",
+            "provider"
+          ]
+        },
+        "unique_provider_id": {
+          "name": "unique_provider_id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider",
+            "providerId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_open_keys": {
+      "name": "user_open_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"SENDROTE\"}'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_open_keys_userid_idx": {
+          "name": "user_open_keys_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_open_keys_userid_users_id_fk": {
+          "name": "user_open_keys_userid_users_id_fk",
+          "tableFrom": "user_open_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "darkmode": {
+          "name": "darkmode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "allowExplore": {
+          "name": "allowExplore",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_settings_userid_idx": {
+          "name": "user_settings_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_settings_userid_users_id_fk": {
+          "name": "user_settings_userid_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_settings_userid_unique": {
+          "name": "user_settings_userid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_sw_subscriptions": {
+      "name": "user_sw_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "expirationTime": {
+          "name": "expirationTime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keys": {
+          "name": "keys",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_sw_subscriptions_userid_idx": {
+          "name": "user_sw_subscriptions_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_sw_subscriptions_endpoint_idx": {
+          "name": "user_sw_subscriptions_endpoint_idx",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_sw_subscriptions_userid_users_id_fk": {
+          "name": "user_sw_subscriptions_userid_users_id_fk",
+          "tableFrom": "user_sw_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_sw_subscriptions_endpoint_unique": {
+          "name": "user_sw_subscriptions_endpoint_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "endpoint"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "passwordhash": {
+          "name": "passwordhash",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salt": {
+          "name": "salt",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover": {
+          "name": "cover",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_username_idx": {
+          "name": "users_username_idx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/drizzle/migrations/meta/_journal.json
+++ b/server/drizzle/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1770032753350,
       "tag": "0011_dusty_firelord",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1774848020569,
+      "tag": "0012_video_poster_support",
+      "breakpoints": true
     }
   ]
 }

--- a/server/drizzle/schema.ts
+++ b/server/drizzle/schema.ts
@@ -215,6 +215,7 @@ export const attachments = pgTable(
     id: uuid('id').primaryKey().defaultRandom(),
     url: text('url').notNull(),
     compressUrl: text('compressUrl').default(''),
+    posterUrl: text('posterUrl').default(''),
     userid: uuid('userid'),
     roteid: uuid('roteid'),
     storage: varchar('storage', { length: 100 }).notNull(),

--- a/server/route/v2/attachment.ts
+++ b/server/route/v2/attachment.ts
@@ -67,6 +67,13 @@ const getExt = (filename?: string, contentType?: string) => {
   return map[contentType] || '';
 };
 
+const extractOriginalUploadUuid = (key?: string) =>
+  key?.match(/\/uploads\/([^/.]+)(\.[^.]+)?$/)?.[1] ?? null;
+
+const extractCompressedUuid = (key?: string) => key?.match(/\/compressed\/([^/.]+)\.webp$/)?.[1] ?? null;
+
+const extractPosterUuid = (key?: string) => key?.match(/\/posters\/([^/.]+)\.[^.]+$/)?.[1] ?? null;
+
 // 删除单个附件
 attachmentsRouter.delete('/:id', authenticateJWT, async (c: HonoContext) => {
   const user = c.get('user') as User;
@@ -169,10 +176,15 @@ attachmentsRouter.post(
       );
     }
 
+    const maxVideoUploadSizeMB = getMaxVideoUploadSizeMB(uiConfig);
+
     // 严格验证每个文件的内容类型和大小
     for (const f of files) {
       validateContentType(f.contentType);
-      validateFileSize(f.size, f.contentType, getMaxVideoUploadSizeMB(uiConfig));
+      if (isVideoContentType(f.contentType) && canAlwaysUploadVideo(user.role)) {
+        continue;
+      }
+      validateFileSize(f.size, f.contentType, maxVideoUploadSizeMB);
     }
 
     const results = await Promise.all(
@@ -204,6 +216,17 @@ attachmentsRouter.post(
           };
         }
 
+        if (mediaKind === 'video') {
+          const posterKey = `users/${user.id}/posters/${uuid}.jpg`;
+          const poster = await presignPutUrl(posterKey, 'image/jpeg', 15 * 60);
+          result.poster = {
+            key: posterKey,
+            putUrl: poster.putUrl,
+            url: poster.url,
+            contentType: 'image/jpeg',
+          };
+        }
+
         return result;
       })
     );
@@ -226,6 +249,7 @@ attachmentsRouter.post(
         uuid: string;
         originalKey: string;
         compressedKey?: string;
+        posterKey?: string;
         size?: number;
         mimetype?: string;
         hash?: string;
@@ -248,17 +272,23 @@ attachmentsRouter.post(
     const invalid = attachments.find(
       (a) =>
         !a.originalKey?.startsWith(prefix) ||
-        (a.compressedKey !== undefined && !a.compressedKey.startsWith(prefix))
+        (a.compressedKey !== undefined && !a.compressedKey.startsWith(prefix)) ||
+        (a.posterKey !== undefined && !a.posterKey.startsWith(prefix))
     );
     if (invalid) {
       throw new Error('Invalid object key');
     }
 
+    const maxVideoUploadSizeMB = getMaxVideoUploadSizeMB(uiConfig);
+
     // 验证 mimetype（如果提供）
     for (const a of attachments) {
       if (a.mimetype) {
         validateContentType(a.mimetype);
-        validateFileSize(a.size, a.mimetype, getMaxVideoUploadSizeMB(uiConfig));
+        if (isVideoContentType(a.mimetype) && canAlwaysUploadVideo(user.role)) {
+          continue;
+        }
+        validateFileSize(a.size, a.mimetype, maxVideoUploadSizeMB);
       }
     }
 
@@ -267,6 +297,7 @@ attachmentsRouter.post(
         inferAttachmentMediaKind({
           mimetype: a.mimetype,
           compressedKey: a.compressedKey,
+          posterKey: a.posterKey,
           key: a.originalKey,
         }) === 'video'
     );
@@ -285,8 +316,11 @@ attachmentsRouter.post(
       const mediaKind = inferAttachmentMediaKind({
         mimetype: a.mimetype,
         compressedKey: a.compressedKey,
+        posterKey: a.posterKey,
         key: a.originalKey,
       });
+
+      const normalizedAttachment = { ...a };
 
       // 1. 验证原图文件是否存在
       const originalExists = await checkObjectExists(a.originalKey);
@@ -295,66 +329,90 @@ attachmentsRouter.post(
         continue;
       }
 
-      // 2. 如果提供了 compressedKey，验证压缩图是否存在
-      if (mediaKind === 'video' && a.compressedKey) {
+      const originalUuid = extractOriginalUploadUuid(a.originalKey);
+      if (!originalUuid) {
+        validationErrors.push(
+          `Invalid original key format for uuid validation: originalKey=${a.originalKey}`
+        );
+        continue;
+      }
+
+      if (originalUuid !== a.uuid) {
+        validationErrors.push(
+          `UUID mismatch: request uuid '${a.uuid}' does not match originalKey uuid '${originalUuid}'`
+        );
+        continue;
+      }
+
+      // 2. 视频不接受 compressedKey
+      if (mediaKind === 'video' && normalizedAttachment.compressedKey) {
         validationErrors.push(
           `Videos cannot include compressedKey: ${a.originalKey} (uuid: ${a.uuid})`
         );
         continue;
       }
 
-      if (mediaKind === 'image' && a.compressedKey) {
-        const compressedExists = await checkObjectExists(a.compressedKey);
+      if (mediaKind === 'image' && normalizedAttachment.posterKey) {
+        validationErrors.push(
+          `Images cannot include posterKey: ${a.originalKey} (uuid: ${a.uuid})`
+        );
+        normalizedAttachment.posterKey = undefined;
+      }
+
+      if (mediaKind === 'image' && normalizedAttachment.compressedKey) {
+        const compressedExists = await checkObjectExists(normalizedAttachment.compressedKey);
         if (!compressedExists) {
-          validationErrors.push(`Compressed file not found: ${a.compressedKey} (uuid: ${a.uuid})`);
-          // 压缩图不存在，但不阻止原图入库，只是不传递 compressedKey
-          validAttachments.push({
-            ...a,
-            compressedKey: undefined,
-          });
-          continue;
-        }
-
-        // 3. 验证 UUID 一致性：确保 compressedKey 中的 uuid 与 originalKey 中的 uuid 一致
-        // originalKey 格式: users/{userId}/uploads/{uuid}{ext}
-        // compressedKey 格式: users/{userId}/compressed/{uuid}.webp
-        // 使用更精确的正则表达式：([^/.]+) 匹配 UUID（不包含 / 和 .），然后匹配可选的扩展名
-        const originalUuidMatch = a.originalKey.match(/\/uploads\/([^/.]+)(\.[^.]+)?$/);
-        const compressedUuidMatch = a.compressedKey.match(/\/compressed\/([^/.]+)\.webp$/);
-
-        if (!originalUuidMatch || !compressedUuidMatch) {
           validationErrors.push(
-            `Invalid key format for uuid validation: originalKey=${a.originalKey}, compressedKey=${a.compressedKey}`
+            `Compressed file not found: ${normalizedAttachment.compressedKey} (uuid: ${a.uuid})`
           );
-          continue;
-        }
+          normalizedAttachment.compressedKey = undefined;
+        } else {
+          const compressedUuid = extractCompressedUuid(normalizedAttachment.compressedKey);
 
-        const originalUuid = originalUuidMatch[1];
-        const compressedUuid = compressedUuidMatch[1];
-
-        if (originalUuid !== compressedUuid) {
-          validationErrors.push(
-            `UUID mismatch: originalKey contains uuid '${originalUuid}', but compressedKey contains uuid '${compressedUuid}'`
-          );
-          // UUID 不匹配，不传递 compressedKey
-          validAttachments.push({
-            ...a,
-            compressedKey: undefined,
-          });
-          continue;
-        }
-
-        // 4. 验证 compressedKey 中的 uuid 是否与请求中的 uuid 一致
-        if (originalUuid !== a.uuid) {
-          validationErrors.push(
-            `UUID mismatch: request uuid '${a.uuid}' does not match originalKey uuid '${originalUuid}'`
-          );
-          continue;
+          if (!compressedUuid) {
+            validationErrors.push(
+              `Invalid key format for uuid validation: originalKey=${a.originalKey}, compressedKey=${normalizedAttachment.compressedKey}`
+            );
+            normalizedAttachment.compressedKey = undefined;
+          } else if (originalUuid !== compressedUuid) {
+            validationErrors.push(
+              `UUID mismatch: originalKey contains uuid '${originalUuid}', but compressedKey contains uuid '${compressedUuid}'`
+            );
+            normalizedAttachment.compressedKey = undefined;
+          }
         }
       }
 
+      if (mediaKind === 'video' && normalizedAttachment.posterKey) {
+        const posterExists = await checkObjectExists(normalizedAttachment.posterKey);
+        if (!posterExists) {
+          validationErrors.push(
+            `Poster file not found: ${normalizedAttachment.posterKey} (uuid: ${a.uuid})`
+          );
+          normalizedAttachment.posterKey = undefined;
+        } else {
+          const posterUuid = extractPosterUuid(normalizedAttachment.posterKey);
+          if (!posterUuid) {
+            validationErrors.push(
+              `Invalid key format for uuid validation: originalKey=${a.originalKey}, posterKey=${normalizedAttachment.posterKey}`
+            );
+            normalizedAttachment.posterKey = undefined;
+          } else if (originalUuid !== posterUuid) {
+            validationErrors.push(
+              `UUID mismatch: originalKey contains uuid '${originalUuid}', but posterKey contains uuid '${posterUuid}'`
+            );
+            normalizedAttachment.posterKey = undefined;
+          }
+        }
+      }
+
+      if (!mediaKind) {
+        validationErrors.push(`Unsupported attachment media type: ${a.originalKey} (uuid: ${a.uuid})`);
+        continue;
+      }
+
       // 所有验证通过
-      validAttachments.push(a);
+      validAttachments.push(normalizedAttachment);
     }
 
     // 如果没有有效的附件，返回错误
@@ -387,8 +445,10 @@ attachmentsRouter.post(
           mediaKind: inferAttachmentMediaKind({
             mimetype: a.mimetype || null,
             compressedKey: a.compressedKey,
+            posterKey: a.posterKey,
           }),
           compressKey: a.compressedKey,
+          posterKey: a.posterKey,
         },
       }));
       validateRoteAttachmentDetails(
@@ -403,9 +463,12 @@ attachmentsRouter.post(
       const mediaKind = inferAttachmentMediaKind({
         mimetype: a.mimetype || null,
         compressedKey: a.compressedKey,
+        posterKey: a.posterKey,
       });
       const cUrl =
         mediaKind === 'image' && a.compressedKey ? `${urlPrefix}/${a.compressedKey}` : null;
+      const pUrl =
+        mediaKind === 'video' && a.posterKey ? `${urlPrefix}/${a.posterKey}` : null;
       const baseDetails: any = {
         size: a.size || 0,
         mimetype: a.mimetype || null,
@@ -414,11 +477,13 @@ attachmentsRouter.post(
         key: a.originalKey,
       };
       if (a.compressedKey) baseDetails.compressKey = a.compressedKey;
+      if (a.posterKey) baseDetails.posterKey = a.posterKey;
       if (a.hash) baseDetails.hash = a.hash;
 
       return {
         url: oUrl,
         compressUrl: cUrl,
+        posterUrl: pUrl,
         details: baseDetails,
       };
     });

--- a/server/route/v2/attachment.ts
+++ b/server/route/v2/attachment.ts
@@ -70,7 +70,8 @@ const getExt = (filename?: string, contentType?: string) => {
 const extractOriginalUploadUuid = (key?: string) =>
   key?.match(/\/uploads\/([^/.]+)(\.[^.]+)?$/)?.[1] ?? null;
 
-const extractCompressedUuid = (key?: string) => key?.match(/\/compressed\/([^/.]+)\.webp$/)?.[1] ?? null;
+const extractCompressedUuid = (key?: string) =>
+  key?.match(/\/compressed\/([^/.]+)\.webp$/)?.[1] ?? null;
 
 const extractPosterUuid = (key?: string) => key?.match(/\/posters\/([^/.]+)\.[^.]+$/)?.[1] ?? null;
 
@@ -407,7 +408,9 @@ attachmentsRouter.post(
       }
 
       if (!mediaKind) {
-        validationErrors.push(`Unsupported attachment media type: ${a.originalKey} (uuid: ${a.uuid})`);
+        validationErrors.push(
+          `Unsupported attachment media type: ${a.originalKey} (uuid: ${a.uuid})`
+        );
         continue;
       }
 
@@ -467,8 +470,7 @@ attachmentsRouter.post(
       });
       const cUrl =
         mediaKind === 'image' && a.compressedKey ? `${urlPrefix}/${a.compressedKey}` : null;
-      const pUrl =
-        mediaKind === 'video' && a.posterKey ? `${urlPrefix}/${a.posterKey}` : null;
+      const pUrl = mediaKind === 'video' && a.posterKey ? `${urlPrefix}/${a.posterKey}` : null;
       const baseDetails: any = {
         size: a.size || 0,
         mimetype: a.mimetype || null,

--- a/server/route/v2/openKeyRouter.ts
+++ b/server/route/v2/openKeyRouter.ts
@@ -96,6 +96,13 @@ const getExt = (filename?: string, contentType?: string) => {
   return map[contentType] || '';
 };
 
+const extractOriginalUploadUuid = (key?: string) =>
+  key?.match(/\/uploads\/([^/.]+)(\.[^.]+)?$/)?.[1] ?? null;
+
+const extractCompressedUuid = (key?: string) => key?.match(/\/compressed\/([^/.]+)\.webp$/)?.[1] ?? null;
+
+const extractPosterUuid = (key?: string) => key?.match(/\/posters\/([^/.]+)\.[^.]+$/)?.[1] ?? null;
+
 function requireOpenKeyPerm(...perms: string[]) {
   return async (c: HonoContext, next: () => Promise<void>) => {
     const openKey = c.get('openKey')!;
@@ -747,10 +754,15 @@ router.post(
       );
     }
 
+    const maxVideoUploadSizeMB = getMaxVideoUploadSizeMB(uiConfig);
+
     // Strict validation
     for (const f of files) {
       validateContentType(f.contentType);
-      validateFileSize(f.size, f.contentType, getMaxVideoUploadSizeMB(uiConfig));
+      if (isVideoContentType(f.contentType) && canAlwaysUploadVideo(owner?.role)) {
+        continue;
+      }
+      validateFileSize(f.size, f.contentType, maxVideoUploadSizeMB);
     }
 
     const results = await Promise.all(
@@ -782,6 +794,17 @@ router.post(
           };
         }
 
+        if (mediaKind === 'video') {
+          const posterKey = `users/${openKey.userid}/posters/${uuid}.jpg`;
+          const poster = await presignPutUrl(posterKey, 'image/jpeg', 15 * 60);
+          result.poster = {
+            key: posterKey,
+            putUrl: poster.putUrl,
+            url: poster.url,
+            contentType: 'image/jpeg',
+          };
+        }
+
         return result;
       })
     );
@@ -805,6 +828,7 @@ router.post(
         uuid: string;
         originalKey: string;
         compressedKey?: string;
+        posterKey?: string;
         size?: number;
         mimetype?: string;
         hash?: string;
@@ -826,25 +850,32 @@ router.post(
     const invalid = attachments.find(
       (a) =>
         !a.originalKey?.startsWith(prefix) ||
-        (a.compressedKey !== undefined && !a.compressedKey.startsWith(prefix))
+        (a.compressedKey !== undefined && !a.compressedKey.startsWith(prefix)) ||
+        (a.posterKey !== undefined && !a.posterKey.startsWith(prefix))
     );
     if (invalid) {
       throw new Error('Invalid object key');
     }
 
+    const owner = await oneUser(openKey.userid);
+    const maxVideoUploadSizeMB = getMaxVideoUploadSizeMB(uiConfig);
+
     for (const a of attachments) {
       if (a.mimetype) {
         validateContentType(a.mimetype);
-        validateFileSize(a.size, a.mimetype, getMaxVideoUploadSizeMB(uiConfig));
+        if (isVideoContentType(a.mimetype) && canAlwaysUploadVideo(owner?.role)) {
+          continue;
+        }
+        validateFileSize(a.size, a.mimetype, maxVideoUploadSizeMB);
       }
     }
 
-    const owner = await oneUser(openKey.userid);
     const hasVideo = attachments.some(
       (a) =>
         inferAttachmentMediaKind({
           mimetype: a.mimetype,
           compressedKey: a.compressedKey,
+          posterKey: a.posterKey,
           key: a.originalKey,
         }) === 'video'
     );
@@ -862,8 +893,11 @@ router.post(
       const mediaKind = inferAttachmentMediaKind({
         mimetype: a.mimetype,
         compressedKey: a.compressedKey,
+        posterKey: a.posterKey,
         key: a.originalKey,
       });
+
+      const normalizedAttachment = { ...a };
 
       const originalExists = await checkObjectExists(a.originalKey);
       if (!originalExists) {
@@ -871,51 +905,88 @@ router.post(
         continue;
       }
 
-      if (mediaKind === 'video' && a.compressedKey) {
+      const originalUuid = extractOriginalUploadUuid(a.originalKey);
+      if (!originalUuid) {
+        validationErrors.push(
+          `Invalid original key format for uuid validation: originalKey=${a.originalKey}`
+        );
+        continue;
+      }
+
+      if (originalUuid !== a.uuid) {
+        validationErrors.push(
+          `UUID mismatch: request uuid '${a.uuid}' does not match originalKey uuid '${originalUuid}'`
+        );
+        continue;
+      }
+
+      if (mediaKind === 'video' && normalizedAttachment.compressedKey) {
         validationErrors.push(
           `Videos cannot include compressedKey: ${a.originalKey} (uuid: ${a.uuid})`
         );
         continue;
       }
 
-      if (mediaKind === 'image' && a.compressedKey) {
-        const compressedExists = await checkObjectExists(a.compressedKey);
+      if (mediaKind === 'image' && normalizedAttachment.posterKey) {
+        validationErrors.push(
+          `Images cannot include posterKey: ${a.originalKey} (uuid: ${a.uuid})`
+        );
+        normalizedAttachment.posterKey = undefined;
+      }
+
+      if (mediaKind === 'image' && normalizedAttachment.compressedKey) {
+        const compressedExists = await checkObjectExists(normalizedAttachment.compressedKey);
         if (!compressedExists) {
-          validationErrors.push(`Compressed file not found: ${a.compressedKey} (uuid: ${a.uuid})`);
-          validAttachments.push({ ...a, compressedKey: undefined });
-          continue;
-        }
-
-        const originalUuidMatch = a.originalKey.match(/\/uploads\/([^/.]+)(\.[^.]+)?$/);
-        const compressedUuidMatch = a.compressedKey.match(/\/compressed\/([^/.]+)\.webp$/);
-
-        if (!originalUuidMatch || !compressedUuidMatch) {
           validationErrors.push(
-            `Invalid key format for uuid validation: originalKey=${a.originalKey}, compressedKey=${a.compressedKey}`
+            `Compressed file not found: ${normalizedAttachment.compressedKey} (uuid: ${a.uuid})`
           );
-          continue;
-        }
+          normalizedAttachment.compressedKey = undefined;
+        } else {
+          const compressedUuid = extractCompressedUuid(normalizedAttachment.compressedKey);
 
-        const originalUuid = originalUuidMatch[1];
-        const compressedUuid = compressedUuidMatch[1];
-
-        if (originalUuid !== compressedUuid) {
-          validationErrors.push(
-            `UUID mismatch: originalKey contains uuid '${originalUuid}', but compressedKey contains uuid '${compressedUuid}'`
-          );
-          validAttachments.push({ ...a, compressedKey: undefined });
-          continue;
-        }
-
-        if (originalUuid !== a.uuid) {
-          validationErrors.push(
-            `UUID mismatch: request uuid '${a.uuid}' does not match originalKey uuid '${originalUuid}'`
-          );
-          continue;
+          if (!compressedUuid) {
+            validationErrors.push(
+              `Invalid key format for uuid validation: originalKey=${a.originalKey}, compressedKey=${normalizedAttachment.compressedKey}`
+            );
+            normalizedAttachment.compressedKey = undefined;
+          } else if (originalUuid !== compressedUuid) {
+            validationErrors.push(
+              `UUID mismatch: originalKey contains uuid '${originalUuid}', but compressedKey contains uuid '${compressedUuid}'`
+            );
+            normalizedAttachment.compressedKey = undefined;
+          }
         }
       }
 
-      validAttachments.push(a);
+      if (mediaKind === 'video' && normalizedAttachment.posterKey) {
+        const posterExists = await checkObjectExists(normalizedAttachment.posterKey);
+        if (!posterExists) {
+          validationErrors.push(
+            `Poster file not found: ${normalizedAttachment.posterKey} (uuid: ${a.uuid})`
+          );
+          normalizedAttachment.posterKey = undefined;
+        } else {
+          const posterUuid = extractPosterUuid(normalizedAttachment.posterKey);
+          if (!posterUuid) {
+            validationErrors.push(
+              `Invalid key format for uuid validation: originalKey=${a.originalKey}, posterKey=${normalizedAttachment.posterKey}`
+            );
+            normalizedAttachment.posterKey = undefined;
+          } else if (originalUuid !== posterUuid) {
+            validationErrors.push(
+              `UUID mismatch: originalKey contains uuid '${originalUuid}', but posterKey contains uuid '${posterUuid}'`
+            );
+            normalizedAttachment.posterKey = undefined;
+          }
+        }
+      }
+
+      if (!mediaKind) {
+        validationErrors.push(`Unsupported attachment media type: ${a.originalKey} (uuid: ${a.uuid})`);
+        continue;
+      }
+
+      validAttachments.push(normalizedAttachment);
     }
 
     if (validAttachments.length === 0) {
@@ -945,8 +1016,10 @@ router.post(
           mediaKind: inferAttachmentMediaKind({
             mimetype: a.mimetype || null,
             compressedKey: a.compressedKey,
+            posterKey: a.posterKey,
           }),
           compressKey: a.compressedKey,
+          posterKey: a.posterKey,
         },
       }));
       validateRoteAttachmentDetails(
@@ -961,9 +1034,12 @@ router.post(
       const mediaKind = inferAttachmentMediaKind({
         mimetype: a.mimetype || null,
         compressedKey: a.compressedKey,
+        posterKey: a.posterKey,
       });
       const cUrl =
         mediaKind === 'image' && a.compressedKey ? `${urlPrefix}/${a.compressedKey}` : null;
+      const pUrl =
+        mediaKind === 'video' && a.posterKey ? `${urlPrefix}/${a.posterKey}` : null;
       const baseDetails: any = {
         size: a.size || 0,
         mimetype: a.mimetype || null,
@@ -972,11 +1048,13 @@ router.post(
         key: a.originalKey,
       };
       if (a.compressedKey) baseDetails.compressKey = a.compressedKey;
+      if (a.posterKey) baseDetails.posterKey = a.posterKey;
       if (a.hash) baseDetails.hash = a.hash;
 
       return {
         url: oUrl,
         compressUrl: cUrl,
+        posterUrl: pUrl,
         details: baseDetails,
       };
     });

--- a/server/route/v2/openKeyRouter.ts
+++ b/server/route/v2/openKeyRouter.ts
@@ -99,7 +99,8 @@ const getExt = (filename?: string, contentType?: string) => {
 const extractOriginalUploadUuid = (key?: string) =>
   key?.match(/\/uploads\/([^/.]+)(\.[^.]+)?$/)?.[1] ?? null;
 
-const extractCompressedUuid = (key?: string) => key?.match(/\/compressed\/([^/.]+)\.webp$/)?.[1] ?? null;
+const extractCompressedUuid = (key?: string) =>
+  key?.match(/\/compressed\/([^/.]+)\.webp$/)?.[1] ?? null;
 
 const extractPosterUuid = (key?: string) => key?.match(/\/posters\/([^/.]+)\.[^.]+$/)?.[1] ?? null;
 
@@ -982,7 +983,9 @@ router.post(
       }
 
       if (!mediaKind) {
-        validationErrors.push(`Unsupported attachment media type: ${a.originalKey} (uuid: ${a.uuid})`);
+        validationErrors.push(
+          `Unsupported attachment media type: ${a.originalKey} (uuid: ${a.uuid})`
+        );
         continue;
       }
 
@@ -1038,8 +1041,7 @@ router.post(
       });
       const cUrl =
         mediaKind === 'image' && a.compressedKey ? `${urlPrefix}/${a.compressedKey}` : null;
-      const pUrl =
-        mediaKind === 'video' && a.posterKey ? `${urlPrefix}/${a.posterKey}` : null;
+      const pUrl = mediaKind === 'video' && a.posterKey ? `${urlPrefix}/${a.posterKey}` : null;
       const baseDetails: any = {
         size: a.size || 0,
         mimetype: a.mimetype || null,

--- a/server/tests/fileValidation.test.ts
+++ b/server/tests/fileValidation.test.ts
@@ -104,6 +104,25 @@ describe('fileValidation', () => {
     ).not.toThrow();
   });
 
+  it('treats attachments with poster keys as videos when mimetype is missing', () => {
+    expect(
+      inferAttachmentMediaKind({
+        posterKey: 'users/test/posters/example.jpg',
+      })
+    ).toBe('video');
+
+    expect(() =>
+      validateRoteAttachmentDetails([
+        {
+          details: {
+            key: 'users/test/uploads/example.mp4',
+            posterKey: 'users/test/posters/example.jpg',
+          },
+        },
+      ])
+    ).not.toThrow();
+  });
+
   it('infers legacy attachment media kind from the stored key extension', () => {
     expect(getMediaKindFromFilename('users/test/uploads/example.mp4')).toBe('video');
     expect(getMediaKindFromFilename('users/test/uploads/example.png')).toBe('image');

--- a/server/types/main.ts
+++ b/server/types/main.ts
@@ -1,6 +1,7 @@
 export interface UploadResult {
   url: string | null;
   compressUrl: string | null;
+  posterUrl: string | null;
   details: {
     size: number;
     mimetype: string | null;
@@ -9,6 +10,7 @@ export interface UploadResult {
     // 对象存储中的 Key，便于删除和追踪
     key?: string;
     compressKey?: string;
+    posterKey?: string;
   };
 }
 

--- a/server/utils/dbMethods/attachment.ts
+++ b/server/utils/dbMethods/attachment.ts
@@ -33,6 +33,7 @@ export async function createAttachments(
       roteid: roteid || null,
       url: e.url,
       compressUrl: e.compressUrl || '',
+      posterUrl: e.posterUrl || '',
       details: e.details,
       storage: 'R2',
       sortIndex: roteid ? startSortIndex + index : 0,
@@ -82,6 +83,7 @@ export async function upsertAttachmentsByOriginalKey(
               roteid: roteid || null,
               url: e.url as string,
               compressUrl: e.compressUrl || '',
+              posterUrl: e.posterUrl || '',
               details: e.details,
               storage: 'R2',
               createdAt: sql`now()`,
@@ -117,6 +119,7 @@ export async function upsertAttachmentsByOriginalKey(
             .set({
               roteid: roteid ?? existing.roteid ?? null,
               compressUrl: e.compressUrl ?? existing.compressUrl ?? '',
+              posterUrl: e.posterUrl ?? existing.posterUrl ?? '',
               details: {
                 ...(existing.details as any),
                 ...(e.details as any),
@@ -136,6 +139,7 @@ export async function upsertAttachmentsByOriginalKey(
               roteid: roteid || null,
               url: e.url as string,
               compressUrl: e.compressUrl || '',
+              posterUrl: e.posterUrl || '',
               details: e.details,
               storage: 'R2',
               createdAt: sql`now()`,

--- a/server/utils/fileValidation.ts
+++ b/server/utils/fileValidation.ts
@@ -42,6 +42,7 @@ type AttachmentLike = {
     mimetype?: string | null;
     contentType?: string | null;
     compressKey?: string | null;
+    posterKey?: string | null;
     key?: string | null;
   } | null;
 };
@@ -52,6 +53,7 @@ type UploadLike = {
   contentType?: string | null;
   compressedKey?: string | null;
   compressKey?: string | null;
+  posterKey?: string | null;
   key?: string | null;
 };
 
@@ -110,6 +112,10 @@ export function inferAttachmentMediaKind(input?: UploadLike | null): MediaKind |
   const mediaKindFromKey = getMediaKindFromFilename(input.key);
   if (mediaKindFromKey) {
     return mediaKindFromKey;
+  }
+
+  if (input.posterKey) {
+    return 'video';
   }
 
   if (input.compressedKey || input.compressKey) {

--- a/web/src/components/editor/AttachmentItem.tsx
+++ b/web/src/components/editor/AttachmentItem.tsx
@@ -79,6 +79,7 @@ function AttachmentItem({
             mediaClassName={isUploading ? 'opacity-55' : undefined}
             playbackSrc={previewSrc}
             posterSrc={thumbSrc}
+            stopInteractionPropagation
           />
 
           {isUploading && (

--- a/web/src/components/editor/AttachmentItem.tsx
+++ b/web/src/components/editor/AttachmentItem.tsx
@@ -1,8 +1,10 @@
 import type { Attachment } from '@/types/main';
+import { VideoAttachmentPreview } from '@/components/rote/VideoAttachmentPreview';
 import { getAttachmentMediaKind } from '@/utils/directUpload';
+import { generateVideoPoster } from '@/utils/generateVideoPoster';
 import { X } from 'lucide-react';
 import { PhotoView } from 'react-photo-view';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 interface AttachmentItemProps {
   attachment: File | Attachment;
@@ -20,6 +22,7 @@ function AttachmentItem({
   onDelete,
 }: AttachmentItemProps) {
   const mediaKind = getAttachmentMediaKind(attachment);
+  const [localPosterSrc, setLocalPosterSrc] = useState<string | null>(null);
   const objectUrl = useMemo(
     () => (attachment instanceof File ? URL.createObjectURL(attachment) : null),
     [attachment]
@@ -27,8 +30,33 @@ function AttachmentItem({
 
   useEffect(() => (objectUrl ? () => URL.revokeObjectURL(objectUrl) : undefined), [objectUrl]);
 
+  useEffect(() => {
+    if (!(attachment instanceof File) || mediaKind !== 'video') {
+      setLocalPosterSrc(null);
+      return;
+    }
+
+    let active = true;
+    let posterObjectUrl: string | null = null;
+
+    void generateVideoPoster(attachment).then((posterBlob) => {
+      if (!active || !posterBlob) return;
+      posterObjectUrl = URL.createObjectURL(posterBlob);
+      setLocalPosterSrc(posterObjectUrl);
+    });
+
+    return () => {
+      active = false;
+      if (posterObjectUrl) {
+        URL.revokeObjectURL(posterObjectUrl);
+      }
+    };
+  }, [attachment, mediaKind]);
+
   const thumbSrc =
-    objectUrl || (!(attachment instanceof File) ? attachment.compressUrl || attachment.url : '');
+    mediaKind === 'video'
+      ? localPosterSrc || (!(attachment instanceof File) ? attachment.posterUrl || '' : '')
+      : objectUrl || (!(attachment instanceof File) ? attachment.compressUrl || attachment.url : '');
   const previewSrc = objectUrl || (!(attachment instanceof File) ? attachment.url : '');
   const progressValue =
     typeof uploadProgress === 'number' ? Math.max(0, Math.min(100, uploadProgress)) : 0;
@@ -44,15 +72,12 @@ function AttachmentItem({
     >
       {mediaKind === 'video' ? (
         <>
-          <video
-            className={`h-full w-full ${isUploading ? 'object-cover opacity-55' : 'object-contain'}`}
-            src={previewSrc}
-            controls={!isUploading}
-            muted={isUploading}
-            playsInline
-            preload="metadata"
-            onPointerDown={(e) => e.stopPropagation()}
-            onClick={(e) => e.stopPropagation()}
+          <VideoAttachmentPreview
+            className="h-full w-full"
+            disabled={isUploading}
+            mediaClassName={isUploading ? 'opacity-55' : undefined}
+            playbackSrc={previewSrc}
+            posterSrc={thumbSrc}
           />
 
           {isUploading && (

--- a/web/src/components/editor/AttachmentItem.tsx
+++ b/web/src/components/editor/AttachmentItem.tsx
@@ -56,7 +56,8 @@ function AttachmentItem({
   const thumbSrc =
     mediaKind === 'video'
       ? localPosterSrc || (!(attachment instanceof File) ? attachment.posterUrl || '' : '')
-      : objectUrl || (!(attachment instanceof File) ? attachment.compressUrl || attachment.url : '');
+      : objectUrl ||
+        (!(attachment instanceof File) ? attachment.compressUrl || attachment.url : '');
   const previewSrc = objectUrl || (!(attachment instanceof File) ? attachment.url : '');
   const progressValue =
     typeof uploadProgress === 'number' ? Math.max(0, Math.min(100, uploadProgress)) : 0;

--- a/web/src/components/editor/RoteEditor.tsx
+++ b/web/src/components/editor/RoteEditor.tsx
@@ -15,6 +15,7 @@ import { useSiteStatus } from '@/hooks/useSiteStatus';
 import { useAuthState } from '@/state/profile';
 
 import { getAttachmentMediaKind } from '@/utils/directUpload';
+import { generateVideoPoster } from '@/utils/generateVideoPoster';
 import {
   DEFAULT_MAX_VIDEO_UPLOAD_SIZE_MB,
   IMAGE_ACCEPT,
@@ -257,6 +258,7 @@ function RoteEditor({ roteAtom, callback }: { roteAtom: RoteAtomType; callback?:
           uuid: string;
           originalKey: string;
           compressedKey?: string;
+          posterKey?: string;
           size: number;
           mimetype: string;
         }> = [];
@@ -269,6 +271,8 @@ function RoteEditor({ roteAtom, callback }: { roteAtom: RoteAtomType; callback?:
             if (!file || (file as File).size === 0) {
               throw new Error('Empty file');
             }
+
+            const posterBlob = isVideoFile(file) ? await generateVideoPoster(file) : null;
 
             // 先压缩图片（如果支持）
             const compressedBlob = await maybeCompressToWebp(file, {
@@ -287,6 +291,7 @@ function RoteEditor({ roteAtom, callback }: { roteAtom: RoteAtomType; callback?:
 
             // 压缩图上传（可选，失败不影响原图）
             let compressedKey: string | undefined;
+            let posterKey: string | undefined;
             if (compressedBlob && item.compressed) {
               try {
                 await uploadToSignedUrl(item.compressed.putUrl, compressedBlob);
@@ -300,12 +305,23 @@ function RoteEditor({ roteAtom, callback }: { roteAtom: RoteAtomType; callback?:
               }
             }
 
+            if (posterBlob && item.poster) {
+              try {
+                await uploadToSignedUrl(item.poster.putUrl, posterBlob);
+                posterKey = item.poster.key;
+              } catch (error) {
+                // eslint-disable-next-line no-console
+                console.warn(`Video poster upload failed for ${item.uuid}:`, error);
+              }
+            }
+
             // 只有原图上传成功（且压缩图上传成功或不需要压缩）才添加到 toFinalize
             // 注意：这里不直接 push，而是通过返回值处理
             return {
               uuid: item.uuid,
               originalKey: item.original.key,
               compressedKey,
+              posterKey,
               size: file.size,
               mimetype: file.type,
             };

--- a/web/src/components/rote/AttachmentsGrid.tsx
+++ b/web/src/components/rote/AttachmentsGrid.tsx
@@ -1,6 +1,7 @@
 import type { Attachment } from '@/types/main';
 import { getAttachmentMediaKind } from '@/utils/directUpload';
 import { PhotoProvider, PhotoView } from 'react-photo-view';
+import { VideoAttachmentPreview } from './VideoAttachmentPreview';
 import 'react-photo-view/dist/react-photo-view.css';
 
 interface AttachmentsGridProps {
@@ -23,13 +24,12 @@ export default function AttachmentsGrid({ attachments, withTimeStamp }: Attachme
       <div className="my-2 flex w-fit flex-wrap gap-1 overflow-hidden rounded-2xl">
         {hasVideo ? (
           sortedAttachments.map((file, index) => (
-            <video
+            <VideoAttachmentPreview
               key={`files_${index}`}
               className="bg-foreground/3 w-full max-w-[500px] rounded-2xl border-[0.5px]"
-              src={file.url}
-              controls
-              playsInline
-              preload="metadata"
+              mediaClassName="h-full w-full object-contain"
+              playbackSrc={file.url}
+              posterSrc={file.posterUrl}
             />
           ))
         ) : (

--- a/web/src/components/rote/VideoAttachmentPreview.tsx
+++ b/web/src/components/rote/VideoAttachmentPreview.tsx
@@ -1,0 +1,42 @@
+import { cn } from '@/lib/utils';
+
+interface VideoAttachmentPreviewProps {
+  posterSrc?: null | string;
+  playbackSrc?: null | string;
+  className?: string;
+  mediaClassName?: string;
+  disabled?: boolean;
+}
+
+export function VideoAttachmentPreview({
+  posterSrc,
+  playbackSrc,
+  className,
+  mediaClassName,
+  disabled = false,
+}: VideoAttachmentPreviewProps) {
+  if (!playbackSrc || disabled) {
+    if (posterSrc) {
+      return (
+        <div className={cn('relative h-full w-full overflow-hidden bg-black', className)}>
+          <img className={cn('h-full w-full bg-black object-contain', mediaClassName)} src={posterSrc} alt="" />
+        </div>
+      );
+    }
+
+    return <div className={cn('h-full w-full bg-black', className)} />;
+  }
+
+  return (
+    <div className={cn('relative h-full w-full overflow-hidden bg-black', className)}>
+      <video
+        className={cn('h-full w-full bg-black object-contain', mediaClassName)}
+        controls
+        playsInline
+        poster={posterSrc || undefined}
+        preload="metadata"
+        src={playbackSrc}
+      />
+    </div>
+  );
+}

--- a/web/src/components/rote/VideoAttachmentPreview.tsx
+++ b/web/src/components/rote/VideoAttachmentPreview.tsx
@@ -6,6 +6,7 @@ interface VideoAttachmentPreviewProps {
   className?: string;
   mediaClassName?: string;
   disabled?: boolean;
+  stopInteractionPropagation?: boolean;
 }
 
 export function VideoAttachmentPreview({
@@ -14,7 +15,14 @@ export function VideoAttachmentPreview({
   className,
   mediaClassName,
   disabled = false,
+  stopInteractionPropagation = false,
 }: VideoAttachmentPreviewProps) {
+  const stopPropagation = (event: { stopPropagation: () => void }) => {
+    if (stopInteractionPropagation) {
+      event.stopPropagation();
+    }
+  };
+
   if (!playbackSrc || disabled) {
     if (posterSrc) {
       return (
@@ -37,6 +45,8 @@ export function VideoAttachmentPreview({
         className={cn('h-full w-full bg-black object-contain', mediaClassName)}
         controls
         playsInline
+        onPointerDown={stopPropagation}
+        onClick={stopPropagation}
         poster={posterSrc || undefined}
         preload="metadata"
         src={playbackSrc}

--- a/web/src/components/rote/VideoAttachmentPreview.tsx
+++ b/web/src/components/rote/VideoAttachmentPreview.tsx
@@ -19,7 +19,11 @@ export function VideoAttachmentPreview({
     if (posterSrc) {
       return (
         <div className={cn('relative h-full w-full overflow-hidden bg-black', className)}>
-          <img className={cn('h-full w-full bg-black object-contain', mediaClassName)} src={posterSrc} alt="" />
+          <img
+            className={cn('h-full w-full bg-black object-contain', mediaClassName)}
+            src={posterSrc}
+            alt=""
+          />
         </div>
       );
     }

--- a/web/src/types/main.ts
+++ b/web/src/types/main.ts
@@ -61,6 +61,7 @@ export type Attachment = {
   id: string;
   url: string;
   compressUrl: string;
+  posterUrl?: null | string;
   userid: string;
   roteid: string | null;
   sortIndex: number;
@@ -75,6 +76,7 @@ export type Attachment = {
     bucket?: string;
     key?: string;
     compressKey?: string;
+    posterKey?: string;
     acl?: string;
     contentType?: string;
     contentDisposition?: string | null;

--- a/web/src/utils/directUpload.ts
+++ b/web/src/utils/directUpload.ts
@@ -9,6 +9,7 @@ export type PresignItem = {
   uuid: string;
   original: { key: string; putUrl: string; url: string; contentType?: string };
   compressed?: { key: string; putUrl: string; url: string; contentType: 'image/webp' };
+  poster?: { key: string; putUrl: string; url: string; contentType: 'image/jpeg' };
 };
 
 export interface PresignResponse {
@@ -127,6 +128,7 @@ export type FinalizeAttachment = {
   uuid: string;
   originalKey: string;
   compressedKey?: string;
+  posterKey?: string;
   size?: number;
   mimetype?: string;
   hash?: string;

--- a/web/src/utils/generateVideoPoster.ts
+++ b/web/src/utils/generateVideoPoster.ts
@@ -1,0 +1,100 @@
+const DEFAULT_CAPTURE_SECONDS = 0.15;
+const DEFAULT_MAX_DIMENSION = 1600;
+const DEFAULT_QUALITY = 0.82;
+
+function waitForEvent(
+  target: HTMLVideoElement,
+  eventName: 'loadeddata' | 'loadedmetadata' | 'seeked'
+) {
+  return new Promise<void>((resolve, reject) => {
+    const cleanup = () => {
+      target.removeEventListener(eventName, handleSuccess);
+      target.removeEventListener('error', handleError);
+    };
+
+    const handleSuccess = () => {
+      cleanup();
+      resolve();
+    };
+
+    const handleError = () => {
+      cleanup();
+      reject(new Error(`Video event failed: ${eventName}`));
+    };
+
+    target.addEventListener(eventName, handleSuccess, { once: true });
+    target.addEventListener('error', handleError, { once: true });
+  });
+}
+
+function canvasToBlob(canvas: HTMLCanvasElement, quality: number) {
+  return new Promise<Blob | null>((resolve) => {
+    canvas.toBlob((blob) => resolve(blob), 'image/jpeg', quality);
+  });
+}
+
+export async function generateVideoPoster(
+  file: Blob,
+  options?: {
+    captureSeconds?: number;
+    maxDimension?: number;
+    quality?: number;
+  }
+) {
+  if (typeof document === 'undefined') {
+    return null;
+  }
+
+  const captureSeconds = options?.captureSeconds ?? DEFAULT_CAPTURE_SECONDS;
+  const maxDimension = options?.maxDimension ?? DEFAULT_MAX_DIMENSION;
+  const quality = options?.quality ?? DEFAULT_QUALITY;
+  const objectUrl = URL.createObjectURL(file);
+  const video = document.createElement('video');
+
+  video.muted = true;
+  video.preload = 'metadata';
+  video.playsInline = true;
+  video.src = objectUrl;
+
+  try {
+    if (video.readyState < HTMLMediaElement.HAVE_METADATA) {
+      await waitForEvent(video, 'loadedmetadata');
+    }
+
+    const duration = Number.isFinite(video.duration) ? video.duration : 0;
+    const targetTime =
+      duration > 0 ? Math.min(captureSeconds, Math.max(duration - 0.01, 0)) : 0;
+
+    if (targetTime > 0) {
+      video.currentTime = targetTime;
+      await waitForEvent(video, 'seeked');
+    } else if (video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA) {
+      await waitForEvent(video, 'loadeddata');
+    }
+
+    const sourceWidth = video.videoWidth;
+    const sourceHeight = video.videoHeight;
+    if (!sourceWidth || !sourceHeight) {
+      return null;
+    }
+
+    const scale = Math.min(1, maxDimension / Math.max(sourceWidth, sourceHeight));
+    const canvas = document.createElement('canvas');
+    canvas.width = Math.max(1, Math.round(sourceWidth * scale));
+    canvas.height = Math.max(1, Math.round(sourceHeight * scale));
+
+    const context = canvas.getContext('2d');
+    if (!context) {
+      return null;
+    }
+
+    context.drawImage(video, 0, 0, canvas.width, canvas.height);
+    return await canvasToBlob(canvas, quality);
+  } catch {
+    return null;
+  } finally {
+    URL.revokeObjectURL(objectUrl);
+    video.removeAttribute('src');
+    video.load();
+  }
+}

--- a/web/src/utils/generateVideoPoster.ts
+++ b/web/src/utils/generateVideoPoster.ts
@@ -62,8 +62,7 @@ export async function generateVideoPoster(
     }
 
     const duration = Number.isFinite(video.duration) ? video.duration : 0;
-    const targetTime =
-      duration > 0 ? Math.min(captureSeconds, Math.max(duration - 0.01, 0)) : 0;
+    const targetTime = duration > 0 ? Math.min(captureSeconds, Math.max(duration - 0.01, 0)) : 0;
 
     if (targetTime > 0) {
       video.currentTime = targetTime;


### PR DESCRIPTION
## Summary
- persist  for video attachments and expose it through the server attachment APIs
- enforce the single-video-per-note rule and updated media validation on the server
- render uploaded videos with poster thumbnails on web and generate/upload posters during editor direct upload

## Testing
- cd server && bun run build
- cd server && bun test tests/fileValidation.test.ts
- cd web && npm run build