### PR TITLE
feat: passkey (WebAuthn) login and registration

### DIFF
--- a/server/bun.lock
+++ b/server/bun.lock
@@ -8,6 +8,7 @@
         "@aws-sdk/client-s3": "^3.948.0",
         "@aws-sdk/s3-request-presigner": "^3.948.0",
         "@octokit/rest": "^22.0.1",
+        "@simplewebauthn/server": "^13.3.0",
         "drizzle-orm": "^0.45.1",
         "feed": "^5.1.0",
         "hono": "^4.10.8",
@@ -227,6 +228,8 @@
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
 
+    "@hexagon/base64": ["@hexagon/base64@1.1.28", "", {}, "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw=="],
+
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
     "@humanfs/node": ["@humanfs/node@0.16.7", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ=="],
@@ -240,6 +243,8 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
+
+    "@levischuck/tiny-cbor": ["@levischuck/tiny-cbor@0.2.11", "", {}, "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -271,7 +276,35 @@
 
     "@octokit/types": ["@octokit/types@16.0.0", "", { "dependencies": { "@octokit/openapi-types": "^27.0.0" } }, "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg=="],
 
+    "@peculiar/asn1-android": ["@peculiar/asn1-android@2.7.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.7.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-iD3VskhVQnM4nE3PN9cBdPTR7JrqZy3FYk+uD2CeG6DUqKoANqaEfx0f7izPmW+Qm5JBM35ek+viLCmjy18ByQ=="],
+
+    "@peculiar/asn1-cms": ["@peculiar/asn1-cms@2.7.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.7.0", "@peculiar/asn1-x509": "^2.7.0", "@peculiar/asn1-x509-attr": "^2.7.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-hew63shtzzvBcSHbhm+cyAmKe6AIfinT9hzEqSPjDC6opTTMKmTkQ0gHuN2KsWlvqiKw1S/fS94fhag/FJkioQ=="],
+
+    "@peculiar/asn1-csr": ["@peculiar/asn1-csr@2.7.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.7.0", "@peculiar/asn1-x509": "^2.7.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-VVsAyGqErT9D1SY4aEqozThXMVI+ssVRiv2DDeYuvpBKLIgZ3hYs3Ay3u/VSoKq6ESFi9cf6rf3IOOzfwh7oMA=="],
+
+    "@peculiar/asn1-ecc": ["@peculiar/asn1-ecc@2.7.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.7.0", "@peculiar/asn1-x509": "^2.7.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-n7KEs/Q/wrB415cxy4fHOBhegp4NdJ15fkJPwcB/3/8iNBQC2L/N7SChJPKDJPZGYH0jD4Tg4/0vnHmwghnbKw=="],
+
+    "@peculiar/asn1-pfx": ["@peculiar/asn1-pfx@2.7.0", "", { "dependencies": { "@peculiar/asn1-cms": "^2.7.0", "@peculiar/asn1-pkcs8": "^2.7.0", "@peculiar/asn1-rsa": "^2.7.0", "@peculiar/asn1-schema": "^2.7.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-V/nrlQVmhg7lYAsM7E13UDL5erAwFv6kCIVFqNaMIHSVi7dngcT839JkRTkQBqznMG98l2XjxYk74ZztAohZzA=="],
+
+    "@peculiar/asn1-pkcs8": ["@peculiar/asn1-pkcs8@2.7.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.7.0", "@peculiar/asn1-x509": "^2.7.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-9GTl1nE8Mx1kTZ+7QyYatDyKsm34QcWRBFkY1iPvWC3X4Dona5s/tlLiQsx5WzVdZqiMBZNYT0buyw4/vbhnjw=="],
+
+    "@peculiar/asn1-pkcs9": ["@peculiar/asn1-pkcs9@2.7.0", "", { "dependencies": { "@peculiar/asn1-cms": "^2.7.0", "@peculiar/asn1-pfx": "^2.7.0", "@peculiar/asn1-pkcs8": "^2.7.0", "@peculiar/asn1-schema": "^2.7.0", "@peculiar/asn1-x509": "^2.7.0", "@peculiar/asn1-x509-attr": "^2.7.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-Bh7m+OuIaSEllPQcSd9OSp93F4ROWH7sbITWV8MI+8dwsjE5111/87VxiWVvYFKyww3vp39geLv9ENqhwWHcew=="],
+
+    "@peculiar/asn1-rsa": ["@peculiar/asn1-rsa@2.7.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.7.0", "@peculiar/asn1-x509": "^2.7.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-/qvENQrXyTZURjMqSeofHul0JJt2sNSzSwk36pl2olkHbaioMQgrASDZAlHXl0xUlnVbHj0uGgOrBMTb5x2aJQ=="],
+
+    "@peculiar/asn1-schema": ["@peculiar/asn1-schema@2.7.0", "", { "dependencies": { "@peculiar/utils": "^2.0.2", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-W8ZfWzLmQnrcky+eh3tni4IozMdqBDiHWU0N+vve/UGjMaUs8c0L7A2oEdkBXS8rTpWDpK/aoI3DG/L/hxmxPg=="],
+
+    "@peculiar/asn1-x509": ["@peculiar/asn1-x509@2.7.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.7.0", "@peculiar/utils": "^2.0.2", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-mUn9RRrkGDnG4ALfunDmzyRW5dg+sWCj/pfnCCqEHYbkGxEpvUt6iVJv8Yw1cyp6SWZ26ZE5oSmI5SqEaen15g=="],
+
+    "@peculiar/asn1-x509-attr": ["@peculiar/asn1-x509-attr@2.7.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.7.0", "@peculiar/asn1-x509": "^2.7.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-NS8e7SOgXipkzUPLF/sce7ukpMpWjhxYsH0n6Y+bHYo4TTxOb95Zv7hqwSuL212mj5YxovjdOKQOgH1As3E94w=="],
+
+    "@peculiar/utils": ["@peculiar/utils@2.0.3", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ=="],
+
+    "@peculiar/x509": ["@peculiar/x509@1.14.3", "", { "dependencies": { "@peculiar/asn1-cms": "^2.6.0", "@peculiar/asn1-csr": "^2.6.0", "@peculiar/asn1-ecc": "^2.6.0", "@peculiar/asn1-pkcs9": "^2.6.0", "@peculiar/asn1-rsa": "^2.6.0", "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.0", "pvtsutils": "^1.3.6", "reflect-metadata": "^0.2.2", "tslib": "^2.8.1", "tsyringe": "^4.10.0" } }, "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA=="],
+
     "@pkgr/core": ["@pkgr/core@0.2.7", "", {}, "sha512-YLT9Zo3oNPJoBjBc4q8G2mjU4tqIbf5CEOORbUUr48dCD9q3umJ3IPlVqOqDakPfd2HuwccBaqlGhN4Gmr5OWg=="],
+
+    "@simplewebauthn/server": ["@simplewebauthn/server@13.3.0", "", { "dependencies": { "@hexagon/base64": "^1.1.27", "@levischuck/tiny-cbor": "^0.2.2", "@peculiar/asn1-android": "^2.6.0", "@peculiar/asn1-ecc": "^2.6.1", "@peculiar/asn1-rsa": "^2.6.1", "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.1", "@peculiar/x509": "^1.14.3" } }, "sha512-MLHYFrYG8/wK2i+86XMhiecK72nMaHKKt4bo+7Q1TbuG9iGjlSdfkPWKO5ZFE/BX+ygCJ7pr8H/AJeyAj1EaTQ=="],
 
     "@sindresorhus/base62": ["@sindresorhus/base62@1.0.0", "", {}, "sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA=="],
 
@@ -458,6 +491,8 @@
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
     "asn1.js": ["asn1.js@5.4.1", "", { "dependencies": { "bn.js": "^4.0.0", "inherits": "^2.0.1", "minimalistic-assert": "^1.0.0", "safer-buffer": "^2.1.0" } }, "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA=="],
+
+    "asn1js": ["asn1js@3.0.10", "", { "dependencies": { "pvtsutils": "^1.3.6", "pvutils": "^1.1.5", "tslib": "^2.8.1" } }, "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg=="],
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
@@ -917,6 +952,10 @@
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
+    "pvtsutils": ["pvtsutils@1.3.6", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg=="],
+
+    "pvutils": ["pvutils@1.1.5", "", {}, "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA=="],
+
     "quansync": ["quansync@0.2.11", "", {}, "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
@@ -926,6 +965,8 @@
     "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
     "refa": ["refa@0.12.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.8.0" } }, "sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g=="],
+
+    "reflect-metadata": ["reflect-metadata@0.2.2", "", {}, "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="],
 
     "regexp-ast-analysis": ["regexp-ast-analysis@0.7.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.8.0", "refa": "^0.12.1" } }, "sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A=="],
 
@@ -1004,6 +1045,8 @@
     "ts-node": ["ts-node@10.9.2", "", { "dependencies": { "@cspotcode/source-map-support": "^0.8.0", "@tsconfig/node10": "^1.0.7", "@tsconfig/node12": "^1.0.7", "@tsconfig/node14": "^1.0.0", "@tsconfig/node16": "^1.0.2", "acorn": "^8.4.1", "acorn-walk": "^8.1.1", "arg": "^4.1.0", "create-require": "^1.1.0", "diff": "^4.0.1", "make-error": "^1.1.1", "v8-compile-cache-lib": "^3.0.1", "yn": "3.1.1" }, "peerDependencies": { "@swc/core": ">=1.2.50", "@swc/wasm": ">=1.2.50", "@types/node": "*", "typescript": ">=2.7" }, "optionalPeers": ["@swc/core", "@swc/wasm"], "bin": { "ts-node": "dist/bin.js", "ts-script": "dist/bin-script-deprecated.js", "ts-node-cwd": "dist/bin-cwd.js", "ts-node-esm": "dist/bin-esm.js", "ts-node-script": "dist/bin-script.js", "ts-node-transpile-only": "dist/bin-transpile.js" } }, "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "tsyringe": ["tsyringe@4.10.0", "", { "dependencies": { "tslib": "^1.9.3" } }, "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw=="],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
@@ -1168,6 +1211,8 @@
     "toml-eslint-parser/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "ts-declaration-location/picomatch": ["picomatch@4.0.2", "", {}, "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg=="],
+
+    "tsyringe/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
     "vue-eslint-parser/debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
 

--- a/server/drizzle/migrations/0013_fuzzy_payback.sql
+++ b/server/drizzle/migrations/0013_fuzzy_payback.sql
@@ -1,0 +1,17 @@
+CREATE TABLE "user_passkeys" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"userid" uuid NOT NULL,
+	"credentialId" text NOT NULL,
+	"publicKey" "bytea" NOT NULL,
+	"counter" integer DEFAULT 0 NOT NULL,
+	"transports" jsonb,
+	"deviceName" varchar(255) DEFAULT '',
+	"deviceType" varchar(50) DEFAULT '',
+	"createdAt" timestamp (6) with time zone DEFAULT now() NOT NULL,
+	"updatedAt" timestamp (6) with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "user_passkeys_credentialId_unique" UNIQUE("credentialId")
+);
+--> statement-breakpoint
+ALTER TABLE "user_passkeys" ADD CONSTRAINT "user_passkeys_userid_users_id_fk" FOREIGN KEY ("userid") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
+CREATE INDEX "user_passkeys_userid_idx" ON "user_passkeys" USING btree ("userid");--> statement-breakpoint
+CREATE INDEX "user_passkeys_credentialId_idx" ON "user_passkeys" USING btree ("credentialId");

--- a/server/drizzle/migrations/meta/0013_snapshot.json
+++ b/server/drizzle/migrations/meta/0013_snapshot.json
@@ -1,0 +1,1865 @@
+{
+  "id": "edeb3ec7-0bed-4417-a94c-8c5d5fe5d0d9",
+  "prevId": "e772df06-da0d-42a9-b756-c8e3989e28ee",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.articles": {
+      "name": "articles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorId": {
+          "name": "authorId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "articles_authorId_idx": {
+          "name": "articles_authorId_idx",
+          "columns": [
+            {
+              "expression": "authorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "articles_authorId_users_id_fk": {
+          "name": "articles_authorId_users_id_fk",
+          "tableFrom": "articles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "authorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attachments": {
+      "name": "attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compressUrl": {
+          "name": "compressUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "posterUrl": {
+          "name": "posterUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roteid": {
+          "name": "roteid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage": {
+          "name": "storage",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sortIndex": {
+          "name": "sortIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "attachments_userid_idx": {
+          "name": "attachments_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attachments_roteid_idx": {
+          "name": "attachments_roteid_idx",
+          "columns": [
+            {
+              "expression": "roteid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attachments_roteid_sortIndex_idx": {
+          "name": "attachments_roteid_sortIndex_idx",
+          "columns": [
+            {
+              "expression": "roteid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sortIndex",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attachments_userid_users_id_fk": {
+          "name": "attachments_userid_users_id_fk",
+          "tableFrom": "attachments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "attachments_roteid_rotes_id_fk": {
+          "name": "attachments_roteid_rotes_id_fk",
+          "tableFrom": "attachments",
+          "tableTo": "rotes",
+          "columnsFrom": [
+            "roteid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.open_key_usage_logs": {
+      "name": "open_key_usage_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "openKeyId": {
+          "name": "openKeyId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientIp": {
+          "name": "clientIp",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statusCode": {
+          "name": "statusCode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responseTime": {
+          "name": "responseTime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "open_key_usage_logs_openKeyId_idx": {
+          "name": "open_key_usage_logs_openKeyId_idx",
+          "columns": [
+            {
+              "expression": "openKeyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "open_key_usage_logs_createdAt_idx": {
+          "name": "open_key_usage_logs_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "open_key_usage_logs_openKeyId_user_open_keys_id_fk": {
+          "name": "open_key_usage_logs_openKeyId_user_open_keys_id_fk",
+          "tableFrom": "open_key_usage_logs",
+          "tableTo": "user_open_keys",
+          "columnsFrom": [
+            "openKeyId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reactions": {
+      "name": "reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visitorId": {
+          "name": "visitorId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visitorInfo": {
+          "name": "visitorInfo",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roteid": {
+          "name": "roteid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reactions_roteid_type_idx": {
+          "name": "reactions_roteid_type_idx",
+          "columns": [
+            {
+              "expression": "roteid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reactions_userid_idx": {
+          "name": "reactions_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reactions_visitorId_idx": {
+          "name": "reactions_visitorId_idx",
+          "columns": [
+            {
+              "expression": "visitorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reactions_roteid_rotes_id_fk": {
+          "name": "reactions_roteid_rotes_id_fk",
+          "tableFrom": "reactions",
+          "tableTo": "rotes",
+          "columnsFrom": [
+            "roteid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "reactions_userid_users_id_fk": {
+          "name": "reactions_userid_users_id_fk",
+          "tableFrom": "reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_reaction": {
+          "name": "unique_reaction",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userid",
+            "visitorId",
+            "roteid",
+            "type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rote_changes": {
+      "name": "rote_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "originid": {
+          "name": "originid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roteid": {
+          "name": "roteid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CREATE'"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rote_changes_originid_createdAt_idx": {
+          "name": "rote_changes_originid_createdAt_idx",
+          "columns": [
+            {
+              "expression": "originid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rote_changes_originid_action_idx": {
+          "name": "rote_changes_originid_action_idx",
+          "columns": [
+            {
+              "expression": "originid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rote_changes_roteid_createdAt_idx": {
+          "name": "rote_changes_roteid_createdAt_idx",
+          "columns": [
+            {
+              "expression": "roteid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rote_changes_userid_idx": {
+          "name": "rote_changes_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rote_changes_roteid_action_idx": {
+          "name": "rote_changes_roteid_action_idx",
+          "columns": [
+            {
+              "expression": "roteid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rote_changes_roteid_rotes_id_fk": {
+          "name": "rote_changes_roteid_rotes_id_fk",
+          "tableFrom": "rote_changes",
+          "tableTo": "rotes",
+          "columnsFrom": [
+            "roteid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rote_link_previews": {
+      "name": "rote_link_previews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "roteid": {
+          "name": "roteid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "siteName": {
+          "name": "siteName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentExcerpt": {
+          "name": "contentExcerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rote_link_previews_roteid_idx": {
+          "name": "rote_link_previews_roteid_idx",
+          "columns": [
+            {
+              "expression": "roteid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rote_link_previews_roteid_rotes_id_fk": {
+          "name": "rote_link_previews_roteid_rotes_id_fk",
+          "tableFrom": "rote_link_previews",
+          "tableTo": "rotes",
+          "columnsFrom": [
+            "roteid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "rote_link_previews_roteid_url_unique": {
+          "name": "rote_link_previews_roteid_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "roteid",
+            "url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rotes": {
+      "name": "rotes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Rote'"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "authorid": {
+          "name": "authorid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "articleId": {
+          "name": "articleId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pin": {
+          "name": "pin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "editor": {
+          "name": "editor",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'normal'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rotes_authorid_state_idx": {
+          "name": "rotes_authorid_state_idx",
+          "columns": [
+            {
+              "expression": "authorid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rotes_authorid_archived_idx": {
+          "name": "rotes_authorid_archived_idx",
+          "columns": [
+            {
+              "expression": "authorid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rotes_authorid_created_at_idx": {
+          "name": "rotes_authorid_created_at_idx",
+          "columns": [
+            {
+              "expression": "authorid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rotes_tags_idx": {
+          "name": "rotes_tags_idx",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "rotes_articleId_idx": {
+          "name": "rotes_articleId_idx",
+          "columns": [
+            {
+              "expression": "articleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rotes_authorid_users_id_fk": {
+          "name": "rotes_authorid_users_id_fk",
+          "tableFrom": "rotes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "authorid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "rotes_articleId_articles_id_fk": {
+          "name": "rotes_articleId_articles_id_fk",
+          "tableFrom": "rotes",
+          "tableTo": "articles",
+          "columnsFrom": [
+            "articleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group": {
+          "name": "group",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isRequired": {
+          "name": "isRequired",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isInitialized": {
+          "name": "isInitialized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isSystem": {
+          "name": "isSystem",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "settings_isRequired_idx": {
+          "name": "settings_isRequired_idx",
+          "columns": [
+            {
+              "expression": "isRequired",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "settings_isInitialized_idx": {
+          "name": "settings_isInitialized_idx",
+          "columns": [
+            {
+              "expression": "isInitialized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "settings_isSystem_idx": {
+          "name": "settings_isSystem_idx",
+          "columns": [
+            {
+              "expression": "isSystem",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "settings_group_unique": {
+          "name": "settings_group_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_oauth_bindings": {
+      "name": "user_oauth_bindings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerUsername": {
+          "name": "providerUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_oauth_bindings_userid_idx": {
+          "name": "user_oauth_bindings_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_oauth_bindings_provider_idx": {
+          "name": "user_oauth_bindings_provider_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_oauth_bindings_providerId_idx": {
+          "name": "user_oauth_bindings_providerId_idx",
+          "columns": [
+            {
+              "expression": "providerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_oauth_bindings_userid_users_id_fk": {
+          "name": "user_oauth_bindings_userid_users_id_fk",
+          "tableFrom": "user_oauth_bindings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_provider": {
+          "name": "unique_user_provider",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userid",
+            "provider"
+          ]
+        },
+        "unique_provider_id": {
+          "name": "unique_provider_id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider",
+            "providerId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_open_keys": {
+      "name": "user_open_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"SENDROTE\"}'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_open_keys_userid_idx": {
+          "name": "user_open_keys_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_open_keys_userid_users_id_fk": {
+          "name": "user_open_keys_userid_users_id_fk",
+          "tableFrom": "user_open_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_passkeys": {
+      "name": "user_passkeys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentialId": {
+          "name": "credentialId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "transports": {
+          "name": "transports",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deviceName": {
+          "name": "deviceName",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "deviceType": {
+          "name": "deviceType",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_passkeys_userid_idx": {
+          "name": "user_passkeys_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_passkeys_credentialId_idx": {
+          "name": "user_passkeys_credentialId_idx",
+          "columns": [
+            {
+              "expression": "credentialId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_passkeys_userid_users_id_fk": {
+          "name": "user_passkeys_userid_users_id_fk",
+          "tableFrom": "user_passkeys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_passkeys_credentialId_unique": {
+          "name": "user_passkeys_credentialId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credentialId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "darkmode": {
+          "name": "darkmode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "allowExplore": {
+          "name": "allowExplore",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_settings_userid_idx": {
+          "name": "user_settings_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_settings_userid_users_id_fk": {
+          "name": "user_settings_userid_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_settings_userid_unique": {
+          "name": "user_settings_userid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_sw_subscriptions": {
+      "name": "user_sw_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "expirationTime": {
+          "name": "expirationTime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keys": {
+          "name": "keys",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_sw_subscriptions_userid_idx": {
+          "name": "user_sw_subscriptions_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_sw_subscriptions_endpoint_idx": {
+          "name": "user_sw_subscriptions_endpoint_idx",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_sw_subscriptions_userid_users_id_fk": {
+          "name": "user_sw_subscriptions_userid_users_id_fk",
+          "tableFrom": "user_sw_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_sw_subscriptions_endpoint_unique": {
+          "name": "user_sw_subscriptions_endpoint_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "endpoint"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "passwordhash": {
+          "name": "passwordhash",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salt": {
+          "name": "salt",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover": {
+          "name": "cover",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_username_idx": {
+          "name": "users_username_idx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/drizzle/migrations/meta/_journal.json
+++ b/server/drizzle/migrations/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1774848020569,
       "tag": "0012_video_poster_support",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1779428594602,
+      "tag": "0013_fuzzy_payback",
+      "breakpoints": true
     }
   ]
 }

--- a/server/drizzle/schema.ts
+++ b/server/drizzle/schema.ts
@@ -390,6 +390,33 @@ export const userOAuthBindings = pgTable(
   })
 );
 
+// User Passkeys 表 - WebAuthn/FIDO2 凭证
+export const userPasskeys = pgTable(
+  'user_passkeys',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    userid: uuid('userid').notNull(),
+    credentialId: text('credentialId').notNull().unique(),
+    publicKey: bytea('publicKey').notNull(),
+    counter: integer('counter').notNull().default(0),
+    transports: jsonb('transports'), // ["internal", "hybrid", "ble", "nfc", "usb"]
+    deviceName: varchar('deviceName', { length: 255 }).default(''),
+    deviceType: varchar('deviceType', { length: 50 }).default(''), // "platform" or "cross-platform"
+    createdAt: timestamp('createdAt', { withTimezone: true, precision: 6 }).notNull().defaultNow(),
+    updatedAt: timestamp('updatedAt', { withTimezone: true, precision: 6 }).notNull().defaultNow(),
+  },
+  (table) => ({
+    useridIdx: index('user_passkeys_userid_idx').on(table.userid),
+    credentialIdIdx: index('user_passkeys_credentialId_idx').on(table.credentialId),
+    useridFk: foreignKey({
+      columns: [table.userid],
+      foreignColumns: [users.id],
+    })
+      .onDelete('cascade')
+      .onUpdate('cascade'),
+  })
+);
+
 // 关系定义
 export const usersRelations = relations(users, ({ one, many }) => ({
   attachments: many(attachments),
@@ -403,6 +430,7 @@ export const usersRelations = relations(users, ({ one, many }) => ({
   }),
   userswsubscription: many(userSwSubscriptions),
   oauthBindings: many(userOAuthBindings),
+  passkeys: many(userPasskeys),
 }));
 
 export const userSettingsRelations = relations(userSettings, ({ one }) => ({
@@ -500,6 +528,13 @@ export const userOAuthBindingsRelations = relations(userOAuthBindings, ({ one })
   }),
 }));
 
+export const userPasskeysRelations = relations(userPasskeys, ({ one }) => ({
+  user: one(users, {
+    fields: [userPasskeys.userid],
+    references: [users.id],
+  }),
+}));
+
 // 导出类型
 export type User = typeof users.$inferSelect;
 export type NewUser = typeof users.$inferInsert;
@@ -527,3 +562,5 @@ export type UserOAuthBinding = typeof userOAuthBindings.$inferSelect;
 export type NewUserOAuthBinding = typeof userOAuthBindings.$inferInsert;
 export type OpenKeyUsageLog = typeof openKeyUsageLogs.$inferSelect;
 export type NewOpenKeyUsageLog = typeof openKeyUsageLogs.$inferInsert;
+export type UserPasskey = typeof userPasskeys.$inferSelect;
+export type NewUserPasskey = typeof userPasskeys.$inferInsert;

--- a/server/package.json
+++ b/server/package.json
@@ -42,6 +42,7 @@
     "@aws-sdk/client-s3": "^3.948.0",
     "@aws-sdk/s3-request-presigner": "^3.948.0",
     "@octokit/rest": "^22.0.1",
+    "@simplewebauthn/server": "^13.3.0",
     "drizzle-orm": "^0.45.1",
     "feed": "^5.1.0",
     "hono": "^4.10.8",

--- a/server/route/v2/auth.ts
+++ b/server/route/v2/auth.ts
@@ -5,12 +5,15 @@ import {
   type RegistrationResponseJSON,
 } from '@simplewebauthn/server';
 import { Hono } from 'hono';
+import { eq, or } from 'drizzle-orm';
+import { users, userPasskeys } from '../../drizzle/schema';
 import type { User } from '../../drizzle/schema';
 import { requireSecurityConfig } from '../../middleware/configCheck';
 import { authenticateJWT } from '../../middleware/jwtAuth';
 import type { SecurityConfig, SiteConfig, UiConfig } from '../../types/config';
 import type { HonoContext, HonoVariables } from '../../types/hono';
 import { getConfig, getGlobalConfig } from '../../utils/config';
+import db from '../../utils/drizzle';
 import { changeUserPassword, createUser, oneUser, passportCheckUser } from '../../utils/dbMethods';
 import { generateAccessToken, generateRefreshToken, verifyRefreshToken } from '../../utils/jwt';
 import { createResponse, sanitizeUserData } from '../../utils/main';
@@ -20,12 +23,19 @@ import { passwordChangeZod, RegisterDataZod } from '../../utils/zod';
 const authRouter = new Hono<{ Variables: HonoVariables }>();
 
 // 无密码注册 - 临时存储 (registrationToken → { userData, challenge, expiresAt })
-const pendingRegistrations = new Map<
-  string,
-  { userData: any; challenge: string; expiresAt: number }
->();
+interface PendingRegistration {
+  userData: { username: string; email: string; nickname: string; tempUserId: string };
+  challenge: string;
+  expiresAt: number;
+}
 
-function storePendingRegistration(token: string, userData: any, challenge: string) {
+const pendingRegistrations = new Map<string, PendingRegistration>();
+
+function storePendingRegistration(
+  token: string,
+  userData: PendingRegistration['userData'],
+  challenge: string
+) {
   if (pendingRegistrations.size > 500) {
     const now = Date.now();
     for (const [k, v] of pendingRegistrations) {
@@ -123,9 +133,6 @@ authRouter.post('/register/passkey/options', async (c: HonoContext) => {
   RegisterDataZod.parse({ username, email, nickname, password: undefined });
 
   // Check username/email uniqueness early
-  const { users } = await import('../../drizzle/schema');
-  const db = (await import('../../utils/drizzle')).default;
-  const { eq, or } = await import('drizzle-orm');
   const existing = await db
     .select({ id: users.id })
     .from(users)
@@ -180,10 +187,10 @@ authRouter.post('/register/passkey/options', async (c: HonoContext) => {
 // 无密码注册 - Step 2: 验证 passkey，创建账号
 authRouter.post('/register/passkey/verify', async (c: HonoContext) => {
   const body = await c.req.json();
-  const { credential, registrationToken, deviceType } = body as {
+  const { credential, registrationToken, deviceName } = body as {
     credential: RegistrationResponseJSON;
     registrationToken: string;
-    deviceType?: string;
+    deviceName?: string;
   };
 
   const pending = getAndDeletePendingRegistration(registrationToken);
@@ -218,8 +225,6 @@ authRouter.post('/register/passkey/verify', async (c: HonoContext) => {
   const { userData } = pending;
 
   // Create user + passkey atomically in a transaction
-  const db = (await import('../../utils/drizzle')).default;
-  const { users, userPasskeys } = await import('../../drizzle/schema');
   const { defaultUserRole } = (await getConfig<UiConfig>('ui')) || {};
 
   const result = await db.transaction(async (tx) => {
@@ -251,7 +256,7 @@ authRouter.post('/register/passkey/verify', async (c: HonoContext) => {
         publicKey: Buffer.from(regCredential.publicKey),
         counter: regCredential.counter,
         transports: credential.response?.transports as string[] | undefined,
-        deviceType: deviceType || '',
+        deviceName: deviceName || '',
       })
       .returning();
 

--- a/server/route/v2/auth.ts
+++ b/server/route/v2/auth.ts
@@ -1,11 +1,16 @@
 import crypto from 'crypto';
+import {
+  generateRegistrationOptions,
+  verifyRegistrationResponse,
+  type RegistrationResponseJSON,
+} from '@simplewebauthn/server';
 import { Hono } from 'hono';
 import type { User } from '../../drizzle/schema';
 import { requireSecurityConfig } from '../../middleware/configCheck';
 import { authenticateJWT } from '../../middleware/jwtAuth';
-import type { UiConfig } from '../../types/config';
+import type { SecurityConfig, SiteConfig, UiConfig } from '../../types/config';
 import type { HonoContext, HonoVariables } from '../../types/hono';
-import { getConfig } from '../../utils/config';
+import { getConfig, getGlobalConfig } from '../../utils/config';
 import { changeUserPassword, createUser, oneUser, passportCheckUser } from '../../utils/dbMethods';
 import { generateAccessToken, generateRefreshToken, verifyRefreshToken } from '../../utils/jwt';
 import { createResponse, sanitizeUserData } from '../../utils/main';
@@ -13,6 +18,32 @@ import { passwordChangeZod, RegisterDataZod } from '../../utils/zod';
 
 // 认证相关路由
 const authRouter = new Hono<{ Variables: HonoVariables }>();
+
+// 无密码注册 - 临时存储 (registrationToken → { userData, challenge, expiresAt })
+const pendingRegistrations = new Map<
+  string,
+  { userData: any; challenge: string; expiresAt: number }
+>();
+
+function storePendingRegistration(token: string, userData: any, challenge: string) {
+  if (pendingRegistrations.size > 500) {
+    const now = Date.now();
+    for (const [k, v] of pendingRegistrations) {
+      if (now > v.expiresAt) pendingRegistrations.delete(k);
+    }
+  }
+  pendingRegistrations.set(token, { userData, challenge, expiresAt: Date.now() + 300_000 });
+}
+
+function getAndDeletePendingRegistration(token: string) {
+  const entry = pendingRegistrations.get(token);
+  if (!entry || Date.now() > entry.expiresAt) {
+    pendingRegistrations.delete(token);
+    return null;
+  }
+  pendingRegistrations.delete(token);
+  return entry;
+}
 
 // 注册
 authRouter.post('/register', async (c: HonoContext) => {
@@ -24,6 +55,13 @@ authRouter.post('/register', async (c: HonoContext) => {
 
   const body = await c.req.json();
   const { username, password, email, nickname } = body;
+
+  // If passkey is disabled, password is required
+  const securityConfig = getGlobalConfig<SecurityConfig>('security');
+  const passkeyEnabled = securityConfig?.passkey?.enabled !== false;
+  if (!passkeyEnabled && !password) {
+    return c.json(createResponse(null, 'Password is required when passkey is disabled', 400), 400);
+  }
 
   RegisterDataZod.parse(body);
 
@@ -42,8 +80,202 @@ authRouter.post('/register', async (c: HonoContext) => {
     throw new Error('Registration failed, username or email already exists');
   }
 
+  // Generate JWT tokens so the user is immediately logged in (supports passkey registration during signup)
+  const accessToken = await generateAccessToken({
+    userId: user.id,
+    username: user.username,
+  });
+  const refreshToken = await generateRefreshToken({
+    userId: user.id,
+    username: user.username,
+  });
+
   const sanitizedUser = sanitizeUserData(user);
-  return c.json(createResponse(sanitizedUser), 201);
+  return c.json(
+    createResponse(
+      {
+        user: sanitizedUser,
+        accessToken,
+        refreshToken,
+      },
+      'Registration successful'
+    ),
+    201
+  );
+});
+
+// 无密码注册 - Step 1: 验证用户数据，生成 passkey 注册 options
+authRouter.post('/register/passkey/options', async (c: HonoContext) => {
+  const uiConfig = await getConfig<UiConfig>('ui');
+  if (uiConfig && uiConfig.allowRegistration === false) {
+    return c.json(createResponse(null, 'Registration is currently disabled'), 403);
+  }
+
+  const securityConfig = getGlobalConfig<SecurityConfig>('security');
+  if (securityConfig?.passkey?.enabled === false) {
+    return c.json(createResponse(null, 'Passkey is disabled', 400), 400);
+  }
+
+  const body = await c.req.json();
+  const { username, email, nickname } = body;
+
+  // Validate user data (no password)
+  RegisterDataZod.parse({ username, email, nickname, password: undefined });
+
+  // Check username/email uniqueness early
+  const { users } = await import('../../drizzle/schema');
+  const db = (await import('../../utils/drizzle')).default;
+  const { eq, or } = await import('drizzle-orm');
+  const existing = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(or(eq(users.username, username), eq(users.email, email)))
+    .limit(1);
+  if (existing.length > 0) {
+    return c.json(createResponse(null, 'Username or email already exists', 409), 409);
+  }
+
+  // Generate temp user ID for WebAuthn
+  const tempUserId = crypto.randomUUID();
+
+  // Get passkey config
+  const origin = c.req.header('origin');
+  const siteConfig = await getConfig<SiteConfig>('site');
+  const passkeyCfg = securityConfig?.passkey;
+  const frontendUrl = origin || siteConfig?.frontendUrl || 'http://localhost:3001';
+  const url = new URL(frontendUrl);
+  let rpId = passkeyCfg?.rpId || url.hostname;
+  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(rpId) || rpId === 'localhost') rpId = 'localhost';
+  const rpName = passkeyCfg?.rpName || siteConfig?.name || 'Rote';
+
+  const options = await generateRegistrationOptions({
+    rpName,
+    rpID: rpId,
+    userName: email || username,
+    userDisplayName: nickname || username,
+    excludeCredentials: [],
+    authenticatorSelection: {
+      residentKey: 'preferred',
+      userVerification: 'preferred',
+    },
+  });
+
+  // Store pending registration
+  const registrationToken = crypto.randomUUID();
+  storePendingRegistration(
+    registrationToken,
+    { username, email, nickname, tempUserId },
+    options.challenge
+  );
+
+  return c.json(
+    createResponse({
+      options,
+      registrationToken,
+    }),
+    200
+  );
+});
+
+// 无密码注册 - Step 2: 验证 passkey，创建账号
+authRouter.post('/register/passkey/verify', async (c: HonoContext) => {
+  const body = await c.req.json();
+  const { credential, registrationToken, deviceType } = body as {
+    credential: RegistrationResponseJSON;
+    registrationToken: string;
+    deviceType?: string;
+  };
+
+  const pending = getAndDeletePendingRegistration(registrationToken);
+  if (!pending) {
+    return c.json(createResponse(null, 'Registration expired or invalid', 400), 400);
+  }
+
+  // Get passkey config for origin/RP verification
+  const origin = c.req.header('origin');
+  const siteConfig = await getConfig<SiteConfig>('site');
+  const securityConfig = getGlobalConfig<SecurityConfig>('security');
+  const passkeyCfg = securityConfig?.passkey;
+  const frontendUrl = origin || siteConfig?.frontendUrl || 'http://localhost:3001';
+  const url = new URL(frontendUrl);
+  let rpId = passkeyCfg?.rpId || url.hostname;
+  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(rpId) || rpId === 'localhost') rpId = 'localhost';
+  const expectedOrigin = passkeyCfg?.origin || frontendUrl;
+
+  // Verify passkey
+  const verification = await verifyRegistrationResponse({
+    response: credential,
+    expectedChallenge: pending.challenge,
+    expectedOrigin,
+    expectedRPID: rpId,
+  });
+
+  if (!verification.verified || !verification.registrationInfo) {
+    return c.json(createResponse(null, 'Passkey verification failed', 400), 400);
+  }
+
+  const { credential: regCredential } = verification.registrationInfo;
+  const { userData } = pending;
+
+  // Create user + passkey atomically in a transaction
+  const db = (await import('../../utils/drizzle')).default;
+  const { users, userPasskeys } = await import('../../drizzle/schema');
+  const { defaultUserRole } = (await getConfig<UiConfig>('ui')) || {};
+
+  const result = await db.transaction(async (tx) => {
+    // Create user (no password)
+    const salt = crypto.randomBytes(16);
+    const userId = crypto.randomUUID();
+    const [user] = await tx
+      .insert(users)
+      .values({
+        id: userId,
+        username: userData.username,
+        email: userData.email,
+        nickname: userData.nickname,
+        passwordhash: null,
+        salt,
+        role: defaultUserRole || 'user',
+        emailVerified: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .returning();
+
+    // Create passkey
+    const [passkey] = await tx
+      .insert(userPasskeys)
+      .values({
+        userid: user.id,
+        credentialId: regCredential.id,
+        publicKey: Buffer.from(regCredential.publicKey),
+        counter: regCredential.counter,
+        transports: credential.response?.transports as string[] | undefined,
+        deviceType: deviceType || '',
+      })
+      .returning();
+
+    return { user, passkey };
+  });
+
+  // Generate JWT tokens
+  const accessToken = await generateAccessToken({
+    userId: result.user.id,
+    username: result.user.username,
+  });
+  const refreshToken = await generateRefreshToken({
+    userId: result.user.id,
+    username: result.user.username,
+  });
+
+  return c.json(
+    createResponse({
+      user: sanitizeUserData(result.user),
+      accessToken,
+      refreshToken,
+    }),
+    201
+  );
 });
 
 // 登录 (手动实现，不再使用 Passport)

--- a/server/route/v2/auth.ts
+++ b/server/route/v2/auth.ts
@@ -151,8 +151,7 @@ authRouter.post('/register/passkey/options', async (c: HonoContext) => {
   const passkeyCfg = securityConfig?.passkey;
   const frontendUrl = origin || siteConfig?.frontendUrl || 'http://localhost:3001';
   const url = new URL(frontendUrl);
-  let rpId = passkeyCfg?.rpId || url.hostname;
-  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(rpId) || rpId === 'localhost') rpId = 'localhost';
+  const rpId = passkeyCfg?.rpId || url.hostname;
   const rpName = passkeyCfg?.rpName || siteConfig?.name || 'Rote';
 
   const options = await generateRegistrationOptions({
@@ -162,7 +161,7 @@ authRouter.post('/register/passkey/options', async (c: HonoContext) => {
     userDisplayName: nickname || username,
     excludeCredentials: [],
     authenticatorSelection: {
-      residentKey: 'preferred',
+      residentKey: 'required',
       userVerification: 'preferred',
     },
   });
@@ -205,8 +204,7 @@ authRouter.post('/register/passkey/verify', async (c: HonoContext) => {
   const passkeyCfg = securityConfig?.passkey;
   const frontendUrl = origin || siteConfig?.frontendUrl || 'http://localhost:3001';
   const url = new URL(frontendUrl);
-  let rpId = passkeyCfg?.rpId || url.hostname;
-  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(rpId) || rpId === 'localhost') rpId = 'localhost';
+  const rpId = passkeyCfg?.rpId || url.hostname;
   const expectedOrigin = passkeyCfg?.origin || frontendUrl;
 
   // Verify passkey

--- a/server/route/v2/index.ts
+++ b/server/route/v2/index.ts
@@ -13,6 +13,7 @@ import notesRouter from './note';
 import notificationsRouter from './notification';
 import oauthRouter from './oauth';
 import openKeyRouter from './openKeyRouter';
+import passkeyRouter from './passkey';
 import reactionsRouter from './reaction';
 import siteRouter from './site';
 import subscriptionsRouter from './subscription';
@@ -112,6 +113,7 @@ router.get('/rss/:username', async (c: HonoContext) => {
 // 注册子路由
 router.route('/auth', authRouter);
 router.route('/auth/oauth', oauthRouter);
+router.route('/auth/passkey', passkeyRouter);
 router.route('/users', usersRouter);
 router.route('/notes', notesRouter);
 router.route('/articles', articlesRouter);

--- a/server/route/v2/passkey.ts
+++ b/server/route/v2/passkey.ts
@@ -123,9 +123,9 @@ passkeyRouter.post('/register/options', authenticateJWT, async (c: HonoContext) 
 passkeyRouter.post('/register/verify', authenticateJWT, async (c: HonoContext) => {
   const user = c.get('user') as User;
   const body = await c.req.json();
-  const { credential, deviceType } = body as {
+  const { credential, deviceName } = body as {
     credential: RegistrationResponseJSON;
-    deviceType?: string;
+    deviceName?: string;
   };
 
   const origin = c.req.header('origin');
@@ -155,7 +155,7 @@ passkeyRouter.post('/register/verify', authenticateJWT, async (c: HonoContext) =
     publicKey: Buffer.from(regCredential.publicKey),
     counter: regCredential.counter,
     transports: credential.response?.transports as string[] | undefined,
-    deviceType: deviceType || '',
+    deviceName: deviceName || '',
   });
 
   return c.json(createResponse(null, 'Passkey registered successfully'), 200);
@@ -271,7 +271,7 @@ passkeyRouter.delete('/:id', authenticateJWT, async (c: HonoContext) => {
     return c.json(
       createResponse(
         null,
-        'Cannot delete: this is your last login method. Please set up a password or another login method first.',
+        'Cannot delete passkey: it is your only login method. Add a password or another passkey first.',
         400
       ),
       400

--- a/server/route/v2/passkey.ts
+++ b/server/route/v2/passkey.ts
@@ -63,11 +63,7 @@ async function getPasskeyConfig(requestOrigin?: string) {
   const frontendUrl = requestOrigin || siteConfig?.frontendUrl || 'http://localhost:3001';
   const url = new URL(frontendUrl);
 
-  // RP ID cannot be an IP address — use 'localhost' for IP-based or localhost URLs
-  let rpId = passkeyConfig?.rpId || url.hostname;
-  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(rpId) || rpId === 'localhost') {
-    rpId = 'localhost';
-  }
+  const rpId = passkeyConfig?.rpId || url.hostname;
 
   return {
     enabled: passkeyConfig?.enabled !== false,
@@ -108,7 +104,7 @@ passkeyRouter.post('/register/options', authenticateJWT, async (c: HonoContext) 
     userDisplayName: user.nickname || user.username,
     excludeCredentials,
     authenticatorSelection: {
-      residentKey: 'preferred',
+      residentKey: 'required',
       userVerification: 'preferred',
     },
   });

--- a/server/route/v2/passkey.ts
+++ b/server/route/v2/passkey.ts
@@ -1,0 +1,285 @@
+import crypto from 'crypto';
+import {
+  generateAuthenticationOptions,
+  generateRegistrationOptions,
+  verifyAuthenticationResponse,
+  verifyRegistrationResponse,
+  type AuthenticatorTransportFuture,
+  type RegistrationResponseJSON,
+  type AuthenticationResponseJSON,
+} from '@simplewebauthn/server';
+import { Hono } from 'hono';
+import type { User } from '../../drizzle/schema';
+import { authenticateJWT } from '../../middleware/jwtAuth';
+import type { SecurityConfig, SiteConfig } from '../../types/config';
+import type { HonoContext, HonoVariables } from '../../types/hono';
+import { getConfig, getGlobalConfig } from '../../utils/config';
+import {
+  createUserPasskey,
+  deleteUserPasskey,
+  getPasskeyByCredentialId,
+  getUserPasskeys,
+  hasOtherLoginMethods,
+  updatePasskeyCounter,
+} from '../../utils/dbMethods';
+import { oneUser } from '../../utils/dbMethods/user';
+import { generateAccessToken, generateRefreshToken } from '../../utils/jwt';
+import { createResponse, sanitizeUserData } from '../../utils/main';
+
+const passkeyRouter = new Hono<{ Variables: HonoVariables }>();
+
+// In-memory challenge store with 2-minute TTL
+const challengeStore = new Map<string, { challenge: string; expiresAt: number }>();
+
+function storeChallenge(key: string, challenge: string) {
+  // Clean up expired entries periodically
+  if (challengeStore.size > 1000) {
+    const now = Date.now();
+    for (const [k, v] of challengeStore) {
+      if (now > v.expiresAt) challengeStore.delete(k);
+    }
+  }
+  challengeStore.set(key, { challenge, expiresAt: Date.now() + 120_000 });
+}
+
+function getAndDeleteChallenge(key: string): string | null {
+  const entry = challengeStore.get(key);
+  if (!entry || Date.now() > entry.expiresAt) {
+    challengeStore.delete(key);
+    return null;
+  }
+  challengeStore.delete(key);
+  return entry.challenge;
+}
+
+// Resolve passkey RP config from site config
+async function getPasskeyConfig(requestOrigin?: string) {
+  const siteConfig = await getConfig<SiteConfig>('site');
+  const securityConfig = getGlobalConfig<SecurityConfig>('security');
+  const passkeyConfig = securityConfig?.passkey;
+
+  // Use the actual request origin if provided (browser's Origin header)
+  // This handles cases where user accesses via localhost but frontendUrl is configured differently
+  const frontendUrl = requestOrigin || siteConfig?.frontendUrl || 'http://localhost:3001';
+  const url = new URL(frontendUrl);
+
+  // RP ID cannot be an IP address — use 'localhost' for IP-based or localhost URLs
+  let rpId = passkeyConfig?.rpId || url.hostname;
+  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(rpId) || rpId === 'localhost') {
+    rpId = 'localhost';
+  }
+
+  return {
+    enabled: passkeyConfig?.enabled !== false,
+    rpName: passkeyConfig?.rpName || siteConfig?.name || 'Rote',
+    rpId,
+    origin: passkeyConfig?.origin || frontendUrl,
+  };
+}
+
+// GET /config - public endpoint to check if passkeys are enabled
+passkeyRouter.get('/config', async (c: HonoContext) => {
+  const origin = c.req.header('origin');
+  const config = await getPasskeyConfig(origin || undefined);
+  return c.json(createResponse({ enabled: config.enabled, rpName: config.rpName }), 200);
+});
+
+// POST /register/options - generate registration options (requires JWT)
+passkeyRouter.post('/register/options', authenticateJWT, async (c: HonoContext) => {
+  const user = c.get('user') as User;
+
+  const origin = c.req.header('origin');
+  const config = await getPasskeyConfig(origin || undefined);
+  if (!config.enabled) {
+    return c.json(createResponse(null, 'Passkeys are disabled', 403), 403);
+  }
+
+  // Get user's existing credential IDs to exclude
+  const existingPasskeys = await getUserPasskeys(user.id);
+  const excludeCredentials = existingPasskeys.map((pk) => ({
+    id: pk.credentialId,
+    transports: (pk.transports as AuthenticatorTransportFuture[]) || [],
+  }));
+
+  const options = await generateRegistrationOptions({
+    rpName: config.rpName,
+    rpID: config.rpId,
+    userName: user.email || user.username,
+    userDisplayName: user.nickname || user.username,
+    excludeCredentials,
+    authenticatorSelection: {
+      residentKey: 'preferred',
+      userVerification: 'preferred',
+    },
+  });
+
+  // Store challenge keyed by userId
+  storeChallenge(`reg:${user.id}`, options.challenge);
+
+  return c.json(createResponse({ options }), 200);
+});
+
+// POST /register/verify - verify registration and store credential (requires JWT)
+passkeyRouter.post('/register/verify', authenticateJWT, async (c: HonoContext) => {
+  const user = c.get('user') as User;
+  const body = await c.req.json();
+  const { credential, deviceType } = body as {
+    credential: RegistrationResponseJSON;
+    deviceType?: string;
+  };
+
+  const origin = c.req.header('origin');
+  const config = await getPasskeyConfig(origin || undefined);
+
+  const expectedChallenge = getAndDeleteChallenge(`reg:${user.id}`);
+  if (!expectedChallenge) {
+    return c.json(createResponse(null, 'Challenge expired or not found', 400), 400);
+  }
+
+  const verification = await verifyRegistrationResponse({
+    response: credential,
+    expectedChallenge,
+    expectedOrigin: config.origin,
+    expectedRPID: config.rpId,
+  });
+
+  if (!verification.verified || !verification.registrationInfo) {
+    return c.json(createResponse(null, 'Registration verification failed', 400), 400);
+  }
+
+  const { credential: regCredential } = verification.registrationInfo;
+
+  await createUserPasskey({
+    userid: user.id,
+    credentialId: regCredential.id,
+    publicKey: Buffer.from(regCredential.publicKey),
+    counter: regCredential.counter,
+    transports: credential.response?.transports as string[] | undefined,
+    deviceType: deviceType || '',
+  });
+
+  return c.json(createResponse(null, 'Passkey registered successfully'), 200);
+});
+
+// POST /authenticate/options - generate authentication options (public)
+passkeyRouter.post('/authenticate/options', async (c: HonoContext) => {
+  const origin = c.req.header('origin');
+  const config = await getPasskeyConfig(origin || undefined);
+  if (!config.enabled) {
+    return c.json(createResponse(null, 'Passkeys are disabled', 403), 403);
+  }
+
+  const options = await generateAuthenticationOptions({
+    rpID: config.rpId,
+    userVerification: 'preferred',
+    // allowCredentials: [] allows discoverable credentials (passkeys without username)
+  });
+
+  // Store challenge with a random key (returned to client for verify)
+  const challengeKey = crypto.randomUUID();
+  storeChallenge(`auth:${challengeKey}`, options.challenge);
+
+  return c.json(createResponse({ options, challengeKey }), 200);
+});
+
+// POST /authenticate/verify - verify authentication and return JWT tokens (public)
+passkeyRouter.post('/authenticate/verify', async (c: HonoContext) => {
+  const body = await c.req.json();
+  const { credential, challengeKey } = body as {
+    credential: AuthenticationResponseJSON;
+    challengeKey: string;
+  };
+
+  const origin = c.req.header('origin');
+  const config = await getPasskeyConfig(origin || undefined);
+
+  const expectedChallenge = getAndDeleteChallenge(`auth:${challengeKey}`);
+  if (!expectedChallenge) {
+    return c.json(createResponse(null, 'Challenge expired or not found', 400), 400);
+  }
+
+  // Look up the passkey by credential ID
+  const passkey = await getPasskeyByCredentialId(credential.id);
+  if (!passkey) {
+    return c.json(createResponse(null, 'Passkey not found', 404), 404);
+  }
+
+  const verification = await verifyAuthenticationResponse({
+    response: credential,
+    expectedChallenge,
+    expectedOrigin: config.origin,
+    expectedRPID: config.rpId,
+    credential: {
+      id: passkey.credentialId,
+      publicKey: new Uint8Array(passkey.publicKey),
+      counter: passkey.counter,
+      transports: (passkey.transports as AuthenticatorTransportFuture[]) || [],
+    },
+  });
+
+  if (!verification.verified) {
+    return c.json(createResponse(null, 'Authentication verification failed', 400), 400);
+  }
+
+  // Update counter
+  await updatePasskeyCounter(passkey.credentialId, verification.authenticationInfo.newCounter);
+
+  // Get the user
+  const user = await oneUser(passkey.userid);
+  if (!user) {
+    return c.json(createResponse(null, 'User not found', 404), 404);
+  }
+
+  // Generate JWT tokens (same as password login)
+  const accessToken = await generateAccessToken({
+    userId: user.id,
+    username: user.username,
+  });
+  const refreshToken = await generateRefreshToken({
+    userId: user.id,
+    username: user.username,
+  });
+
+  return c.json(
+    createResponse(
+      {
+        user: sanitizeUserData(user),
+        accessToken,
+        refreshToken,
+      },
+      'Passkey authentication successful'
+    ),
+    200
+  );
+});
+
+// GET / - list user's passkeys (requires JWT)
+passkeyRouter.get('/', authenticateJWT, async (c: HonoContext) => {
+  const user = c.get('user') as User;
+  const passkeys = await getUserPasskeys(user.id);
+  return c.json(createResponse(passkeys), 200);
+});
+
+// DELETE /:id - delete passkey (requires JWT)
+passkeyRouter.delete('/:id', authenticateJWT, async (c: HonoContext) => {
+  const user = c.get('user') as User;
+  const id = c.req.param('id');
+
+  // Check if this is the last login method
+  const canDelete = await hasOtherLoginMethods(user.id);
+  if (!canDelete) {
+    return c.json(
+      createResponse(
+        null,
+        'Cannot delete: this is your last login method. Please set up a password or another login method first.',
+        400
+      ),
+      400
+    );
+  }
+
+  await deleteUserPasskey(id, user.id);
+  return c.json(createResponse(null, 'Passkey deleted successfully'), 200);
+});
+
+export default passkeyRouter;

--- a/server/route/v2/site.ts
+++ b/server/route/v2/site.ts
@@ -163,6 +163,11 @@ siteRouter.get('/status', async (c: HonoContext) => {
         };
       })(),
 
+      // Passkey 配置（用于前端判断是否显示 Passkey 登录按钮）
+      passkey: {
+        enabled: securityConfig?.passkey?.enabled !== false,
+      },
+
       // 时间戳
       timestamp: new Date().toISOString(),
 

--- a/server/types/config.ts
+++ b/server/types/config.ts
@@ -45,6 +45,13 @@ export interface OAuthConfig {
   providers: Record<string, OAuthProviderConfig | AppleOAuthProviderConfig>;
 }
 
+export interface PasskeyConfig {
+  enabled?: boolean; // defaults to true
+  rpName?: string; // defaults to site name
+  rpId?: string; // defaults to hostname from frontendUrl
+  origin?: string; // defaults to frontendUrl
+}
+
 export interface SecurityConfig {
   jwtSecret: string;
   jwtRefreshSecret: string;
@@ -55,6 +62,8 @@ export interface SecurityConfig {
   requireVerifiedEmailForExplore?: boolean;
   // OAuth 配置
   oauth?: OAuthConfig;
+  // Passkey 配置
+  passkey?: PasskeyConfig;
 }
 
 export interface NotificationConfig {

--- a/server/utils/dbMethods/index.ts
+++ b/server/utils/dbMethods/index.ts
@@ -15,5 +15,6 @@ export * from './user';
 export * from './userAccount';
 export * from './userData';
 export * from './userOAuth';
+export * from './userPasskey';
 export * from './userProfile';
 export * from './userSettings';

--- a/server/utils/dbMethods/userPasskey.ts
+++ b/server/utils/dbMethods/userPasskey.ts
@@ -1,5 +1,5 @@
 import { and, count, eq } from 'drizzle-orm';
-import { userOAuthBindings, userPasskeys } from '../../drizzle/schema';
+import { users, userOAuthBindings, userPasskeys } from '../../drizzle/schema';
 import db from '../drizzle';
 import { DatabaseError } from './common';
 
@@ -9,7 +9,7 @@ export async function createUserPasskey(data: {
   publicKey: Buffer;
   counter: number;
   transports?: string[];
-  deviceType?: string;
+  deviceName?: string;
 }) {
   try {
     const [passkey] = await db
@@ -20,7 +20,7 @@ export async function createUserPasskey(data: {
         publicKey: data.publicKey,
         counter: data.counter,
         transports: data.transports || [],
-        deviceType: data.deviceType || '',
+        deviceName: data.deviceName || '',
       })
       .returning();
     return passkey;
@@ -34,7 +34,7 @@ export async function getUserPasskeys(userId: string) {
     return await db
       .select({
         id: userPasskeys.id,
-        deviceType: userPasskeys.deviceType,
+        deviceName: userPasskeys.deviceName,
         credentialId: userPasskeys.credentialId,
         transports: userPasskeys.transports,
         createdAt: userPasskeys.createdAt,
@@ -101,7 +101,6 @@ export async function getUserPasskeyCount(userId: string): Promise<number> {
 
 export async function hasOtherLoginMethods(userId: string): Promise<boolean> {
   try {
-    const { users } = await import('../../drizzle/schema');
     const [fullUser] = await db
       .select({ passwordhash: users.passwordhash, salt: users.salt })
       .from(users)

--- a/server/utils/dbMethods/userPasskey.ts
+++ b/server/utils/dbMethods/userPasskey.ts
@@ -1,0 +1,127 @@
+import { and, count, eq } from 'drizzle-orm';
+import { userOAuthBindings, userPasskeys } from '../../drizzle/schema';
+import db from '../drizzle';
+import { DatabaseError } from './common';
+
+export async function createUserPasskey(data: {
+  userid: string;
+  credentialId: string;
+  publicKey: Buffer;
+  counter: number;
+  transports?: string[];
+  deviceType?: string;
+}) {
+  try {
+    const [passkey] = await db
+      .insert(userPasskeys)
+      .values({
+        userid: data.userid,
+        credentialId: data.credentialId,
+        publicKey: data.publicKey,
+        counter: data.counter,
+        transports: data.transports || [],
+        deviceType: data.deviceType || '',
+      })
+      .returning();
+    return passkey;
+  } catch (error: any) {
+    throw new DatabaseError(`Failed to create passkey: ${error.message}`, error);
+  }
+}
+
+export async function getUserPasskeys(userId: string) {
+  try {
+    return await db
+      .select({
+        id: userPasskeys.id,
+        deviceType: userPasskeys.deviceType,
+        credentialId: userPasskeys.credentialId,
+        transports: userPasskeys.transports,
+        createdAt: userPasskeys.createdAt,
+        updatedAt: userPasskeys.updatedAt,
+      })
+      .from(userPasskeys)
+      .where(eq(userPasskeys.userid, userId));
+  } catch (error: any) {
+    throw new DatabaseError(`Failed to get passkeys for user: ${userId}`, error);
+  }
+}
+
+export async function getPasskeyByCredentialId(credentialId: string) {
+  try {
+    const [passkey] = await db
+      .select()
+      .from(userPasskeys)
+      .where(eq(userPasskeys.credentialId, credentialId))
+      .limit(1);
+    return passkey || null;
+  } catch (error: any) {
+    throw new DatabaseError(`Failed to get passkey by credential ID`, error);
+  }
+}
+
+export async function updatePasskeyCounter(credentialId: string, newCounter: number) {
+  try {
+    await db
+      .update(userPasskeys)
+      .set({ counter: newCounter, updatedAt: new Date() })
+      .where(eq(userPasskeys.credentialId, credentialId));
+  } catch (error: any) {
+    throw new DatabaseError(`Failed to update passkey counter`, error);
+  }
+}
+
+export async function deleteUserPasskey(id: string, userId: string) {
+  try {
+    const result = await db
+      .delete(userPasskeys)
+      .where(and(eq(userPasskeys.id, id), eq(userPasskeys.userid, userId)))
+      .returning();
+    if (result.length === 0) {
+      throw new DatabaseError('Passkey not found or access denied');
+    }
+    return result[0];
+  } catch (error: any) {
+    if (error instanceof DatabaseError) throw error;
+    throw new DatabaseError(`Failed to delete passkey`, error);
+  }
+}
+
+export async function getUserPasskeyCount(userId: string): Promise<number> {
+  try {
+    const [result] = await db
+      .select({ count: count() })
+      .from(userPasskeys)
+      .where(eq(userPasskeys.userid, userId));
+    return result?.count || 0;
+  } catch (error: any) {
+    throw new DatabaseError(`Failed to count passkeys for user: ${userId}`, error);
+  }
+}
+
+export async function hasOtherLoginMethods(userId: string): Promise<boolean> {
+  try {
+    const { users } = await import('../../drizzle/schema');
+    const [fullUser] = await db
+      .select({ passwordhash: users.passwordhash, salt: users.salt })
+      .from(users)
+      .where(eq(users.id, userId))
+      .limit(1);
+
+    const hasPassword = Boolean(fullUser?.passwordhash && fullUser?.salt);
+
+    const [oauthBinding] = await db
+      .select({ id: userOAuthBindings.id })
+      .from(userOAuthBindings)
+      .where(eq(userOAuthBindings.userid, userId))
+      .limit(1);
+
+    const hasOAuth = Boolean(oauthBinding);
+
+    const passkeyCount = await getUserPasskeyCount(userId);
+
+    return hasPassword || hasOAuth || passkeyCount > 1;
+  } catch (error: any) {
+    throw new DatabaseError(`Failed to check login methods for user: ${userId}`, error);
+  }
+}

--- a/server/utils/zod.ts
+++ b/server/utils/zod.ts
@@ -13,9 +13,11 @@ export const RegisterDataZod = z.object({
     }),
   password: z
     .string()
-    .refine((val) => val.length > 0, { message: 'Password cannot be empty' })
-    .refine((val) => val.length >= 6, { message: 'Password must be at least 6 characters' })
-    .max(128, 'Password cannot exceed 128 characters'),
+    .max(128, 'Password cannot exceed 128 characters')
+    .optional()
+    .refine((val) => !val || val.length >= 6, {
+      message: 'Password must be at least 6 characters',
+    }),
   email: z
     .string()
     .min(1, 'Email cannot be empty')

--- a/web/package.json
+++ b/web/package.json
@@ -35,6 +35,7 @@
     "@radix-ui/react-toggle": "^1.1.10",
     "@radix-ui/react-toggle-group": "^1.1.11",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@simplewebauthn/browser": "^13.3.0",
     "@tailwindcss/aspect-ratio": "^0.4.2",
     "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.1.18",

--- a/web/src/hooks/usePasskey.ts
+++ b/web/src/hooks/usePasskey.ts
@@ -9,19 +9,39 @@ import {
 } from '@/utils/passkey';
 import { authService } from '@/utils/auth';
 
+interface PasskeyItem {
+  id: string;
+  deviceName: string;
+  credentialId: string;
+  transports: string[] | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export function usePasskey() {
   const { t } = useTranslation('translation', { keyPrefix: 'pages' });
   const [isRegistering, setIsRegistering] = useState(false);
   const [isAuthenticating, setIsAuthenticating] = useState(false);
-  const [passkeys, setPasskeys] = useState<any[]>([]);
+  const [passkeys, setPasskeys] = useState<PasskeyItem[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+
+  const fetchPasskeys = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const data = await listPasskeysUtil();
+      setPasskeys(data || []);
+    } catch (error: any) {
+      toast.error(error?.message || t('settings.passkey.fetchFailed'));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [t]);
 
   const registerPasskey = useCallback(async () => {
     setIsRegistering(true);
     try {
       await registerPasskeyUtil();
       toast.success(t('login.passkey.registerSuccess'));
-      // Refresh the list
       await fetchPasskeys();
       return true;
     } catch (error: any) {
@@ -34,13 +54,12 @@ export function usePasskey() {
     } finally {
       setIsRegistering(false);
     }
-  }, []);
+  }, [t, fetchPasskeys]);
 
   const authenticateWithPasskey = useCallback(async () => {
     setIsAuthenticating(true);
     try {
       const result = await authenticateWithPasskeyUtil();
-      // Store tokens
       authService.setTokens(result.accessToken, result.refreshToken);
       toast.success(t('login.passkey.loginSuccess'));
       return result;
@@ -54,19 +73,7 @@ export function usePasskey() {
     } finally {
       setIsAuthenticating(false);
     }
-  }, []);
-
-  const fetchPasskeys = useCallback(async () => {
-    setIsLoading(true);
-    try {
-      const data = await listPasskeysUtil();
-      setPasskeys(data || []);
-    } catch (error: any) {
-      toast.error(error?.message || t('login.passkey.loginFailed'));
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
+  }, [t]);
 
   const deletePasskey = useCallback(
     async (id: string) => {
@@ -78,7 +85,7 @@ export function usePasskey() {
         toast.error(error?.message || t('profile.settings.passkey.deleteFailed'));
       }
     },
-    [fetchPasskeys]
+    [t, fetchPasskeys]
   );
 
   return {

--- a/web/src/hooks/usePasskey.ts
+++ b/web/src/hooks/usePasskey.ts
@@ -1,0 +1,94 @@
+import { useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+import {
+  registerPasskey as registerPasskeyUtil,
+  authenticateWithPasskey as authenticateWithPasskeyUtil,
+  listPasskeys as listPasskeysUtil,
+  deletePasskey as deletePasskeyUtil,
+} from '@/utils/passkey';
+import { authService } from '@/utils/auth';
+
+export function usePasskey() {
+  const { t } = useTranslation('translation', { keyPrefix: 'pages' });
+  const [isRegistering, setIsRegistering] = useState(false);
+  const [isAuthenticating, setIsAuthenticating] = useState(false);
+  const [passkeys, setPasskeys] = useState<any[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const registerPasskey = useCallback(async () => {
+    setIsRegistering(true);
+    try {
+      await registerPasskeyUtil();
+      toast.success(t('login.passkey.registerSuccess'));
+      // Refresh the list
+      await fetchPasskeys();
+      return true;
+    } catch (error: any) {
+      if (error?.name === 'NotAllowedError') {
+        toast.info(t('login.passkey.cancelled'));
+      } else {
+        toast.error(error?.message || t('login.passkey.registerFailed'));
+      }
+      return false;
+    } finally {
+      setIsRegistering(false);
+    }
+  }, []);
+
+  const authenticateWithPasskey = useCallback(async () => {
+    setIsAuthenticating(true);
+    try {
+      const result = await authenticateWithPasskeyUtil();
+      // Store tokens
+      authService.setTokens(result.accessToken, result.refreshToken);
+      toast.success(t('login.passkey.loginSuccess'));
+      return result;
+    } catch (error: any) {
+      if (error?.name === 'NotAllowedError') {
+        toast.info(t('login.passkey.cancelled'));
+      } else {
+        toast.error(error?.message || t('login.passkey.loginFailed'));
+      }
+      return null;
+    } finally {
+      setIsAuthenticating(false);
+    }
+  }, []);
+
+  const fetchPasskeys = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const data = await listPasskeysUtil();
+      setPasskeys(data || []);
+    } catch (error: any) {
+      toast.error(error?.message || t('login.passkey.loginFailed'));
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const deletePasskey = useCallback(
+    async (id: string) => {
+      try {
+        await deletePasskeyUtil(id);
+        toast.success(t('profile.settings.passkey.deleteSuccess'));
+        await fetchPasskeys();
+      } catch (error: any) {
+        toast.error(error?.message || t('profile.settings.passkey.deleteFailed'));
+      }
+    },
+    [fetchPasskeys]
+  );
+
+  return {
+    isRegistering,
+    isAuthenticating,
+    passkeys,
+    isLoading,
+    registerPasskey,
+    authenticateWithPasskey,
+    fetchPasskeys,
+    deletePasskey,
+  };
+}

--- a/web/src/hooks/useSiteStatus.ts
+++ b/web/src/hooks/useSiteStatus.ts
@@ -59,6 +59,9 @@ interface SiteStatusData {
       };
     };
   };
+  passkey?: {
+    enabled: boolean;
+  };
   frontendConfig: FrontendConfig;
   timestamp: string;
 }

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -194,7 +194,7 @@
         "registerSuccess": "Passkey registered successfully",
         "registerFailed": "Passkey registration failed",
         "cancelled": "Operation cancelled",
-        "passwordOptionalHint": "You can skip the password and use passkey to log in."
+        "passwordOptionalHint": "You can skip the password and register with a passkey."
       }
     },
     "home": {
@@ -251,7 +251,8 @@
           "add": "Add Passkey",
           "adding": "Adding passkey...",
           "deleteSuccess": "Passkey deleted",
-          "deleteFailed": "Failed to delete passkey"
+          "deleteFailed": "Failed to delete passkey",
+          "fetchFailed": "Failed to load passkeys"
         },
         "oauth": {
           "title": "Account Linking",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -145,11 +145,15 @@
       },
       "fields": {
         "username": "Username",
+        "usernamePlaceholder": "username",
         "usernameOrEmail": "Username or Email",
         "usernameOrEmailPlaceholder": "username or email",
         "password": "Password",
+        "passwordOptional": "password (optional)",
         "email": "Email",
-        "nickname": "Nickname"
+        "emailPlaceholder": "someone@mail.com",
+        "nickname": "Nickname",
+        "nicknamePlaceholder": "nickname"
       },
       "buttons": {
         "login": "Login",
@@ -177,7 +181,21 @@
       "emailMaxLength": "Email cannot exceed 30 characters",
       "emailFormat": "Invalid email format",
       "nicknameRequired": "Nickname is required",
-      "nicknameMaxLength": "Nickname cannot exceed 20 characters"
+      "nicknameMaxLength": "Nickname cannot exceed 20 characters",
+      "passkey": {
+        "promptTitle": "Set up a passkey?",
+        "promptDescription": "A passkey lets you log in with just your fingerprint, face, or security key. No password needed.",
+        "setup": "Set up Passkey",
+        "skip": "Skip for now",
+        "settingUp": "Setting up...",
+        "loginWithPasskey": "Login with Passkey",
+        "loginSuccess": "Login successful",
+        "loginFailed": "Passkey login failed",
+        "registerSuccess": "Passkey registered successfully",
+        "registerFailed": "Passkey registration failed",
+        "cancelled": "Operation cancelled",
+        "passwordOptionalHint": "You can skip the password and use passkey to log in."
+      }
     },
     "home": {
       "statistics": "Statistics"
@@ -225,6 +243,16 @@
         "saving": "Saving…",
         "saveSuccess": "Settings saved",
         "saveFailed": "Failed to save: {{error}}",
+        "passkey": {
+          "title": "Passkeys",
+          "description": "Manage your passkeys for passwordless login.",
+          "confirmDelete": "Delete this passkey?",
+          "noPasskeys": "No passkeys registered yet.",
+          "add": "Add Passkey",
+          "adding": "Adding passkey...",
+          "deleteSuccess": "Passkey deleted",
+          "deleteFailed": "Failed to delete passkey"
+        },
         "oauth": {
           "title": "Account Linking",
           "description": "Link third-party accounts to enable multiple login methods",
@@ -478,6 +506,7 @@
         "username": "Username",
         "email": "Email",
         "password": "Password",
+        "passwordOptional": "Password (optional)",
         "nickname": "Nickname"
       },
       "placeholders": {

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -194,7 +194,7 @@
         "registerSuccess": "パスキーの登録に成功しました",
         "registerFailed": "パスキーの登録に失敗しました",
         "cancelled": "操作がキャンセルされました",
-        "passwordOptionalHint": "パスワードをスキップして、パスキーでログインできます。"
+        "passwordOptionalHint": "パスワードをスキップして、パスキーで登録できます。"
       }
     },
     "home": {
@@ -251,7 +251,8 @@
           "add": "パスキーを追加",
           "adding": "パスキーを追加中...",
           "deleteSuccess": "パスキーを削除しました",
-          "deleteFailed": "パスキーの削除に失敗しました"
+          "deleteFailed": "パスキーの削除に失敗しました",
+          "fetchFailed": "パスキーの読み込みに失敗しました"
         },
         "oauth": {
           "title": "アカウント連携",

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -145,11 +145,15 @@
       },
       "fields": {
         "username": "ユーザー名",
+        "usernamePlaceholder": "ユーザー名",
         "usernameOrEmail": "ユーザー名またはメールアドレス",
-        "usernameOrEmailPlaceholder": "username or email",
+        "usernameOrEmailPlaceholder": "ユーザー名またはメールアドレス",
         "password": "パスワード",
+        "passwordOptional": "パスワード（任意）",
         "email": "メールアドレス",
-        "nickname": "ニックネーム"
+        "emailPlaceholder": "someone@mail.com",
+        "nickname": "ニックネーム",
+        "nicknamePlaceholder": "ニックネーム"
       },
       "buttons": {
         "login": "ログイン",
@@ -177,7 +181,21 @@
       "emailMaxLength": "メールアドレスは30文字以内で入力してください",
       "emailFormat": "無効なメールアドレス形式です",
       "nicknameRequired": "ニックネームは必須です",
-      "nicknameMaxLength": "ニックネームは20文字以内で入力してください"
+      "nicknameMaxLength": "ニックネームは20文字以内で入力してください",
+      "passkey": {
+        "promptTitle": "パスキーを設定しますか？",
+        "promptDescription": "パスキーを使用すると、指紋、顔認証、またはセキュリティキーだけでログインできます。パスワードは不要です。",
+        "setup": "パスキーを設定",
+        "skip": "後で設定する",
+        "settingUp": "設定中...",
+        "loginWithPasskey": "パスキーでログイン",
+        "loginSuccess": "ログイン成功",
+        "loginFailed": "パスキーログインに失敗しました",
+        "registerSuccess": "パスキーの登録に成功しました",
+        "registerFailed": "パスキーの登録に失敗しました",
+        "cancelled": "操作がキャンセルされました",
+        "passwordOptionalHint": "パスワードをスキップして、パスキーでログインできます。"
+      }
     },
     "home": {
       "statistics": "統計"
@@ -225,6 +243,16 @@
         "saving": "保存中…",
         "saveSuccess": "設定を保存しました",
         "saveFailed": "保存に失敗しました：{{error}}",
+        "passkey": {
+          "title": "パスキー",
+          "description": "パスワードレスログイン用のパスキーを管理します。",
+          "confirmDelete": "このパスキーを削除しますか？",
+          "noPasskeys": "まだパスキーが登録されていません。",
+          "add": "パスキーを追加",
+          "adding": "パスキーを追加中...",
+          "deleteSuccess": "パスキーを削除しました",
+          "deleteFailed": "パスキーの削除に失敗しました"
+        },
         "oauth": {
           "title": "アカウント連携",
           "description": "サードパーティアカウントを連携して、複数のログイン方法を有効にします",
@@ -478,6 +506,7 @@
         "username": "ユーザー名",
         "email": "メールアドレス",
         "password": "パスワード",
+        "passwordOptional": "パスワード（任意）",
         "nickname": "ニックネーム"
       },
       "placeholders": {

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -184,7 +184,7 @@
         "registerSuccess": "通行密钥注册成功",
         "registerFailed": "通行密钥注册失败",
         "cancelled": "操作已取消",
-        "passwordOptionalHint": "可以跳过密码设置，使用通行密钥登录。"
+        "passwordOptionalHint": "可以跳过密码设置，使用通行密钥注册。"
       }
     },
     "home": {
@@ -241,7 +241,8 @@
           "add": "添加通行密钥",
           "adding": "正在添加通行密钥...",
           "deleteSuccess": "通行密钥已删除",
-          "deleteFailed": "删除通行密钥失败"
+          "deleteFailed": "删除通行密钥失败",
+          "fetchFailed": "加载通行密钥失败"
         },
         "oauth": {
           "title": "账户关联",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -135,11 +135,15 @@
       },
       "fields": {
         "username": "用户名",
+        "usernamePlaceholder": "用户名",
         "usernameOrEmail": "用户名或邮箱",
-        "usernameOrEmailPlaceholder": "username or email",
+        "usernameOrEmailPlaceholder": "用户名或邮箱",
         "password": "密码",
+        "passwordOptional": "密码（可选）",
         "email": "邮箱",
-        "nickname": "昵称"
+        "emailPlaceholder": "someone@mail.com",
+        "nickname": "昵称",
+        "nicknamePlaceholder": "昵称"
       },
       "buttons": {
         "login": "登录",
@@ -167,7 +171,21 @@
       "emailMaxLength": "邮箱最长30位",
       "emailFormat": "请输入正确的邮箱格式",
       "nicknameRequired": "请输入昵称",
-      "nicknameMaxLength": "昵称最长20位"
+      "nicknameMaxLength": "昵称最长20位",
+      "passkey": {
+        "promptTitle": "设置通行密钥？",
+        "promptDescription": "通行密钥可以让您通过指纹、面容或安全密钥快速登录，无需记住密码。",
+        "setup": "设置通行密钥",
+        "skip": "暂不设置",
+        "settingUp": "设置中...",
+        "loginWithPasskey": "使用通行密钥登录",
+        "loginSuccess": "登录成功",
+        "loginFailed": "通行密钥登录失败",
+        "registerSuccess": "通行密钥注册成功",
+        "registerFailed": "通行密钥注册失败",
+        "cancelled": "操作已取消",
+        "passwordOptionalHint": "可以跳过密码设置，使用通行密钥登录。"
+      }
     },
     "home": {
       "statistics": "统计 / Static"
@@ -215,6 +233,16 @@
         "saving": "保存中…",
         "saveSuccess": "设置已保存",
         "saveFailed": "保存失败：{{error}}",
+        "passkey": {
+          "title": "通行密钥",
+          "description": "管理您的通行密钥，用于免密码登录。",
+          "confirmDelete": "确定要删除此通行密钥吗？",
+          "noPasskeys": "暂未注册通行密钥。",
+          "add": "添加通行密钥",
+          "adding": "正在添加通行密钥...",
+          "deleteSuccess": "通行密钥已删除",
+          "deleteFailed": "删除通行密钥失败"
+        },
         "oauth": {
           "title": "账户关联",
           "description": "关联第三方账户后，您可以使用多种方式登录",
@@ -468,6 +496,7 @@
         "username": "用户名",
         "email": "邮箱",
         "password": "密码",
+        "passwordOptional": "密码（可选）",
         "nickname": "昵称"
       },
       "placeholders": {

--- a/web/src/pages/login/index.tsx
+++ b/web/src/pages/login/index.tsx
@@ -16,7 +16,9 @@ import { useSiteStatus } from '@/hooks/useSiteStatus';
 import { get, getApiUrl, post } from '@/utils/api';
 import { authService } from '@/utils/auth';
 import { useAPIGet } from '@/utils/fetcher';
-import { Github } from 'lucide-react';
+import { registerWithPasskey } from '@/utils/passkey';
+import { usePasskey } from '@/hooks/usePasskey';
+import { Fingerprint, Github } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
@@ -51,6 +53,9 @@ function Login() {
   const [disbled, setDisbled] = useState(false);
   const [activeTab, setActiveTab] = useState('login');
   const [searchParams] = useSearchParams();
+  const { authenticateWithPasskey, registerPasskey, isAuthenticating, isRegistering } =
+    usePasskey();
+  const [showPasskeyPrompt, setShowPasskeyPrompt] = useState(false);
 
   // 如果注册被禁用，确保 activeTab 是 'login'
   useEffect(() => {
@@ -116,6 +121,8 @@ function Login() {
       .max(128, t('passwordMaxLength')),
   });
 
+  const passkeyEnabled = siteStatus?.passkey?.enabled !== false;
+
   const RegisterDataZod = z.object({
     username: z
       .string()
@@ -125,11 +132,17 @@ function Login() {
       .refine((value) => !siteStatus?.frontendConfig?.safeRoutes?.includes(value), {
         message: t('usernameConflict'),
       }),
-    password: z
-      .string()
-      .refine((val) => val.length > 0, { message: t('passwordRequired') })
-      .refine((val) => val.length >= 6, { message: t('passwordMin') })
-      .max(128, t('passwordMaxLength')),
+    password: passkeyEnabled
+      ? z
+          .string()
+          .max(128, t('passwordMaxLength'))
+          .optional()
+          .refine((val) => !val || val.length >= 6, { message: t('passwordMin') })
+      : z
+          .string()
+          .min(1, t('passwordRequired'))
+          .refine((val) => val.length >= 6, { message: t('passwordMin') })
+          .max(128, t('passwordMaxLength')),
     email: z
       .string()
       .min(1, t('emailRequired'))
@@ -231,8 +244,36 @@ function Login() {
     }
 
     setDisbled(true);
+
+    // No password + passkey enabled → two-step passkey registration
+    if (!registerData.password && passkeyEnabled) {
+      registerWithPasskey({
+        username: registerData.username,
+        email: registerData.email,
+        nickname: registerData.nickname,
+      })
+        .then((result) => {
+          toast.success(t('messages.registerSuccess'));
+          authService.setTokens(result.accessToken, result.refreshToken);
+          mutateProfile();
+          navigate('/home');
+        })
+        .catch((err: any) => {
+          setDisbled(false);
+          if (err?.name === 'NotAllowedError') {
+            toast.info(t('passkey.cancelled'));
+          } else {
+            const errorMessage = err.response?.data?.message || err?.message;
+            toast.error(errorMessage || t('messages.backendDown'));
+          }
+        })
+        .finally(() => setDisbled(false));
+      return;
+    }
+
+    // Has password → standard registration
     post('/auth/register', registerData)
-      .then(() => {
+      .then((response) => {
         toast.success(t('messages.registerSuccess'));
         setDisbled(false);
         setRegisterData({
@@ -241,12 +282,24 @@ function Login() {
           email: '',
           nickname: '',
         });
-        // 注册成功后自动切换到登录 tab
-        setActiveTab('login');
+
+        const { accessToken, refreshToken } = response.data;
+        if (accessToken && refreshToken) {
+          authService.setTokens(accessToken, refreshToken);
+
+          if (passkeyEnabled) {
+            // Has password, passkey optional → show passkey prompt with skip
+            setShowPasskeyPrompt(true);
+          } else {
+            mutateProfile();
+            navigate('/home');
+          }
+        } else {
+          setActiveTab('login');
+        }
       })
       .catch((err: any) => {
         setDisbled(false);
-        // 使用 message 字段
         const errorMessage = err.response?.data?.message;
         toast.error(errorMessage || t('messages.backendDown'));
       });
@@ -411,157 +464,222 @@ function Login() {
             </div>
 
             {backendStatusOk ? (
-              <Tabs
-                value={activeTab}
-                onValueChange={setActiveTab}
-                className="bg-muted w-full rounded-lg"
-              >
-                <TabsList
-                  className={`grid w-full ${backendStatusOk.ui?.allowRegistration !== false ? 'grid-cols-2' : 'grid-cols-1'}`}
+              showPasskeyPrompt ? (
+                // Passkey setup prompt after registration
+                <div className="bg-muted w-full rounded-lg p-6 text-center">
+                  <Fingerprint className="mx-auto mb-4 size-12" />
+                  <h2 className="mb-2 text-lg font-semibold">{t('passkey.promptTitle')}</h2>
+                  <p className="text-muted-foreground mb-6 text-sm">
+                    {t('passkey.promptDescription')}
+                  </p>
+                  <div className="space-y-2">
+                    <Button
+                      onClick={async () => {
+                        const success = await registerPasskey();
+                        if (success) {
+                          mutateProfile();
+                          navigate('/home');
+                        }
+                      }}
+                      disabled={isRegistering}
+                      className="w-full"
+                    >
+                      {isRegistering ? t('passkey.settingUp') : t('passkey.setup')}
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      onClick={() => {
+                        mutateProfile();
+                        navigate('/home');
+                      }}
+                      className="w-full"
+                    >
+                      {t('passkey.skip')}
+                    </Button>
+                  </div>
+                </div>
+              ) : (
+                <Tabs
+                  value={activeTab}
+                  onValueChange={setActiveTab}
+                  className="bg-muted w-full rounded-lg"
                 >
-                  <TabsTrigger value="login">{t('buttons.login')}</TabsTrigger>
-                  {backendStatusOk.ui?.allowRegistration !== false && (
-                    <TabsTrigger value="register">{t('buttons.register')}</TabsTrigger>
-                  )}
-                </TabsList>
-
-                <TabsContents className="bg-background mx-1 -mt-2 mb-1 h-full rounded-sm">
-                  <div className="space-y-4 p-4">
-                    <TabsContent value="login" className="space-y-4 py-4">
-                      <div className="space-y-5">
-                        <div className="space-y-2">
-                          <Label htmlFor="login-username">{t('fields.usernameOrEmail')}</Label>
-                          <Input
-                            id="login-username"
-                            placeholder={t('fields.usernameOrEmailPlaceholder')}
-                            className="text-md rounded-md font-mono"
-                            maxLength={255}
-                            value={loginData.username}
-                            onInput={(e) => handleInputChange(e, 'username', 'login')}
-                          />
-                        </div>
-                        <div className="space-y-2">
-                          <Label htmlFor="login-password">{t('fields.password')}</Label>
-                          <Input
-                            id="login-password"
-                            placeholder="password"
-                            type="password"
-                            className="text-md rounded-md font-mono"
-                            maxLength={30}
-                            value={loginData.password}
-                            onInput={(e) => handleInputChange(e, 'password', 'login')}
-                            onKeyDown={handleLoginKeyDown}
-                          />
-                        </div>
-                      </div>
-                      <Button disabled={disbled} onClick={login} className="w-full">
-                        {disbled ? t('messages.loggingIn') : t('buttons.login')}
-                      </Button>
-                      {hasEnabledOAuthProviders && (
-                        <>
-                          <div className="relative my-4">
-                            <div className="absolute inset-0 flex items-center">
-                              <span className="w-full border-t" />
-                            </div>
-                            <div className="relative flex justify-center text-xs uppercase">
-                              <span className="bg-background text-muted-foreground px-2">
-                                {t('oauth.or')}
-                              </span>
-                            </div>
-                          </div>
-                          {backendStatusOk?.oauth?.providers &&
-                            Object.entries(backendStatusOk.oauth.providers).map(
-                              ([provider, config]: [string, any]) => {
-                                if (!config?.enabled) return null;
-                                const providerInfo = getOAuthProviderInfo(provider);
-                                const IconComponent = providerInfo.icon;
-                                return (
-                                  <Button
-                                    key={provider}
-                                    type="button"
-                                    variant="outline"
-                                    onClick={() => handleOAuthLogin(provider)}
-                                    className="w-full"
-                                    disabled={disbled}
-                                  >
-                                    {IconComponent && <IconComponent className="mr-2 size-4" />}
-                                    {t(providerInfo.labelKey)}
-                                  </Button>
-                                );
-                              }
-                            )}
-                        </>
-                      )}
-                    </TabsContent>
-
+                  <TabsList
+                    className={`grid w-full ${backendStatusOk.ui?.allowRegistration !== false ? 'grid-cols-2' : 'grid-cols-1'}`}
+                  >
+                    <TabsTrigger value="login">{t('buttons.login')}</TabsTrigger>
                     {backendStatusOk.ui?.allowRegistration !== false && (
-                      <TabsContent value="register" className="space-y-4 py-4">
+                      <TabsTrigger value="register">{t('buttons.register')}</TabsTrigger>
+                    )}
+                  </TabsList>
+
+                  <TabsContents className="bg-background mx-1 -mt-2 mb-1 h-full rounded-sm">
+                    <div className="space-y-4 p-4">
+                      <TabsContent value="login" className="space-y-4 py-4">
                         <div className="space-y-5">
                           <div className="space-y-2">
-                            <Label htmlFor="register-username">{t('fields.username')}</Label>
+                            <Label htmlFor="login-username">{t('fields.usernameOrEmail')}</Label>
                             <Input
-                              id="register-username"
-                              placeholder="username"
+                              id="login-username"
+                              placeholder={t('fields.usernameOrEmailPlaceholder')}
                               className="text-md rounded-md font-mono"
-                              maxLength={20}
-                              value={registerData.username}
-                              onInput={(e) => handleInputChange(e, 'username', 'register')}
+                              maxLength={255}
+                              value={loginData.username}
+                              onInput={(e) => handleInputChange(e, 'username', 'login')}
                             />
                           </div>
                           <div className="space-y-2">
-                            <Label htmlFor="register-email">{t('fields.email')}</Label>
+                            <Label htmlFor="login-password">{t('fields.password')}</Label>
                             <Input
-                              id="register-email"
-                              placeholder="someone@mail.com"
-                              className="text-md rounded-md font-mono"
-                              maxLength={30}
-                              value={registerData.email}
-                              onInput={(e) => handleInputChange(e, 'email', 'register')}
-                            />
-                          </div>
-                          <div className="space-y-2">
-                            <Label htmlFor="register-nickname">{t('fields.nickname')}</Label>
-                            <Input
-                              id="register-nickname"
-                              placeholder="nickname"
-                              className="text-md rounded-md font-mono"
-                              maxLength={20}
-                              value={registerData.nickname}
-                              onInput={(e) => handleInputChange(e, 'nickname', 'register')}
-                            />
-                          </div>
-                          <div className="space-y-2">
-                            <Label htmlFor="register-password">{t('fields.password')}</Label>
-                            <Input
-                              id="register-password"
+                              id="login-password"
                               placeholder="password"
                               type="password"
                               className="text-md rounded-md font-mono"
                               maxLength={30}
-                              value={registerData.password}
-                              onInput={(e) => handleInputChange(e, 'password', 'register')}
-                              onKeyDown={handleRegisterKeyDown}
+                              value={loginData.password}
+                              onInput={(e) => handleInputChange(e, 'password', 'login')}
+                              onKeyDown={handleLoginKeyDown}
                             />
                           </div>
                         </div>
-                        <Button disabled={disbled} onClick={register} className="w-full">
-                          {disbled ? t('messages.registering') : t('buttons.register')}
+                        <Button disabled={disbled} onClick={login} className="w-full">
+                          {disbled ? t('messages.loggingIn') : t('buttons.login')}
                         </Button>
+                        {siteStatus?.passkey?.enabled !== false && (
+                          <Button
+                            variant="outline"
+                            disabled={disbled || isAuthenticating}
+                            onClick={async () => {
+                              const result = await authenticateWithPasskey();
+                              if (result) {
+                                mutateProfile();
+                                if (searchParams.get('type') === 'ioslogin') {
+                                  const callbackUrl = `rote://callback?token=${result.accessToken}&refreshToken=${result.refreshToken}`;
+                                  window.location.href = callbackUrl;
+                                  return;
+                                }
+                                navigate('/home');
+                              }
+                            }}
+                            className="w-full"
+                          >
+                            <Fingerprint className="mr-2 size-4" />
+                            {isAuthenticating
+                              ? t('messages.loggingIn')
+                              : t('passkey.loginWithPasskey')}
+                          </Button>
+                        )}
+                        {hasEnabledOAuthProviders && (
+                          <>
+                            <div className="relative my-4">
+                              <div className="absolute inset-0 flex items-center">
+                                <span className="w-full border-t" />
+                              </div>
+                              <div className="relative flex justify-center text-xs uppercase">
+                                <span className="bg-background text-muted-foreground px-2">
+                                  {t('oauth.or')}
+                                </span>
+                              </div>
+                            </div>
+                            {backendStatusOk?.oauth?.providers &&
+                              Object.entries(backendStatusOk.oauth.providers).map(
+                                ([provider, config]: [string, any]) => {
+                                  if (!config?.enabled) return null;
+                                  const providerInfo = getOAuthProviderInfo(provider);
+                                  const IconComponent = providerInfo.icon;
+                                  return (
+                                    <Button
+                                      key={provider}
+                                      type="button"
+                                      variant="outline"
+                                      onClick={() => handleOAuthLogin(provider)}
+                                      className="w-full"
+                                      disabled={disbled}
+                                    >
+                                      {IconComponent && <IconComponent className="mr-2 size-4" />}
+                                      {t(providerInfo.labelKey)}
+                                    </Button>
+                                  );
+                                }
+                              )}
+                          </>
+                        )}
                       </TabsContent>
-                    )}
 
-                    <div className="my-4 flex cursor-pointer items-center justify-center gap-1 text-sm duration-300 active:scale-95">
-                      <Link to="/explore">
-                        <div className="duration-300 hover:opacity-60">{t('nav.explore')}</div>
-                      </Link>
-                      <span className="px-2">/</span>
-                      <Link to="/landing">
-                        <div className="duration-300 hover:opacity-60">{t('nav.home')}</div>
-                      </Link>
+                      {backendStatusOk.ui?.allowRegistration !== false && (
+                        <TabsContent value="register" className="space-y-4 py-4">
+                          <div className="space-y-5">
+                            <div className="space-y-2">
+                              <Label htmlFor="register-username">{t('fields.username')}</Label>
+                              <Input
+                                id="register-username"
+                                placeholder={t('fields.usernamePlaceholder')}
+                                className="text-md rounded-md font-mono"
+                                maxLength={20}
+                                value={registerData.username}
+                                onInput={(e) => handleInputChange(e, 'username', 'register')}
+                              />
+                            </div>
+                            <div className="space-y-2">
+                              <Label htmlFor="register-email">{t('fields.email')}</Label>
+                              <Input
+                                id="register-email"
+                                placeholder={t('fields.emailPlaceholder')}
+                                className="text-md rounded-md font-mono"
+                                maxLength={30}
+                                value={registerData.email}
+                                onInput={(e) => handleInputChange(e, 'email', 'register')}
+                              />
+                            </div>
+                            <div className="space-y-2">
+                              <Label htmlFor="register-nickname">{t('fields.nickname')}</Label>
+                              <Input
+                                id="register-nickname"
+                                placeholder={t('fields.nicknamePlaceholder')}
+                                className="text-md rounded-md font-mono"
+                                maxLength={20}
+                                value={registerData.nickname}
+                                onInput={(e) => handleInputChange(e, 'nickname', 'register')}
+                              />
+                            </div>
+                            <div className="space-y-2">
+                              <Label htmlFor="register-password">{t('fields.password')}</Label>
+                              <Input
+                                id="register-password"
+                                placeholder={t('fields.passwordOptional')}
+                                type="password"
+                                className="text-md rounded-md font-mono"
+                                maxLength={30}
+                                value={registerData.password}
+                                onInput={(e) => handleInputChange(e, 'password', 'register')}
+                                onKeyDown={handleRegisterKeyDown}
+                              />
+                              {siteStatus?.passkey?.enabled !== false && (
+                                <p className="text-muted-foreground text-xs">
+                                  {t('passkey.passwordOptionalHint')}
+                                </p>
+                              )}
+                            </div>
+                          </div>
+                          <Button disabled={disbled} onClick={register} className="w-full">
+                            {disbled ? t('messages.registering') : t('buttons.register')}
+                          </Button>
+                        </TabsContent>
+                      )}
+
+                      <div className="my-4 flex cursor-pointer items-center justify-center gap-1 text-sm duration-300 active:scale-95">
+                        <Link to="/explore">
+                          <div className="duration-300 hover:opacity-60">{t('nav.explore')}</div>
+                        </Link>
+                        <span className="px-2">/</span>
+                        <Link to="/landing">
+                          <div className="duration-300 hover:opacity-60">{t('nav.home')}</div>
+                        </Link>
+                      </div>
                     </div>
-                  </div>
-                </TabsContents>
-              </Tabs>
+                  </TabsContents>
+                </Tabs>
+              )
             ) : (
               <div>
                 <div className=" ">{t('error.backendIssue')}</div>

--- a/web/src/pages/login/index.tsx
+++ b/web/src/pages/login/index.tsx
@@ -259,7 +259,6 @@ function Login() {
           navigate('/home');
         })
         .catch((err: any) => {
-          setDisbled(false);
           if (err?.name === 'NotAllowedError') {
             toast.info(t('passkey.cancelled'));
           } else {

--- a/web/src/pages/profile/setting/index.tsx
+++ b/web/src/pages/profile/setting/index.tsx
@@ -22,7 +22,7 @@ import { del, put } from '@/utils/api';
 import { authService } from '@/utils/auth';
 import i18n from 'i18next';
 import { useAtomValue, useSetAtom } from 'jotai';
-import { Github, Loader, Settings2, Stars } from 'lucide-react';
+import { Fingerprint, Github, Loader, Settings2, Stars, Trash2 } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
@@ -30,6 +30,7 @@ import DeleteAccountDialog from '../components/DeleteAccountDialog';
 import MergeAccountDialog from '../components/MergeAccountDialog';
 import ProfileSidebar from '../components/ProfileSidebar';
 import { useOAuthBinding } from '../hooks/useOAuthBinding';
+import { usePasskey } from '@/hooks/usePasskey';
 
 export default function SettingsPage() {
   const { data: siteStatus } = useSiteStatus();
@@ -62,6 +63,15 @@ export default function SettingsPage() {
     handleOAuthCallback,
   } = useOAuthBinding(loadProfile);
 
+  const {
+    isRegistering,
+    passkeys,
+    isLoading: isLoadingPasskeys,
+    registerPasskey,
+    fetchPasskeys,
+    deletePasskey,
+  } = usePasskey();
+
   useEffect(() => {
     if (!profile) {
       loadProfile();
@@ -76,6 +86,12 @@ export default function SettingsPage() {
   useEffect(() => {
     handleOAuthCallback();
   }, [handleOAuthCallback]);
+
+  useEffect(() => {
+    if (profile && siteStatus?.passkey?.enabled !== false) {
+      fetchPasskeys();
+    }
+  }, [profile, siteStatus, fetchPasskeys]);
 
   const saveSettings = async () => {
     try {
@@ -297,6 +313,67 @@ export default function SettingsPage() {
               );
             })}
           </div>
+        </div>
+      )}
+
+      {/* Passkey 管理 */}
+      {siteStatus?.passkey?.enabled !== false && (
+        <div className="space-y-4 p-4">
+          <div>
+            <div className="text-base font-semibold">{t('settings.passkey.title')}</div>
+            <p className="text-muted-foreground text-sm">{t('settings.passkey.description')}</p>
+          </div>
+
+          {/* Passkey list */}
+          {isLoadingPasskeys ? (
+            <div className="flex items-center justify-center py-4">
+              <Loader className="size-4 animate-spin" />
+            </div>
+          ) : passkeys.length > 0 ? (
+            <div className="grid gap-3">
+              {passkeys.map((pk) => (
+                <div
+                  key={pk.id}
+                  className="flex items-center justify-between gap-3 rounded-lg border p-3"
+                >
+                  <div className="flex min-w-0 flex-1 items-center gap-3">
+                    <Fingerprint className="size-5 shrink-0" />
+                    <div className="min-w-0 flex-1">
+                      <div className="text-sm font-semibold">{pk.deviceType || 'Unknown'}</div>
+                      <div className="text-muted-foreground text-xs">
+                        {new Date(pk.createdAt).toLocaleDateString()}
+                      </div>
+                    </div>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="text-destructive size-8"
+                    onClick={() => {
+                      if (confirm(t('settings.passkey.confirmDelete'))) {
+                        deletePasskey(pk.id);
+                      }
+                    }}
+                  >
+                    <Trash2 className="size-4" />
+                  </Button>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="text-muted-foreground text-sm">{t('settings.passkey.noPasskeys')}</div>
+          )}
+
+          <Button
+            onClick={() => registerPasskey()}
+            disabled={isRegistering}
+            variant="outline"
+            className="w-full"
+          >
+            {isRegistering && <Loader className="mr-2 size-4 animate-spin" />}
+            <Fingerprint className="mr-2 size-4" />
+            {isRegistering ? t('settings.passkey.adding') : t('settings.passkey.add')}
+          </Button>
         </div>
       )}
 

--- a/web/src/pages/profile/setting/index.tsx
+++ b/web/src/pages/profile/setting/index.tsx
@@ -339,7 +339,7 @@ export default function SettingsPage() {
                   <div className="flex min-w-0 flex-1 items-center gap-3">
                     <Fingerprint className="size-5 shrink-0" />
                     <div className="min-w-0 flex-1">
-                      <div className="text-sm font-semibold">{pk.deviceType || 'Unknown'}</div>
+                      <div className="text-sm font-semibold">{pk.deviceName || 'Unknown'}</div>
                       <div className="text-muted-foreground text-xs">
                         {new Date(pk.createdAt).toLocaleDateString()}
                       </div>

--- a/web/src/utils/passkey.ts
+++ b/web/src/utils/passkey.ts
@@ -1,0 +1,88 @@
+import {
+  startRegistration,
+  startAuthentication,
+  browserSupportsWebAuthn,
+} from '@simplewebauthn/browser';
+import { get, post, del } from './api';
+
+export function isPasskeySupported(): boolean {
+  return browserSupportsWebAuthn();
+}
+
+export async function registerWithPasskey(data: {
+  username: string;
+  email: string;
+  nickname: string;
+}): Promise<{ user: any; accessToken: string; refreshToken: string }> {
+  // Step 1: validate user data, get passkey options
+  const optionsRes = await post('/auth/register/passkey/options', data);
+  const { options, registrationToken } = optionsRes.data;
+
+  // Step 2: browser WebAuthn ceremony
+  const credential = await startRegistration(options);
+
+  // Step 3: verify passkey + create account atomically
+  const verifyRes = await post('/auth/register/passkey/verify', {
+    credential,
+    registrationToken,
+    deviceType: getDeviceType(),
+  });
+
+  return verifyRes.data;
+}
+
+export async function registerPasskey(): Promise<boolean> {
+  const res = await post('/auth/passkey/register/options', {});
+  const { options } = res.data;
+
+  const credential = await startRegistration(options);
+
+  await post('/auth/passkey/register/verify', {
+    credential,
+    deviceType: getDeviceType(),
+  });
+
+  return true;
+}
+
+export async function authenticateWithPasskey(): Promise<{
+  user: any;
+  accessToken: string;
+  refreshToken: string;
+}> {
+  // Get authentication options from backend
+  const res = await post('/auth/passkey/authenticate/options', {});
+  const { options, challengeKey } = res.data;
+
+  // Trigger browser WebAuthn UI
+  const credential = await startAuthentication(options);
+
+  // Verify with backend and get tokens
+  const verifyRes = await post('/auth/passkey/authenticate/verify', {
+    credential,
+    challengeKey,
+  });
+
+  return verifyRes.data;
+}
+
+export async function listPasskeys() {
+  const res = await get('/auth/passkey');
+  return res.data;
+}
+
+export async function deletePasskey(id: string) {
+  const res = await del(`/auth/passkey/${id}`);
+  return res.data;
+}
+
+function getDeviceType(): string {
+  const ua = navigator.userAgent;
+  if (/iPhone/.test(ua)) return 'iPhone';
+  if (/iPad/.test(ua)) return 'iPad';
+  if (/Mac/.test(ua)) return 'Mac';
+  if (/Android/.test(ua)) return 'Android';
+  if (/Windows/.test(ua)) return 'Windows';
+  if (/Linux/.test(ua)) return 'Linux';
+  return 'Unknown';
+}

--- a/web/src/utils/passkey.ts
+++ b/web/src/utils/passkey.ts
@@ -19,13 +19,13 @@ export async function registerWithPasskey(data: {
   const { options, registrationToken } = optionsRes.data;
 
   // Step 2: browser WebAuthn ceremony
-  const credential = await startRegistration(options);
+  const credential = await startRegistration({ optionsJSON: options });
 
   // Step 3: verify passkey + create account atomically
   const verifyRes = await post('/auth/register/passkey/verify', {
     credential,
     registrationToken,
-    deviceType: getDeviceType(),
+    deviceName: getDeviceName(),
   });
 
   return verifyRes.data;
@@ -35,11 +35,11 @@ export async function registerPasskey(): Promise<boolean> {
   const res = await post('/auth/passkey/register/options', {});
   const { options } = res.data;
 
-  const credential = await startRegistration(options);
+  const credential = await startRegistration({ optionsJSON: options });
 
   await post('/auth/passkey/register/verify', {
     credential,
-    deviceType: getDeviceType(),
+    deviceName: getDeviceName(),
   });
 
   return true;
@@ -55,7 +55,7 @@ export async function authenticateWithPasskey(): Promise<{
   const { options, challengeKey } = res.data;
 
   // Trigger browser WebAuthn UI
-  const credential = await startAuthentication(options);
+  const credential = await startAuthentication({ optionsJSON: options });
 
   // Verify with backend and get tokens
   const verifyRes = await post('/auth/passkey/authenticate/verify', {
@@ -76,7 +76,7 @@ export async function deletePasskey(id: string) {
   return res.data;
 }
 
-function getDeviceType(): string {
+function getDeviceName(): string {
   const ua = navigator.userAgent;
   if (/iPhone/.test(ua)) return 'iPhone';
   if (/iPad/.test(ua)) return 'iPad';


### PR DESCRIPTION
## Summary
- Add passkey (WebAuthn) login and registration support
- Two-step passkey-only registration with atomic account + credential creation
- Passkey management in profile settings (list, add, delete)
- Passkey login button on login page (enabled by default)
- Store real device type at registration time
- Full i18n support (en, zh, ja)

## Test plan
- [ ] Passkey login button appears on login page
- [ ] Passkey-only registration creates account atomically after passkey verification
- [ ] Password + optional passkey registration works
- [ ] Profile settings shows passkey management section
- [ ] Can add and delete passkeys from settings
- [ ] Cannot delete last login method
- [ ] i18n works in all three languages

🤖 Generated with [Claude Code](https://claude.ai/claude-code)