### PR TITLE
feat: improve article creation UX and fix archived note access

### DIFF
--- a/server/utils/dbMethods/note.ts
+++ b/server/utils/dbMethods/note.ts
@@ -977,13 +977,13 @@ export async function getAllPublicRssData(limit = 20): Promise<{ notes: any[] }>
   }
 }
 
-// 根据文章ID查找公开且未归档的笔记（用于文章公开访问）
+// 根据文章ID查找关联的笔记（用于文章公开访问权限检查）
 export async function getNoteByArticleId(articleId: string): Promise<any> {
   try {
     if (!articleId) return null;
-    // 查找公开且未归档且 articleId 匹配的笔记
+    // 查找 articleId 匹配的笔记（不过滤归档状态，归档的公开笔记仍可访问其文章）
     const note = await db.query.rotes.findFirst({
-      where: (rotes, { eq, and }) => and(eq(rotes.articleId, articleId), eq(rotes.archived, false)),
+      where: (rotes, { eq }) => eq(rotes.articleId, articleId),
       with: {
         author: {
           columns: {

--- a/web/src/components/editor/RoteEditor.tsx
+++ b/web/src/components/editor/RoteEditor.tsx
@@ -32,17 +32,23 @@ import { Archive, BookOpen, Globe2, Globe2Icon, PinIcon, Send, X } from 'lucide-
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import 'react-photo-view/dist/react-photo-view.css';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
+import { getArticleFull } from '@/utils/articleApi';
+
 import { ArticleSelectionModal } from '../article/ArticleSelectionModal';
 import { Textarea } from '../ui/textarea';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
 import AttachmentList from './AttachmentList';
 
+// sessionStorage key for article creation context
+export const ARTICLE_CREATION_CONTEXT_KEY = 'article-creation-context';
+
 type RoteAtomType = PrimitiveAtom<Rote>;
 
 function RoteEditor({ roteAtom, callback }: { roteAtom: RoteAtomType; callback?: () => void }) {
   const navigate = useNavigate();
+  const location = useLocation();
   const { t } = useTranslation('translation', {
     keyPrefix: 'components.roteInputSimple',
   });
@@ -157,6 +163,33 @@ function RoteEditor({ roteAtom, callback }: { roteAtom: RoteAtomType; callback?:
       article: null,
     }));
   }, [setRote]);
+
+  // 检测从文章创建页面返回后，自动关联新创建的文章
+  useEffect(() => {
+    const checkNewArticle = async () => {
+      try {
+        const contextStr = sessionStorage.getItem(ARTICLE_CREATION_CONTEXT_KEY);
+        if (!contextStr) return;
+
+        const context = JSON.parse(contextStr);
+        // 检查是否有新创建的文章且返回路径匹配当前路径
+        if (context.newArticleId && context.returnPath === location.pathname) {
+          // 清除上下文
+          sessionStorage.removeItem(ARTICLE_CREATION_CONTEXT_KEY);
+
+          // 获取文章详情并关联
+          const article = await getArticleFull(context.newArticleId);
+          selectArticle(article);
+          toast.success(t('articleLinked'));
+        }
+      } catch {
+        // 解析失败或获取文章失败，清除上下文
+        sessionStorage.removeItem(ARTICLE_CREATION_CONTEXT_KEY);
+      }
+    };
+
+    checkNewArticle();
+  }, [location.pathname, selectArticle, t]);
 
   // 删除附件：先本地移除（乐观），再静默调用后端删除
   const deleteFile = useCallback(
@@ -754,7 +787,12 @@ function RoteEditor({ roteAtom, callback }: { roteAtom: RoteAtomType; callback?:
         onSelect={selectArticle}
         onCreateNew={() => {
           setArticleSelectionOpen(false);
-          navigate('/article/new');
+          // 保存创建上下文，以便创建完成后自动返回并关联
+          sessionStorage.setItem(
+            ARTICLE_CREATION_CONTEXT_KEY,
+            JSON.stringify({ returnPath: location.pathname })
+          );
+          navigate('/article/new?fromRoteEditor=true');
         }}
       />
     </div>

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -836,7 +836,8 @@
       "singleVideoOnly": "Only one video can be uploaded per Rote",
       "imageLimitExceeded": "You can upload up to {{count}} images",
       "unsupportedFileType": "Unsupported file type included",
-      "videoTooLarge": "Video must be {{size}}MB or smaller"
+      "videoTooLarge": "Video must be {{size}}MB or smaller",
+      "articleLinked": "Article linked"
     },
     "roteItem": {
       "details": "Details",

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -836,7 +836,8 @@
       "singleVideoOnly": "1つの Rote には動画を 1 本だけアップロードできます",
       "imageLimitExceeded": "{{count}} 枚まで画像をアップロードできます",
       "unsupportedFileType": "未対応のファイル形式が含まれています",
-      "videoTooLarge": "動画サイズは {{size}}MB 以下にしてください"
+      "videoTooLarge": "動画サイズは {{size}}MB 以下にしてください",
+      "articleLinked": "記事がリンクされました"
     },
     "roteItem": {
       "details": "詳細",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -826,7 +826,8 @@
       "singleVideoOnly": "一个动态最多只能上传 1 个视频",
       "imageLimitExceeded": "最多只能上传 {{count}} 张图片",
       "unsupportedFileType": "包含不支持的文件类型",
-      "videoTooLarge": "视频大小不能超过 {{size}}MB"
+      "videoTooLarge": "视频大小不能超过 {{size}}MB",
+      "articleLinked": "文章已关联"
     },
     "roteItem": {
       "details": "详情",

--- a/web/src/pages/article/edit.tsx
+++ b/web/src/pages/article/edit.tsx
@@ -25,9 +25,10 @@ import {
 import { useEffect, useMemo, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import ReactMarkdown from 'react-markdown';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import remarkGfm from 'remark-gfm';
 import { toast } from 'sonner';
+import { ARTICLE_CREATION_CONTEXT_KEY } from '@/components/editor/RoteEditor';
 
 const CREATE_CACHE_KEY = 'article-create-cache';
 
@@ -36,6 +37,8 @@ export default function ArticleEditPage() {
   const { t: tActions } = useTranslation('translation', { keyPrefix: 'article.actions' });
   const { articleid } = useParams();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const fromRoteEditor = searchParams.get('fromRoteEditor') === 'true';
   const [content, setContent] = useState('');
   const [loading, setLoading] = useState(false);
   const [isInitialLoading, setIsInitialLoading] = useState(!!articleid);
@@ -114,14 +117,35 @@ export default function ArticleEditPage() {
       if (isEditMode && articleid) {
         await updateArticle(articleid, { content });
         toast.success(t('updateSuccess'));
-        // Success, return to previous page
-        navigate(-1);
+        // Success, navigate to article detail page
+        navigate(`/article/${articleid}`, { replace: true });
       } else {
         const created = await createArticle({ content });
         toast.success(t('createSuccess'));
         clearCreateCache();
-        // Success, navigate to article detail or return
-        navigate(`/article/${created.id}`);
+
+        // 如果是从笔记编辑器来的，更新上下文并返回原页面
+        if (fromRoteEditor) {
+          try {
+            const contextStr = sessionStorage.getItem(ARTICLE_CREATION_CONTEXT_KEY);
+            if (contextStr) {
+              const context = JSON.parse(contextStr);
+              // 更新上下文，添加新创建的文章 ID
+              sessionStorage.setItem(
+                ARTICLE_CREATION_CONTEXT_KEY,
+                JSON.stringify({ ...context, newArticleId: created.id })
+              );
+              // 返回原页面
+              navigate(context.returnPath, { replace: true });
+              return;
+            }
+          } catch {
+            // 解析失败，走默认逻辑
+          }
+        }
+
+        // 默认：跳转到文章详情页
+        navigate(`/article/${created.id}`, { replace: true });
       }
     } catch (error: any) {
       const message =


### PR DESCRIPTION
## Summary
- Auto-link article when creating from note editor - eliminates manual steps after article creation
- Fix 404 error when accessing articles linked by archived public notes
- Use replace navigation to prevent returning to empty create page

## Changes
1. **Auto-link article flow**: When creating an article from the note editor, it automatically returns and links the new article
2. **Archived note fix**: Articles linked by archived public notes are now accessible (previously returned 404)

## Test plan
- [ ] Create a note, click "link article", create new article, verify it auto-links after save
- [ ] Archive a public note with linked article, verify the article is still accessible
- [ ] Edit an existing article, verify navigation works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)