### PR TITLE
fix: unify statistics field naming to roteCount

### DIFF
--- a/server/utils/dbMethods/admin.ts
+++ b/server/utils/dbMethods/admin.ts
@@ -116,9 +116,9 @@ export async function listUsers(params: {
         avatar: users.avatar,
         role: users.role,
         emailVerified: users.emailVerified,
-        noteCount:
+        roteCount:
           sql<number>`(SELECT COUNT(*)::int FROM rotes WHERE rotes.authorid = users.id)`.as(
-            'noteCount'
+            'roteCount'
           ),
         attachmentCount:
           sql<number>`(SELECT COUNT(*)::int FROM attachments WHERE attachments.userid = users.id)`.as(

--- a/server/utils/dbMethods/userData.ts
+++ b/server/utils/dbMethods/userData.ts
@@ -5,15 +5,15 @@ import { DatabaseError } from './common';
 
 export async function statistics(authorid: string): Promise<any> {
   try {
-    const [noteCountResult, attachmentsList, articleCountResult] = await Promise.all([
+    const [roteCountResult, attachmentsList, articleCountResult] = await Promise.all([
       db.select({ count: count() }).from(rotes).where(eq(rotes.authorid, authorid)),
       db.select().from(attachments).where(eq(attachments.userid, authorid)),
       db.select({ count: count() }).from(articles).where(eq(articles.authorId, authorid)),
     ]);
 
     return {
-      noteCount: noteCountResult[0]?.count || 0,
-      attachmentsCount: attachmentsList.length,
+      roteCount: roteCountResult[0]?.count || 0,
+      attachmentCount: attachmentsList.length,
       articleCount: articleCountResult[0]?.count || 0,
     };
   } catch (error) {

--- a/web/src/components/experiment/exportData.tsx
+++ b/web/src/components/experiment/exportData.tsx
@@ -86,14 +86,14 @@ export default function ExportData() {
             <div className="flex flex-col items-center justify-center gap-2">
               <SlidingNumber
                 className="text-4xl font-semibold"
-                number={data?.noteCount || '0'}
+                number={data?.roteCount || '0'}
               ></SlidingNumber>
-              <div className="text-info text-sm">{t('noteCount')}</div>
+              <div className="text-info text-sm">{t('roteCount')}</div>
             </div>
             <div className="flex flex-col items-center justify-center gap-2">
               <SlidingNumber
                 className="text-4xl font-semibold"
-                number={data?.attachmentsCount || '0'}
+                number={data?.attachmentCount || '0'}
               ></SlidingNumber>
               <div className="text-info text-sm">{t('attachmentCount')}</div>
             </div>

--- a/web/src/components/experiment/importData.tsx
+++ b/web/src/components/experiment/importData.tsx
@@ -32,7 +32,7 @@ export default function ImportData() {
   const [isImporting, setIsImporting] = useState(false);
   const [stats, setStats] = useState<{
     articleCount: number;
-    noteCount: number;
+    roteCount: number;
     attachmentCount: number;
   } | null>(null);
   const [fileData, setFileData] = useState<any | null>(null);
@@ -118,7 +118,7 @@ export default function ImportData() {
 
           setStats({
             articleCount: articleIds.size,
-            noteCount: json.notes.length,
+            roteCount: json.notes.length,
             attachmentCount,
           });
           setFileData(json);
@@ -290,7 +290,7 @@ export default function ImportData() {
               <div className="flex flex-col items-center justify-center gap-2">
                 <SlidingNumber
                   className="text-4xl font-semibold"
-                  number={stats.noteCount}
+                  number={stats.roteCount}
                 ></SlidingNumber>
                 <div className="text-info text-sm">{t('notesFound')}</div>
               </div>

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -351,7 +351,7 @@
       "exportData": {
         "title": "Export Data",
         "description": "Export complete data in JSON format for use elsewhere.",
-        "noteCount": "Notes Count",
+        "roteCount": "Notes Count",
         "attachmentCount": "Attachments Count",
         "articleCount": "Articles Count",
         "includesArticlesHint": "The exported JSON now includes articles and note-to-article bindings.",
@@ -700,7 +700,7 @@
           "nickname": "Nickname",
           "role": "Role",
           "emailVerified": "Email Verified",
-          "noteCount": "Notes",
+          "roteCount": "Notes",
           "attachmentCount": "Attachments",
           "createdAt": "Created At",
           "actions": "Actions",

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -351,7 +351,7 @@
       "exportData": {
         "title": "データエクスポート",
         "description": "完全なデータをJSON形式でエクスポートして、他の場所で使用します。",
-        "noteCount": "ノート数",
+        "roteCount": "ノート数",
         "attachmentCount": "添付ファイル数",
         "articleCount": "記事数",
         "includesArticlesHint": "エクスポートされる JSON には、記事データとノートとの関連付けが含まれます。",
@@ -700,7 +700,7 @@
           "nickname": "ニックネーム",
           "role": "ロール",
           "emailVerified": "メール確認済み",
-          "noteCount": "ノート数",
+          "roteCount": "ノート数",
           "attachmentCount": "添付数",
           "createdAt": "作成日時",
           "actions": "操作",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -341,7 +341,7 @@
       "exportData": {
         "title": "数据导出",
         "description": "导出完整的 json 格式数据，以便在其他地方使用。",
-        "noteCount": "笔记数量",
+        "roteCount": "笔记数量",
         "attachmentCount": "附件数量",
         "articleCount": "文章数量",
         "includesArticlesHint": "导出的 JSON 现在会包含文章数据及笔记与文章的绑定关系。",
@@ -690,7 +690,7 @@
           "nickname": "昵称",
           "role": "角色",
           "emailVerified": "邮箱验证",
-          "noteCount": "笔记数",
+          "roteCount": "笔记数",
           "attachmentCount": "附件数",
           "createdAt": "创建时间",
           "actions": "操作",

--- a/web/src/pages/admin/components/UsersTab.tsx
+++ b/web/src/pages/admin/components/UsersTab.tsx
@@ -53,7 +53,7 @@ interface User {
   avatar: string | null;
   role: string;
   emailVerified: boolean;
-  noteCount: number;
+  roteCount: number;
   attachmentCount: number;
   createdAt: string;
   updatedAt: string;
@@ -242,7 +242,7 @@ export default function UsersTab() {
                     <TableHead>{t('table.nickname')}</TableHead>
                     <TableHead>{t('table.role')}</TableHead>
                     <TableHead>{t('table.emailVerified')}</TableHead>
-                    <TableHead className="whitespace-nowrap">{t('table.noteCount')}</TableHead>
+                    <TableHead className="whitespace-nowrap">{t('table.roteCount')}</TableHead>
                     <TableHead className="whitespace-nowrap">
                       {t('table.attachmentCount')}
                     </TableHead>
@@ -293,7 +293,7 @@ export default function UsersTab() {
                           </Badge>
                         )}
                       </TableCell>
-                      <TableCell className="whitespace-nowrap">{user.noteCount ?? 0}</TableCell>
+                      <TableCell className="whitespace-nowrap">{user.roteCount ?? 0}</TableCell>
                       <TableCell className="whitespace-nowrap">
                         {user.attachmentCount ?? 0}
                       </TableCell>

--- a/web/src/pages/filter/index.tsx
+++ b/web/src/pages/filter/index.tsx
@@ -32,14 +32,14 @@ function SideBar() {
       <div className="gap2 flex flex-col items-center justify-center py-4">
         <SlidingNumber
           className="font-mono text-xl font-black"
-          number={statisticsData?.noteCount || 0}
+          number={statisticsData?.roteCount || 0}
         />
         <div className="font-light">{t('note')}</div>
       </div>
       <div className="gap2 flex flex-col items-center justify-center py-4">
         <SlidingNumber
           className="font-mono text-xl font-black"
-          number={statisticsData?.attachmentsCount || 0}
+          number={statisticsData?.attachmentCount || 0}
         />
         <div className="font-light">{t('attachment')}</div>
       </div>

--- a/web/src/types/main.ts
+++ b/web/src/types/main.ts
@@ -224,8 +224,8 @@ export type ApiGetRotesParams = {
 };
 
 export type Statistics = {
-  noteCount: number;
-  attachmentsCount: number;
+  roteCount: number;
+  attachmentCount: number;
   articleCount: number;
 };
 


### PR DESCRIPTION
## Summary
- `userData.ts`: `noteCount` → `roteCount`, `attachmentsCount` → `attachmentCount`
- `admin.ts`: `noteCount` → `roteCount` in `listUsers()`

Aligns API response fields with database table name (`rotes`) and maintains consistency with TypeScript types throughout the codebase.

## Test plan
- [ ] Verify `/v2/api/openkey/statistics` returns `roteCount` instead of `noteCount`
- [ ] Verify `/v2/api/admin/users` returns `roteCount` instead of `noteCount`
- [ ] Update any frontend code that depends on `noteCount` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)