### PR TITLE
fix: prioritize public notes in article access lookup

### DIFF
--- a/server/utils/dbMethods/note.ts
+++ b/server/utils/dbMethods/note.ts
@@ -981,9 +981,13 @@ export async function getAllPublicRssData(limit = 20): Promise<{ notes: any[] }>
 export async function getNoteByArticleId(articleId: string): Promise<any> {
   try {
     if (!articleId) return null;
-    // 查找 articleId 匹配的笔记（不过滤归档状态，归档的公开笔记仍可访问其文章）
+    // 查找 articleId 匹配的笔记，优先返回公开笔记（不过滤归档状态）
     const note = await db.query.rotes.findFirst({
       where: (rotes, { eq }) => eq(rotes.articleId, articleId),
+      // 优先返回公开笔记，避免私有笔记先被匹配导致误拒访问
+      orderBy: (rotes, { desc, sql }) => [
+        desc(sql`CASE WHEN ${rotes.state} = 'public' THEN 1 ELSE 0 END`),
+      ],
       with: {
         author: {
           columns: {


### PR DESCRIPTION
## Summary
Fix Codex review feedback: prioritize public notes when looking up article access.

## Changes
When multiple notes reference the same article, the query now prioritizes public notes to avoid incorrectly denying access when a private note is matched first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)