### PR TITLE
Refine AI agent retrieval and streaming UX

### DIFF
--- a/server/route/v2/admin.ts
+++ b/server/route/v2/admin.ts
@@ -297,14 +297,50 @@ adminRouter.post('/setup', async (c: HonoContext) => {
       );
     }
 
-    // 检查管理员用户是否已存在
+    // 检查管理员用户是否已存在。旧版/半初始化数据库可能已有管理员但缺少 system
+    // settings，此时复用现有管理员完成配置初始化，避免卡在重复用户名。
+    const hasExistingAdmin = await hasAdminUser();
     const existingUser = await findUserByUsernameOrEmail({
       username: setupData.admin.username,
       email: setupData.admin.email,
     });
 
+    let adminUser: {
+      id: string;
+      username: string;
+      email: string;
+      role: string;
+    };
+    let reusedExistingAdmin = false;
+
     if (existingUser) {
-      return c.json(createResponse(null, 'Username or email already exists'), 400);
+      const isExistingAdmin = ['admin', 'super_admin'].includes(existingUser.role);
+      const isSameAdminIdentity =
+        existingUser.username === setupData.admin.username &&
+        existingUser.email === setupData.admin.email;
+
+      if (!isExistingAdmin || !isSameAdminIdentity) {
+        return c.json(createResponse(null, 'Username or email already exists'), 400);
+      }
+
+      adminUser = existingUser;
+      reusedExistingAdmin = true;
+    } else if (hasExistingAdmin) {
+      return c.json(
+        createResponse(
+          null,
+          'An admin user already exists. Please use the existing admin username and email to finish setup.'
+        ),
+        400
+      );
+    } else {
+      // 创建管理员用户（在事务中）
+      adminUser = await createAdminUser({
+        username: setupData.admin.username,
+        email: setupData.admin.email,
+        password: setupData.admin.password,
+        nickname: setupData.admin.nickname,
+      });
     }
 
     // 开始初始化流程
@@ -334,14 +370,6 @@ adminRouter.post('/setup', async (c: HonoContext) => {
       throw new Error('Failed to generate security keys');
     }
 
-    // 5. 创建管理员用户（在事务中）
-    const adminUser = await createAdminUser({
-      username: setupData.admin.username,
-      email: setupData.admin.email,
-      password: setupData.admin.password,
-      nickname: setupData.admin.nickname,
-    });
-
     // 6. 标记系统为已初始化
     // 获取当前迁移版本
     const migrationVersion = await getLatestMigrationVersion();
@@ -362,7 +390,9 @@ adminRouter.post('/setup', async (c: HonoContext) => {
 
     const response: SetupResponse = {
       success: true,
-      message: 'System initialization completed successfully',
+      message: reusedExistingAdmin
+        ? 'System initialization completed using the existing admin user. The existing password was not changed.'
+        : 'System initialization completed successfully',
       data: {
         adminUser,
         generatedKeys: {

--- a/server/route/v2/ai.ts
+++ b/server/route/v2/ai.ts
@@ -106,7 +106,7 @@ async function streamLegacyChatResponse(
   }
 
   if (lastUsage) {
-    logAiTokenUsage({
+    await logAiTokenUsage({
       userid: user.id,
       model: config.chat.model,
       type: 'chat',

--- a/server/route/v2/ai.ts
+++ b/server/route/v2/ai.ts
@@ -50,12 +50,44 @@ async function writeSseEvent(
   });
 }
 
+function normalizeSourcePreview(text: unknown): string {
+  return String(text || '')
+    .replace(/^(Title:[^\n]*\n)?(Tags:[^\n]*\n)?/i, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 180);
+}
+
+function toClientSource(source: any) {
+  const metadata = source?.metadata || {};
+  const tags = Array.isArray(metadata.tags)
+    ? metadata.tags.filter((tag: unknown) => typeof tag === 'string').slice(0, 8)
+    : [];
+
+  return {
+    sourceType: source.sourceType,
+    sourceId: source.sourceId,
+    similarity: Number(source.similarity) || 0,
+    preview: normalizeSourcePreview(source.text),
+    metadata: {
+      title: typeof metadata.title === 'string' ? metadata.title : '',
+      tags,
+      state: typeof metadata.state === 'string' ? metadata.state : undefined,
+      archived: typeof metadata.archived === 'boolean' ? metadata.archived : undefined,
+      createdAt: metadata.createdAt,
+    },
+  };
+}
+
 async function writeAgentSseEvent(
   stream: Parameters<Parameters<typeof streamSSE>[1]>[0],
   event: RoteAgentStreamEvent
 ): Promise<void> {
   const data = { ...(event as any) };
   delete data.type;
+  if (event.type === 'sources') {
+    data.sources = Array.isArray(event.sources) ? event.sources.map(toClientSource) : [];
+  }
   await writeSseEvent(stream, event.type, data);
 }
 
@@ -75,7 +107,7 @@ async function streamLegacyChatResponse(
     excludeIds: body?.excludeIds,
     history: body?.history,
     onPlanThinkingDelta: async (text) => {
-      await writeSseEvent(stream, 'thinking', { phase: 'planning', text });
+      await writeSseEvent(stream, 'thinking', { phase: 'retrieval_planning', text });
     },
     onPlanGenerated: async (generatedPlan) => {
       await writeSseEvent(stream, 'plan', { plan: generatedPlan });
@@ -114,7 +146,7 @@ async function streamLegacyChatResponse(
       completionTokens: lastUsage.completion_tokens,
       totalTokens: lastUsage.total_tokens,
     });
-    await writeSseEvent(stream, 'usage', lastUsage);
+    await writeSseEvent(stream, 'usage', { phase: 'answer', usage: lastUsage });
   }
 
   if (!emittedText) {

--- a/server/tests/aiRetrievalPlanner.test.ts
+++ b/server/tests/aiRetrievalPlanner.test.ts
@@ -17,7 +17,6 @@ const AVAILABLE_TAGS = ['大喜', '大悲', '工作', '生活', '技术', '植�
 function makePreviousPlan(overrides?: Partial<AiRetrievalPlan>): AiRetrievalPlan {
   return {
     originalMessage: '最近开心的事',
-    operations: ['summarize'],
     query: '开心的事',
     filters: {
       time: null,
@@ -243,7 +242,7 @@ describe('sanitizePlannerOutput', () => {
     expect(result.patch?.tags?.include).not.toContain('#大喜');
   });
 
-  it('normalizes operations', () => {
+  it('ignores legacy operation fields', () => {
     const raw = {
       intent: 'new_search',
       patch: { operations: ['summarize', 'invalid_op', 'compare'] },
@@ -251,7 +250,7 @@ describe('sanitizePlannerOutput', () => {
       reasonCode: 'note_analysis',
     };
     const result = sanitizePlannerOutput(raw, 'test');
-    expect(result.patch?.operations).toEqual(['summarize', 'compare']);
+    expect(result.patch).not.toHaveProperty('operations');
   });
 
   it('parses Rote domain scope options', () => {
@@ -567,58 +566,33 @@ describe('buildNewSearchPlan', () => {
     expect(plan.filters.time!.timeKind).toBe('rolling');
   });
 
-  it('defaults to summarize operation', () => {
-    const plan = buildNewSearchPlan({ query: 'test' }, AVAILABLE_TAGS);
-    expect(plan.operations).toEqual(['summarize']);
-  });
-
-  it('uses patch operations when provided', () => {
-    const plan = buildNewSearchPlan(
-      { query: 'test', operations: ['find_open_loops'] },
-      AVAILABLE_TAGS
-    );
-    expect(plan.operations).toEqual(['find_open_loops']);
-  });
-
-  it('excludes archived notes by default for open-loop queries', () => {
-    const plan = buildNewSearchPlan(
-      { query: '最近没收尾的 Flag', operations: ['find_open_loops'] },
-      AVAILABLE_TAGS
-    );
-    expect(plan.filters.archived).toBe(false);
-    expect(plan.summary).toContain('未归档内容');
+  it('does not infer archived scope from task-like wording without structured scope', () => {
+    const plan = buildNewSearchPlan({ query: '最近没收尾的 Flag' }, AVAILABLE_TAGS);
+    expect(plan.filters.archived).toBeNull();
   });
 
   it('respects explicit archived scope even for task queries', () => {
     const plan = buildNewSearchPlan(
       {
         query: '归档的任务有哪些',
-        operations: ['find_open_loops'],
         archivedScope: 'archived',
       },
       AVAILABLE_TAGS
     );
     expect(plan.filters.archived).toBe(true);
-    expect(plan.summary).toContain('归档内容');
+    expect(plan.summary).toContain('归档范围：仅归档');
   });
 
   it('preserves explicit all scope for open-loop queries', () => {
     const plan = buildNewSearchPlan(
       {
         query: '包括归档的所有 TODO',
-        operations: ['find_open_loops'],
         taskStatusScope: 'all',
       },
       AVAILABLE_TAGS
     );
     expect(plan.filters.archived).toBeNull();
-    expect(plan.summary || []).not.toContain('未归档内容');
-  });
-
-  it('does not infer archived scope from task-like wording without structured scope', () => {
-    const plan = buildNewSearchPlan({ query: '还有哪些任务没完成' }, AVAILABLE_TAGS);
-    expect(plan.operations).toEqual(['summarize']);
-    expect(plan.filters.archived).toBeNull();
+    expect(plan.summary || []).not.toContain('归档范围：未归档');
   });
 
   it('maps taskStatusScope=open to active notes', () => {
@@ -627,7 +601,7 @@ describe('buildNewSearchPlan', () => {
       AVAILABLE_TAGS
     );
     expect(plan.filters.archived).toBe(false);
-    expect(plan.summary).toContain('未归档内容');
+    expect(plan.summary).toContain('归档范围：未归档');
   });
 });
 
@@ -673,7 +647,6 @@ describe('sanitizePreviousPlan', () => {
     const raw = {
       originalMessage: 'test',
       query: 'test query',
-      operations: ['summarize'],
       confidence: 0.8,
       retrievalNeeded: false,
       pagination: 'more',

--- a/server/utils/ai/agent/prompt.ts
+++ b/server/utils/ai/agent/prompt.ts
@@ -32,6 +32,12 @@ ${getNativeRoteSkillSummary()}
 - Do not infer tag filters unless the user explicitly names a tag or asks for labels. Natural topic words can stay semantic.
 - If the evidence sample is small, say that clearly and keep conclusions tentative.
 
+## Language
+
+- Answer in the same language as the user's latest message.
+- If the user writes Chinese, answer in Chinese.
+- Do not switch to English unless the user asks for English.
+
 ## Sources
 
 When using Rote content, cite source numbers like [1].
@@ -52,6 +58,7 @@ If the user asks to organize, edit, tag, merge, or create notes, provide a propo
 
 export function buildFinalAnswerInstruction(): string {
   return `Use the gathered Rote tool results to answer the user's latest request.
+Answer in the same language as the user's latest message. If the user wrote Chinese, answer in Chinese.
 Keep the answer concise and grounded in sources.
 Cite source numbers like [1] whenever you rely on Rote content.
 If there is not enough evidence, say so instead of inventing.`;

--- a/server/utils/ai/agent/runtime.ts
+++ b/server/utils/ai/agent/runtime.ts
@@ -222,7 +222,7 @@ export async function runRoteAgentStream(params: {
   let emittedText = false;
 
   await params.emit({ type: 'run_started', runId });
-  await params.emit({ type: 'progress', phase: 'understanding', message: '正在理解问题' });
+  await params.emit({ type: 'progress', phase: 'understanding', message: '正在理解问题和目标' });
 
   for (let step = 0; step < policy.maxIterations; step += 1) {
     const phase: RoteAgentPhase = step === 0 ? 'planning' : 'tool_calling';
@@ -232,7 +232,7 @@ export async function runRoteAgentStream(params: {
         params.emit,
         policy,
         phase,
-        step === 0 ? '正在判断是否需要查询 Rote' : '正在判断是否需要补查',
+        step === 0 ? '正在判断是否需要读取记录' : '正在确认是否需要更多证据',
         () =>
           createChatCompletionWithTools(
             params.config.chat,
@@ -320,7 +320,7 @@ export async function runRoteAgentStream(params: {
       await params.emit({
         type: 'tool_finished',
         toolName: toolCall.function.name,
-        summary: result.observations.join(' '),
+        summary: result.displaySummary || result.observations.join(' '),
       });
 
       messages.push({

--- a/server/utils/ai/agent/runtime.ts
+++ b/server/utils/ai/agent/runtime.ts
@@ -1,6 +1,6 @@
 import {
   createChatCompletionStreamParts,
-  createChatCompletionWithTools,
+  createChatCompletionWithToolsStreaming,
   type ChatMessage,
   type ChatToolCall,
 } from '../client';
@@ -67,7 +67,6 @@ function sanitizeAgentState(request: RoteAgentRequest): RoteAgentClientState {
     conversationId: typeof state.conversationId === 'string' ? state.conversationId : undefined,
     previousPlan: state.previousPlan || request.previousPlan || null,
     seenSourceIds,
-    lastSources: Array.isArray(state.lastSources) ? state.lastSources.slice(0, 30) : [],
     selectedContext: state.selectedContext || request.selectedContext || null,
     stateVersion: Number.isFinite(state.stateVersion) ? state.stateVersion : 1,
   };
@@ -79,6 +78,14 @@ function parseToolArguments(call: ChatToolCall): unknown {
   } catch {
     return {};
   }
+}
+
+function buildToolRegistryCorrection(unknownToolNames: string[], availableToolNames: string[]) {
+  return [
+    `The requested tool name is not registered: ${unknownToolNames.join(', ')}.`,
+    `Available tools are: ${availableToolNames.join(', ')}.`,
+    'Choose one of the registered tools exactly as named, or answer without tools if no tool is needed.',
+  ].join('\n');
 }
 
 function isLikelyToolUnsupportedError(error: any): boolean {
@@ -97,12 +104,15 @@ async function emitWithHeartbeat<T>(
   emit: RoteAgentEmitter,
   policy: RoteAgentPolicy,
   phase: RoteAgentPhase,
-  message: string,
   task: () => Promise<T>
 ): Promise<T> {
-  await emit({ type: 'progress', phase, message });
+  await emit({ type: 'progress', phase });
+  let heartbeatSeq = 0;
   const timer = setInterval(() => {
-    void Promise.resolve(emit({ type: 'heartbeat', phase, message })).catch(() => {});
+    heartbeatSeq += 1;
+    void Promise.resolve(
+      emit({ type: 'heartbeat', phase, seq: heartbeatSeq, timestamp: new Date().toISOString() })
+    ).catch(() => {});
   }, policy.heartbeatMs);
 
   try {
@@ -146,18 +156,8 @@ function buildInitialMessages(request: RoteAgentRequest): ChatMessage[] {
   return messages;
 }
 
-async function emitText(emit: RoteAgentEmitter, text: string): Promise<boolean> {
-  const clean = text.trim();
-  if (!clean) return false;
-  const chunkSize = 120;
-  for (let index = 0; index < clean.length; index += chunkSize) {
-    await emit({ type: 'delta', text: clean.slice(index, index + chunkSize) });
-  }
-  return true;
-}
-
 async function streamFinalAnswer(ctx: RoteAgentContext, messages: ChatMessage[]): Promise<boolean> {
-  await ctx.emit({ type: 'progress', phase: 'answering', message: '正在组织回答' });
+  await ctx.emit({ type: 'progress', phase: 'answering' });
   let emittedText = false;
   let lastUsage: any = null;
 
@@ -176,13 +176,24 @@ async function streamFinalAnswer(ctx: RoteAgentContext, messages: ChatMessage[])
 
   if (lastUsage) {
     await logChatUsage(ctx.userId, ctx.config.chat.model, lastUsage);
-    await ctx.emit({ type: 'usage', usage: lastUsage });
+    await ctx.emit({ type: 'usage', phase: 'answer', usage: lastUsage });
   }
 
   return emittedText;
 }
 
-function fallbackAnswer(sources: SemanticSearchResult[]): string {
+function isLikelyChinese(text: string): boolean {
+  return /[\u3400-\u9fff]/.test(text);
+}
+
+function fallbackAnswer(sources: SemanticSearchResult[], question: string): string {
+  if (isLikelyChinese(question)) {
+    if (sources.length) {
+      return '我找到了相关的 Rote 记忆，但模型没有返回可用回答。可以换个问法，或把范围收窄后再试一次。';
+    }
+    return '没有找到匹配的 Rote 记忆，所以我现在还不能基于你的笔记回答这个问题。';
+  }
+
   if (sources.length) {
     return 'I found related Rote memory, but the model did not return a usable answer. Please try again or narrow the scope.';
   }
@@ -222,29 +233,33 @@ export async function runRoteAgentStream(params: {
   let emittedText = false;
 
   await params.emit({ type: 'run_started', runId });
-  await params.emit({ type: 'progress', phase: 'understanding', message: '正在理解问题和目标' });
+  await params.emit({ type: 'progress', phase: 'understanding' });
 
   for (let step = 0; step < policy.maxIterations; step += 1) {
     const phase: RoteAgentPhase = step === 0 ? 'planning' : 'tool_calling';
     let assistantMessage: ChatMessage;
     try {
-      const response = await emitWithHeartbeat(
-        params.emit,
-        policy,
-        phase,
-        step === 0 ? '正在判断是否需要读取记录' : '正在确认是否需要更多证据',
-        () =>
-          createChatCompletionWithTools(
-            params.config.chat,
-            messages,
-            tools.map((tool) => tool.definition),
-            { temperature: 0.2, enableThinking: true }
-          )
+      const response = await emitWithHeartbeat(params.emit, policy, phase, () =>
+        createChatCompletionWithToolsStreaming(
+          params.config.chat,
+          messages,
+          tools.map((tool) => tool.definition),
+          {
+            temperature: 0.2,
+            enableThinking: true,
+            onReasoning: (text) =>
+              params.emit({
+                type: 'thinking',
+                phase: step === 0 ? 'route_decision' : 'evidence_decision',
+                text,
+              }),
+          }
+        )
       );
       assistantMessage = response.message;
       if (response.usage) {
         await logChatUsage(params.userId, params.config.chat.model, response.usage);
-        await params.emit({ type: 'usage', usage: response.usage });
+        await params.emit({ type: 'usage', phase: 'tool_decision', usage: response.usage });
       }
     } catch (error: any) {
       if (step === 0 && isLikelyToolUnsupportedError(error)) {
@@ -255,17 +270,36 @@ export async function runRoteAgentStream(params: {
 
     const toolCalls = assistantMessage.tool_calls || [];
     if (!toolCalls.length) {
-      emittedText = await emitText(params.emit, assistantMessage.content || '');
       break;
+    }
+
+    const validToolCalls = toolCalls.filter((toolCall) => toolByName.has(toolCall.function.name));
+    const unknownToolNames = Array.from(
+      new Set(
+        toolCalls
+          .map((toolCall) => toolCall.function.name)
+          .filter((toolName) => !toolByName.has(toolName))
+      )
+    );
+
+    if (unknownToolNames.length > 0) {
+      messages.push({
+        role: 'system',
+        content: buildToolRegistryCorrection(unknownToolNames, Array.from(toolByName.keys())),
+      });
+    }
+
+    if (validToolCalls.length === 0) {
+      continue;
     }
 
     messages.push({
       role: 'assistant',
       content: assistantMessage.content || null,
-      tool_calls: toolCalls,
+      tool_calls: validToolCalls,
     });
 
-    for (const toolCall of toolCalls) {
+    for (const toolCall of validToolCalls) {
       if (toolCallCount >= policy.maxToolCalls) {
         messages.push({
           role: 'tool',
@@ -289,26 +323,8 @@ export async function runRoteAgentStream(params: {
       const args = parseToolArguments(toolCall);
       await params.emit({ type: 'tool_started', toolName: toolCall.function.name, args });
 
-      if (!tool) {
-        const errorContent = JSON.stringify({
-          status: 'error',
-          message: `Unknown tool: ${toolCall.function.name}`,
-        });
-        messages.push({ role: 'tool', tool_call_id: toolCall.id, content: errorContent });
-        await params.emit({
-          type: 'tool_finished',
-          toolName: toolCall.function.name,
-          summary: 'Unknown tool',
-        });
-        continue;
-      }
-
-      const result = await emitWithHeartbeat(
-        params.emit,
-        policy,
-        'tool_calling',
-        `正在执行 ${toolCall.function.name}`,
-        () => tool.execute(args, ctx, toolCall)
+      const result = await emitWithHeartbeat(params.emit, policy, 'tool_calling', () =>
+        tool!.execute(args, ctx, toolCall)
       );
 
       if (result.plan) await params.emit({ type: 'plan', plan: result.plan });
@@ -349,7 +365,7 @@ export async function runRoteAgentStream(params: {
   }
 
   if (!emittedText) {
-    await params.emit({ type: 'delta', text: fallbackAnswer(ctx.getSources()) });
+    await params.emit({ type: 'delta', text: fallbackAnswer(ctx.getSources(), request.message) });
   }
 
   await params.emit({
@@ -357,7 +373,6 @@ export async function runRoteAgentStream(params: {
     state: {
       seenSourceIds: ctx.state.seenSourceIds,
       previousPlan: ctx.state.previousPlan,
-      lastSources: ctx.getSources(),
     },
   });
   await params.emit({ type: 'done' });

--- a/server/utils/ai/agent/tools.ts
+++ b/server/utils/ai/agent/tools.ts
@@ -205,10 +205,16 @@ function normalizePreviousStatePlan(
   return sanitizePreviousPlan(ctx.request.previousPlan || ctx.state.previousPlan, availableTags);
 }
 
-function buildSeenSourceIds(ctx: RoteAgentContext, sources: SemanticSearchResult[]): string[] {
-  return Array.from(
-    new Set([...(ctx.state.seenSourceIds || []), ...sources.map((source) => sourceKey(source))])
-  ).slice(0, 500);
+function buildSeenSourceIds(
+  ctx: RoteAgentContext,
+  sources: SemanticSearchResult[],
+  includePrevious = true
+): string[] {
+  const previousIds = includePrevious ? ctx.state.seenSourceIds || [] : [];
+  return Array.from(new Set([...previousIds, ...sources.map((source) => sourceKey(source))])).slice(
+    0,
+    500
+  );
 }
 
 async function resolveSearchPlan(
@@ -277,10 +283,10 @@ async function executeSearchNotes(
     toolName: 'rote_search_notes',
     message: '正在检索相关记录',
   });
-  const excludeIds = sanitizeExcludeIds([
-    ...(ctx.request.excludeIds || []),
-    ...(ctx.state.seenSourceIds || []),
-  ]);
+  const shouldUseSeenSourceIds = plan.pagination === 'more';
+  const excludeIds = shouldUseSeenSourceIds
+    ? sanitizeExcludeIds([...(ctx.request.excludeIds || []), ...(ctx.state.seenSourceIds || [])])
+    : undefined;
   const limit = normalizeLimit(input.limit, ctx.request.limit || 8);
   const { sources, diagnostics } = await buildRetrievalContext({
     ownerId: ctx.userId,
@@ -292,7 +298,7 @@ async function executeSearchNotes(
   const registeredSources = formatRegisteredSources(registrations, ctx.policy.maxSourceChars);
   const statePatch = {
     previousPlan: plan,
-    seenSourceIds: buildSeenSourceIds(ctx, sources),
+    seenSourceIds: buildSeenSourceIds(ctx, sources, shouldUseSeenSourceIds),
     lastSources: sources,
   };
 

--- a/server/utils/ai/agent/tools.ts
+++ b/server/utils/ai/agent/tools.ts
@@ -17,7 +17,6 @@ import {
   createRetrievalPlan,
   getUserRoteTags,
   type AiArchivedScope,
-  type AiRetrievalOperation,
   type AiRetrievalPlan,
   type AiTaskStatusScope,
   type PlannerOutput,
@@ -33,7 +32,6 @@ import type {
 type SearchNotesInput = {
   query?: string;
   intentHint?: 'new_search' | 'more' | 'refine' | 'review';
-  operations?: AiRetrievalOperation[];
   tags?: { include?: string[]; exclude?: string[] };
   semanticScope?: string[];
   timeExpression?: string;
@@ -44,15 +42,6 @@ type SearchNotesInput = {
 };
 
 const VALID_SOURCE_TYPES = new Set<AiSourceType>(['rote', 'article']);
-const VALID_OPERATIONS = new Set<AiRetrievalOperation>([
-  'summarize',
-  'compare',
-  'timeline',
-  'find_open_loops',
-  'analyze_mood',
-  'analyze_stress',
-  'analyze_personality',
-]);
 const VALID_ARCHIVED_SCOPES = new Set<AiArchivedScope>([
   'active',
   'archived',
@@ -65,7 +54,6 @@ const VALID_TASK_STATUS_SCOPES = new Set<AiTaskStatusScope>([
   'all',
   'unspecified',
 ]);
-
 function asRecord(value: unknown): Record<string, any> {
   return value && typeof value === 'object' && !Array.isArray(value)
     ? (value as Record<string, any>)
@@ -86,7 +74,11 @@ function uniqueStrings(value: unknown, limit = 20): string[] {
 function normalizeLimit(value: unknown, fallback = 8): number {
   const numeric = Number(value);
   if (!Number.isFinite(numeric)) return fallback;
-  return Math.min(Math.max(Math.floor(numeric), 1), 30);
+  return Math.min(Math.max(Math.floor(numeric), 1), 50);
+}
+
+function resolveAgentFinalSourceLimit(requestedLimit?: number): number {
+  return normalizeLimit(requestedLimit, 15);
 }
 
 function sourceKey(source: SemanticSearchResult): string {
@@ -127,30 +119,6 @@ function formatRegisteredSources(
   }));
 }
 
-function formatSourceTypeLabel(sources: SemanticSearchResult[]): string {
-  const sourceTypes = new Set(sources.map((source) => source.sourceType));
-  if (sourceTypes.size === 1 && sourceTypes.has('rote')) return '笔记';
-  if (sourceTypes.size === 1 && sourceTypes.has('article')) return '文章';
-  return '记录';
-}
-
-function formatSampleStatusLabel(sampleStatus: 'no_evidence' | 'limited_sample' | 'adequate') {
-  if (sampleStatus === 'no_evidence') return '没有足够证据';
-  if (sampleStatus === 'limited_sample') return '样本偏少，结论会保守';
-  return '样本量足够';
-}
-
-function formatSearchDisplaySummary(
-  sources: SemanticSearchResult[],
-  diagnostics: { sampleStatus: 'no_evidence' | 'limited_sample' | 'adequate' }
-): string {
-  if (sources.length === 0) return '没有找到可用的相关记录';
-  const sourceLabel = formatSourceTypeLabel(sources);
-  return `找到 ${sources.length} 条相关${sourceLabel}，${formatSampleStatusLabel(
-    diagnostics.sampleStatus
-  )}`;
-}
-
 function toModelContent(value: unknown): string {
   return JSON.stringify(value, null, 2);
 }
@@ -161,11 +129,6 @@ function parseSearchNotesInput(args: unknown): SearchNotesInput {
   const sourceTypes = uniqueStrings(raw.sourceTypes)
     .filter((type): type is AiSourceType => VALID_SOURCE_TYPES.has(type as AiSourceType))
     .slice(0, 2);
-  const operations = uniqueStrings(raw.operations)
-    .filter((operation): operation is AiRetrievalOperation =>
-      VALID_OPERATIONS.has(operation as AiRetrievalOperation)
-    )
-    .slice(0, 4);
   return {
     query: typeof raw.query === 'string' ? raw.query.trim() : undefined,
     intentHint:
@@ -175,7 +138,6 @@ function parseSearchNotesInput(args: unknown): SearchNotesInput {
       raw.intentHint === 'new_search'
         ? raw.intentHint
         : undefined,
-    operations: operations.length ? operations : undefined,
     tags:
       tags.include || tags.exclude
         ? {
@@ -192,13 +154,12 @@ function parseSearchNotesInput(args: unknown): SearchNotesInput {
       ? (raw.taskStatusScope as AiTaskStatusScope)
       : undefined,
     sourceTypes: sourceTypes.length ? sourceTypes : undefined,
-    limit: normalizeLimit(raw.limit),
+    limit: raw.limit === undefined ? undefined : normalizeLimit(raw.limit),
   };
 }
 
 function hasStructuredSearchPatch(input: SearchNotesInput): boolean {
   return Boolean(
-    input.operations?.length ||
     input.tags?.include?.length ||
     input.tags?.exclude?.length ||
     input.semanticScope?.length ||
@@ -209,10 +170,23 @@ function hasStructuredSearchPatch(input: SearchNotesInput): boolean {
   );
 }
 
-function buildPatchFromSearchInput(input: SearchNotesInput): PlannerOutput['patch'] {
+function buildPatchFromSearchInput(
+  input: SearchNotesInput,
+  fallbackQuery: string
+): PlannerOutput['patch'] {
+  const toolQuery = input.query?.trim() || '';
+  const hasHardScope = Boolean(
+    input.tags?.include?.length ||
+    input.tags?.exclude?.length ||
+    input.timeExpression ||
+    input.archivedScope ||
+    input.taskStatusScope ||
+    input.sourceTypes?.length
+  );
+  const hasSoftScope = Boolean(input.semanticScope?.length);
+  const query = toolQuery || (hasHardScope && !hasSoftScope ? '' : fallbackQuery);
   return {
-    query: input.query || '',
-    operations: input.operations,
+    query,
     tags: input.tags,
     semanticScope: input.semanticScope,
     timeExpression: input.timeExpression,
@@ -246,12 +220,12 @@ async function resolveSearchPlan(
   ctx: RoteAgentContext
 ): Promise<AiRetrievalPlan> {
   const availableTags = await getUserRoteTags(ctx.userId);
+  const fallbackQuery = ctx.request.message?.trim() || '';
   if (hasStructuredSearchPatch(input)) {
-    return buildNewSearchPlan(buildPatchFromSearchInput(input), availableTags);
+    return buildNewSearchPlan(buildPatchFromSearchInput(input, fallbackQuery), availableTags);
   }
 
-  const query =
-    input.query || (input.intentHint === 'more' ? '多来几条' : '') || ctx.request.message || '';
+  const query = input.query || (input.intentHint === 'more' ? '多来几条' : '') || fallbackQuery;
   const previousPlan = normalizePreviousStatePlan(ctx, availableTags);
 
   return createRetrievalPlan({
@@ -262,16 +236,18 @@ async function resolveSearchPlan(
     clarificationAnswer: ctx.request.clarificationAnswer,
     previousPlan,
     history: ctx.request.history,
-    onThinkingDelta: (text) => ctx.emit({ type: 'thinking', phase: 'planning', text }),
-    onUsage: (usage) =>
-      logAiTokenUsage({
+    onThinkingDelta: (text) => ctx.emit({ type: 'thinking', phase: 'retrieval_planning', text }),
+    onUsage: async (usage) => {
+      await logAiTokenUsage({
         userid: ctx.userId,
         model: ctx.config.chat.model,
         type: 'chat',
         promptTokens: usage.prompt_tokens,
         completionTokens: usage.completion_tokens,
         totalTokens: usage.total_tokens,
-      }),
+      });
+      await ctx.emit({ type: 'usage', phase: 'planning', usage });
+    },
   });
 }
 
@@ -283,7 +259,7 @@ async function executeSearchNotes(
   await ctx.emit({
     type: 'tool_progress',
     toolName: 'rote_search_notes',
-    message: '正在确定查询范围',
+    status: 'determining_scope',
   });
   const plan = await resolveSearchPlan(input, ctx);
 
@@ -305,17 +281,19 @@ async function executeSearchNotes(
   await ctx.emit({
     type: 'tool_progress',
     toolName: 'rote_search_notes',
-    message: '正在检索相关记录',
+    status: 'retrieving_sources',
   });
   const shouldUseSeenSourceIds = plan.pagination === 'more';
   const excludeIds = shouldUseSeenSourceIds
     ? sanitizeExcludeIds([...(ctx.request.excludeIds || []), ...(ctx.state.seenSourceIds || [])])
     : undefined;
-  const limit = normalizeLimit(input.limit, ctx.request.limit || 8);
+  const requestedLimit = input.limit ?? ctx.request.limit;
+  const sourceLimit = resolveAgentFinalSourceLimit(requestedLimit);
   const { sources, diagnostics } = await buildRetrievalContext({
     ownerId: ctx.userId,
     plan,
-    limit,
+    limit: sourceLimit,
+    sourceLimit,
     excludeIds,
   });
   const registrations = ctx.registerSources(sources);
@@ -323,7 +301,6 @@ async function executeSearchNotes(
   const statePatch = {
     previousPlan: plan,
     seenSourceIds: buildSeenSourceIds(ctx, sources, shouldUseSeenSourceIds),
-    lastSources: sources,
   };
 
   return {
@@ -331,7 +308,11 @@ async function executeSearchNotes(
       `Found ${sources.length} source(s).`,
       `Sample status: ${diagnostics.sampleStatus}.`,
     ],
-    displaySummary: formatSearchDisplaySummary(sources, diagnostics),
+    displaySummary: {
+      count: sources.length,
+      sampleStatus: diagnostics.sampleStatus,
+      sourceTypes: Array.from(new Set(sources.map((s) => s.sourceType))),
+    },
     sources,
     plan,
     statePatch,
@@ -339,7 +320,6 @@ async function executeSearchNotes(
       status: 'ok',
       plan: {
         query: plan.query,
-        operations: plan.operations,
         summary: plan.summary || [],
         sampleStatus: diagnostics.sampleStatus,
         candidateCount: diagnostics.candidateCount,
@@ -420,7 +400,7 @@ async function executeGetNote(args: unknown, ctx: RoteAgentContext): Promise<Rot
   const sourceId = typeof raw.sourceId === 'string' ? raw.sourceId.trim() : '';
   if (!sourceId) throw new Error('sourceId is required');
 
-  await ctx.emit({ type: 'tool_progress', toolName: 'rote_get_note', message: '正在读取记录内容' });
+  await ctx.emit({ type: 'tool_progress', toolName: 'rote_get_note', status: 'reading_source' });
   const { source, content } = await loadOwnedSource(ctx, sourceType, sourceId);
   const registration = ctx.registerSources([source]);
   const maxContentLength = Math.min(ctx.policy.maxSourceChars, 8000);
@@ -430,7 +410,6 @@ async function executeGetNote(args: unknown, ctx: RoteAgentContext): Promise<Rot
     sources: [source],
     statePatch: {
       seenSourceIds: buildSeenSourceIds(ctx, [source]),
-      lastSources: [source],
     },
     modelContent: toModelContent({
       status: 'ok',
@@ -455,7 +434,7 @@ async function executeFindRelatedNotes(
   await ctx.emit({
     type: 'tool_progress',
     toolName: 'rote_find_related_notes',
-    message: '正在查找相关记录',
+    status: 'finding_related',
   });
   const { content } = await loadOwnedSource(ctx, sourceType, sourceId);
   const sources = await semanticSearch({
@@ -472,7 +451,6 @@ async function executeFindRelatedNotes(
     sources,
     statePatch: {
       seenSourceIds: buildSeenSourceIds(ctx, sources),
-      lastSources: sources,
     },
     modelContent: toModelContent({
       status: 'ok',
@@ -482,7 +460,7 @@ async function executeFindRelatedNotes(
 }
 
 async function executeGetTags(_args: unknown, ctx: RoteAgentContext): Promise<RoteAgentToolResult> {
-  await ctx.emit({ type: 'tool_progress', toolName: 'rote_get_tags', message: '正在读取标签' });
+  await ctx.emit({ type: 'tool_progress', toolName: 'rote_get_tags', status: 'loading_tags' });
   const rows = await db
     .select({ tags: rotes.tags })
     .from(rotes)
@@ -548,15 +526,12 @@ export function getNativeRoteTools(): RoteAgentTool[] {
           parameters: {
             type: 'object',
             properties: {
-              query: { type: 'string' },
-              intentHint: { type: 'string', enum: ['new_search', 'more', 'refine', 'review'] },
-              operations: {
-                type: 'array',
-                items: {
-                  type: 'string',
-                  enum: Array.from(VALID_OPERATIONS),
-                },
+              query: {
+                type: 'string',
+                description:
+                  'Semantic evidence query. For broad analysis, write a broad useful query; leave empty only for pure hard-filter browsing.',
               },
+              intentHint: { type: 'string', enum: ['new_search', 'more', 'refine', 'review'] },
               tags: {
                 type: 'object',
                 properties: {
@@ -564,7 +539,12 @@ export function getNativeRoteTools(): RoteAgentTool[] {
                   exclude: { type: 'array', items: { type: 'string' } },
                 },
               },
-              semanticScope: { type: 'array', items: { type: 'string' } },
+              semanticScope: {
+                type: 'array',
+                items: { type: 'string' },
+                description:
+                  'Soft topic keywords for semantic retrieval. Use for themes and patterns that are not verified tags.',
+              },
               timeExpression: { type: 'string' },
               archivedScope: {
                 type: 'string',
@@ -582,7 +562,11 @@ export function getNativeRoteTools(): RoteAgentTool[] {
                 type: 'array',
                 items: { type: 'string', enum: ['rote', 'article'] },
               },
-              limit: { type: 'number' },
+              limit: {
+                type: 'number',
+                description:
+                  'Final source count to return. Choose a larger value for broad pattern analysis and a smaller value for focused lookup.',
+              },
             },
             required: ['query'],
           },

--- a/server/utils/ai/agent/tools.ts
+++ b/server/utils/ai/agent/tools.ts
@@ -127,6 +127,30 @@ function formatRegisteredSources(
   }));
 }
 
+function formatSourceTypeLabel(sources: SemanticSearchResult[]): string {
+  const sourceTypes = new Set(sources.map((source) => source.sourceType));
+  if (sourceTypes.size === 1 && sourceTypes.has('rote')) return '笔记';
+  if (sourceTypes.size === 1 && sourceTypes.has('article')) return '文章';
+  return '记录';
+}
+
+function formatSampleStatusLabel(sampleStatus: 'no_evidence' | 'limited_sample' | 'adequate') {
+  if (sampleStatus === 'no_evidence') return '没有足够证据';
+  if (sampleStatus === 'limited_sample') return '样本偏少，结论会保守';
+  return '样本量足够';
+}
+
+function formatSearchDisplaySummary(
+  sources: SemanticSearchResult[],
+  diagnostics: { sampleStatus: 'no_evidence' | 'limited_sample' | 'adequate' }
+): string {
+  if (sources.length === 0) return '没有找到可用的相关记录';
+  const sourceLabel = formatSourceTypeLabel(sources);
+  return `找到 ${sources.length} 条相关${sourceLabel}，${formatSampleStatusLabel(
+    diagnostics.sampleStatus
+  )}`;
+}
+
 function toModelContent(value: unknown): string {
   return JSON.stringify(value, null, 2);
 }
@@ -307,6 +331,7 @@ async function executeSearchNotes(
       `Found ${sources.length} source(s).`,
       `Sample status: ${diagnostics.sampleStatus}.`,
     ],
+    displaySummary: formatSearchDisplaySummary(sources, diagnostics),
     sources,
     plan,
     statePatch,

--- a/server/utils/ai/agent/types.ts
+++ b/server/utils/ai/agent/types.ts
@@ -89,6 +89,7 @@ export type RoteAgentContext = {
 
 export type RoteAgentToolResult = {
   observations: string[];
+  displaySummary?: string;
   modelContent: string;
   sources?: SemanticSearchResult[];
   plan?: AiRetrievalPlan;

--- a/server/utils/ai/agent/types.ts
+++ b/server/utils/ai/agent/types.ts
@@ -12,11 +12,24 @@ export type RoteAgentPhase =
   | 'reading'
   | 'answering';
 
+export type RoteAgentToolProgressStatus =
+  | 'determining_scope'
+  | 'retrieving_sources'
+  | 'reading_source'
+  | 'finding_related'
+  | 'loading_tags';
+
+export type RoteAgentUsagePhase = 'planning' | 'tool_decision' | 'answer';
+export type RoteAgentThinkingPhase =
+  | 'route_decision'
+  | 'evidence_decision'
+  | 'retrieval_planning'
+  | 'answer';
+
 export type RoteAgentClientState = {
   conversationId?: string;
   previousPlan?: AiRetrievalPlan | null;
   seenSourceIds?: string[];
-  lastSources?: SemanticSearchResult[];
   selectedContext?: {
     currentRoteId?: string;
     currentArticleId?: string;
@@ -52,18 +65,18 @@ export type RoteAgentPolicy = {
 export type RoteAgentStreamEvent =
   | { type: 'run_started'; runId: string }
   | { type: 'skill_selected'; skillName: string }
-  | { type: 'progress'; phase: RoteAgentPhase; message: string }
-  | { type: 'heartbeat'; phase: RoteAgentPhase; message?: string }
+  | { type: 'progress'; phase: RoteAgentPhase }
+  | { type: 'heartbeat'; phase: RoteAgentPhase; seq: number; timestamp: string }
   | { type: 'tool_started'; toolName: string; args?: unknown }
-  | { type: 'tool_progress'; toolName: string; message: string }
-  | { type: 'tool_finished'; toolName: string; summary?: string }
+  | { type: 'tool_progress'; toolName: string; status: RoteAgentToolProgressStatus }
+  | { type: 'tool_finished'; toolName: string; summary?: unknown }
   | { type: 'sources'; sources: SemanticSearchResult[] }
   | { type: 'plan'; plan: AiRetrievalPlan }
   | { type: 'clarification'; question: string; pendingPlan: AiRetrievalPlan }
-  | { type: 'thinking'; phase: 'planning' | 'answer'; text: string }
+  | { type: 'thinking'; phase: RoteAgentThinkingPhase; text: string }
   | { type: 'delta'; text: string }
   | { type: 'state_patch'; state: Partial<RoteAgentClientState> }
-  | { type: 'usage'; usage: ChatCompletionUsage }
+  | { type: 'usage'; phase: RoteAgentUsagePhase; usage: ChatCompletionUsage }
   | { type: 'done' }
   | { type: 'error'; message: string };
 
@@ -89,7 +102,7 @@ export type RoteAgentContext = {
 
 export type RoteAgentToolResult = {
   observations: string[];
-  displaySummary?: string;
+  displaySummary?: unknown;
   modelContent: string;
   sources?: SemanticSearchResult[];
   plan?: AiRetrievalPlan;

--- a/server/utils/ai/client.ts
+++ b/server/utils/ai/client.ts
@@ -77,6 +77,26 @@ function normalizeBaseUrl(baseUrl: string): string {
   return baseUrl.trim().replace(/\/+$/, '');
 }
 
+function normalizeToolCalls(value: unknown): ChatToolCall[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const toolCalls = value
+    .filter(
+      (call: any) =>
+        typeof call?.id === 'string' &&
+        call?.type === 'function' &&
+        typeof call?.function?.name === 'string'
+    )
+    .map((call: any) => ({
+      id: call.id,
+      type: 'function' as const,
+      function: {
+        name: call.function.name,
+        arguments: typeof call.function.arguments === 'string' ? call.function.arguments : '{}',
+      },
+    }));
+  return toolCalls.length ? toolCalls : undefined;
+}
+
 function buildHeaders(config: AiProviderConfig): Record<string, string> {
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
@@ -241,31 +261,140 @@ export async function createChatCompletionWithTools(
     throw new Error('Chat provider returned an invalid tool completion response');
   }
 
-  const toolCalls = Array.isArray(message.tool_calls)
-    ? message.tool_calls
-        .filter(
-          (call: any) =>
-            typeof call?.id === 'string' &&
-            call?.type === 'function' &&
-            typeof call?.function?.name === 'string'
-        )
-        .map((call: any) => ({
-          id: call.id,
-          type: 'function' as const,
-          function: {
-            name: call.function.name,
-            arguments: typeof call.function.arguments === 'string' ? call.function.arguments : '{}',
-          },
-        }))
-    : undefined;
-
   return {
     message: {
       role: 'assistant',
       content: typeof message.content === 'string' ? message.content : null,
-      tool_calls: toolCalls,
+      tool_calls: normalizeToolCalls(message.tool_calls),
     },
     usage: normalizeUsage(body?.usage),
+  };
+}
+
+export async function createChatCompletionWithToolsStreaming(
+  config: AiProviderConfig,
+  messages: ChatMessage[],
+  tools: ChatToolDefinition[],
+  options: ChatCompletionOptions & {
+    onReasoning?: (text: string) => Promise<void> | void;
+  } = {}
+): Promise<{
+  message: ChatMessage;
+  usage?: ChatCompletionUsage;
+}> {
+  ensureProviderConfig(config);
+
+  const response = await fetch(`${normalizeBaseUrl(config.baseUrl)}/chat/completions`, {
+    method: 'POST',
+    headers: buildHeaders(config),
+    body: JSON.stringify(
+      buildChatRequestBody(config, {
+        messages,
+        tools,
+        toolChoice: 'auto',
+        temperature: options.temperature ?? 0.2,
+        stream: true,
+        enableThinking: options.enableThinking,
+      })
+    ),
+  });
+
+  if (!response.ok) {
+    await readJsonResponse(response);
+  }
+
+  if (!response.body) {
+    throw new Error('Chat provider returned an empty tool stream response');
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  const toolCallsByIndex = new Map<number, ChatToolCall>();
+  let buffer = '';
+  let content = '';
+  let usage: ChatCompletionUsage | undefined;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split(/\r?\n/);
+      buffer = lines.pop() || '';
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith(':') || !trimmed.startsWith('data:')) continue;
+
+        const data = trimmed.slice(5).trim();
+        if (data === '[DONE]') {
+          return {
+            message: {
+              role: 'assistant',
+              content: content || null,
+              tool_calls: normalizeToolCalls(Array.from(toolCallsByIndex.values())),
+            },
+            usage,
+          };
+        }
+
+        let chunk: any;
+        try {
+          chunk = JSON.parse(data);
+        } catch {
+          continue;
+        }
+
+        const delta = chunk?.choices?.[0]?.delta || {};
+        const reasoning = delta.reasoning_content || delta.reasoning;
+        if (typeof reasoning === 'string' && reasoning.length > 0) {
+          await options.onReasoning?.(reasoning);
+        }
+
+        if (typeof delta.content === 'string' && delta.content.length > 0) {
+          content += delta.content;
+        }
+
+        if (Array.isArray(delta.tool_calls)) {
+          for (const deltaCall of delta.tool_calls) {
+            const index = Number.isInteger(deltaCall?.index)
+              ? deltaCall.index
+              : toolCallsByIndex.size;
+            const existing =
+              toolCallsByIndex.get(index) ||
+              ({
+                id: typeof deltaCall?.id === 'string' ? deltaCall.id : `call_${index}`,
+                type: 'function',
+                function: { name: '', arguments: '' },
+              } satisfies ChatToolCall);
+
+            if (typeof deltaCall?.id === 'string') existing.id = deltaCall.id;
+            if (typeof deltaCall?.function?.name === 'string') {
+              existing.function.name = deltaCall.function.name;
+            }
+            if (typeof deltaCall?.function?.arguments === 'string') {
+              existing.function.arguments += deltaCall.function.arguments;
+            }
+            toolCallsByIndex.set(index, existing);
+          }
+        }
+
+        const chunkUsage = normalizeUsage(chunk?.usage);
+        if (chunkUsage) usage = chunkUsage;
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  return {
+    message: {
+      role: 'assistant',
+      content: content || null,
+      tool_calls: normalizeToolCalls(Array.from(toolCallsByIndex.values())),
+    },
+    usage,
   };
 }
 

--- a/server/utils/ai/client.ts
+++ b/server/utils/ai/client.ts
@@ -43,6 +43,36 @@ export type ChatCompletionStreamPart =
       usage: ChatCompletionUsage;
     };
 
+function toTokenCount(value: unknown): number {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric > 0 ? Math.floor(numeric) : 0;
+}
+
+function normalizeUsage(usage: any, fallbackCompletionTokens = 0): ChatCompletionUsage | undefined {
+  if (!usage || typeof usage !== 'object') return undefined;
+
+  const promptTokens = toTokenCount(
+    usage.prompt_tokens ?? usage.input_tokens ?? usage.promptTokens ?? usage.inputTokens
+  );
+  const completionTokens = toTokenCount(
+    usage.completion_tokens ??
+      usage.output_tokens ??
+      usage.completionTokens ??
+      usage.outputTokens ??
+      fallbackCompletionTokens
+  );
+  const explicitTotalTokens = toTokenCount(usage.total_tokens ?? usage.totalTokens);
+  const totalTokens = explicitTotalTokens || promptTokens + completionTokens;
+
+  if (totalTokens === 0) return undefined;
+
+  return {
+    prompt_tokens: promptTokens,
+    completion_tokens: completionTokens,
+    total_tokens: totalTokens,
+  };
+}
+
 function normalizeBaseUrl(baseUrl: string): string {
   return baseUrl.trim().replace(/\/+$/, '');
 }
@@ -142,12 +172,7 @@ export async function createEmbedding(
 
   return {
     embedding,
-    usage: body?.usage
-      ? {
-          prompt_tokens: body.usage.prompt_tokens || 0,
-          total_tokens: body.usage.total_tokens || 0,
-        }
-      : undefined,
+    usage: normalizeUsage(body?.usage),
   };
 }
 
@@ -181,13 +206,7 @@ export async function createChatCompletion(
 
   return {
     content,
-    usage: body?.usage
-      ? {
-          prompt_tokens: body.usage.prompt_tokens || 0,
-          completion_tokens: body.usage.completion_tokens || 0,
-          total_tokens: body.usage.total_tokens || 0,
-        }
-      : undefined,
+    usage: normalizeUsage(body?.usage),
   };
 }
 
@@ -246,13 +265,7 @@ export async function createChatCompletionWithTools(
       content: typeof message.content === 'string' ? message.content : null,
       tool_calls: toolCalls,
     },
-    usage: body?.usage
-      ? {
-          prompt_tokens: body.usage.prompt_tokens || 0,
-          completion_tokens: body.usage.completion_tokens || 0,
-          total_tokens: body.usage.total_tokens || 0,
-        }
-      : undefined,
+    usage: normalizeUsage(body?.usage),
   };
 }
 
@@ -322,14 +335,11 @@ export async function* createChatCompletionStreamParts(
           yield { type: 'content', text: content };
         }
 
-        if (chunk?.usage) {
+        const usage = normalizeUsage(chunk?.usage);
+        if (usage) {
           yield {
             type: 'usage',
-            usage: {
-              prompt_tokens: chunk.usage.prompt_tokens || 0,
-              completion_tokens: chunk.usage.completion_tokens || 0,
-              total_tokens: chunk.usage.total_tokens || 0,
-            },
+            usage,
           };
         }
       }

--- a/server/utils/ai/retrievalPlan.ts
+++ b/server/utils/ai/retrievalPlan.ts
@@ -4,15 +4,6 @@ import type { AiConfig } from '../../types/config';
 import db from '../drizzle';
 import { createChatCompletionStreamParts, type ChatCompletionUsage } from './client';
 
-export type AiRetrievalOperation =
-  | 'summarize'
-  | 'compare'
-  | 'timeline'
-  | 'find_open_loops'
-  | 'analyze_mood'
-  | 'analyze_stress'
-  | 'analyze_personality';
-
 export type AiTimeKind =
   | 'none'
   | 'rolling'
@@ -96,7 +87,6 @@ export interface PlannerOutput {
     semanticScope?: string[];
     timeExpression?: string;
     sourceTypes?: ('rote' | 'article')[];
-    operations?: AiRetrievalOperation[];
     archivedScope?: AiArchivedScope;
     taskStatusScope?: AiTaskStatusScope;
     comparison?: {
@@ -116,7 +106,6 @@ export interface PlannerOutput {
 
 export interface AiRetrievalPlan {
   originalMessage?: string;
-  operations: AiRetrievalOperation[];
   query: string;
   filters: AiRetrievalFilters;
   comparison: AiRetrievalComparison | null;
@@ -133,16 +122,6 @@ export interface AiNormalizedTimeRange {
   to: string;
   label: string;
 }
-
-const VALID_OPERATIONS = new Set<AiRetrievalOperation>([
-  'summarize',
-  'compare',
-  'timeline',
-  'find_open_loops',
-  'analyze_mood',
-  'analyze_stress',
-  'analyze_personality',
-]);
 
 const VALID_SOURCE_TYPES = new Set(['rote', 'article']);
 
@@ -208,7 +187,6 @@ function emptyTagPlan(): AiTagPlan {
 export function fallbackPlan(message: string): AiRetrievalPlan {
   return {
     originalMessage: message,
-    operations: ['summarize'],
     query: message,
     filters: createDefaultFilters(),
     comparison: null,
@@ -295,11 +273,6 @@ export function sanitizePlannerOutput(raw: any, message: string): PlannerOutput 
       patch.sourceTypes = normalizeSourceTypes(raw.patch.sourceTypes);
     patch.archivedScope = normalizeArchivedScopeOption(raw.patch.archivedScope);
     patch.taskStatusScope = normalizeTaskStatusScopeOption(raw.patch.taskStatusScope);
-    if (Array.isArray(raw.patch.operations)) {
-      patch.operations = raw.patch.operations.filter((op: unknown): op is AiRetrievalOperation =>
-        VALID_OPERATIONS.has(op as AiRetrievalOperation)
-      );
-    }
     if (raw.patch.comparison && typeof raw.patch.comparison === 'object') {
       const comp = raw.patch.comparison;
       const validModes = new Set(['time', 'tag_groups', 'filter_groups']);
@@ -412,12 +385,6 @@ function monthRange(year: number, monthIndex: number): AiNormalizedTimeRange {
   };
 }
 
-function defaultDaysForOperations(operations: AiRetrievalOperation[]): number {
-  if (operations.includes('timeline')) return 30;
-  if (operations.includes('compare')) return 30;
-  return 90;
-}
-
 function hasAllTimeExpression(message: string, time?: AiTimePlan | null): boolean {
   const expression = `${message} ${time?.timeExpression || ''}`;
   return /全部|长期|历史|所有/.test(expression) || time?.timeKind === 'all_time';
@@ -429,17 +396,6 @@ function hasAmbiguousTimeExpression(time?: AiTimePlan | null): boolean {
     time?.timeKind === 'ambiguous' &&
     /(那段|开始|以后|之前|低落|这阵子|那时候|那会儿)/.test(expression)
   );
-}
-
-function normalizeArchivedScope(
-  operations: AiRetrievalOperation[],
-  archived: boolean | null,
-  archivedScopeSpecified?: boolean
-): boolean | null {
-  if (operations.includes('find_open_loops') && archived === null && !archivedScopeSpecified) {
-    return false;
-  }
-  return archived;
 }
 
 function archivedFromDomainScopes(
@@ -478,7 +434,6 @@ function isPlainRecentExpression(expression: string): boolean {
 
 function normalizeTimeRange(
   message: string,
-  operations: AiRetrievalOperation[],
   time?: AiTimePlan | null
 ): { time: AiTimePlan | null; needsClarification: boolean } {
   if (hasAllTimeExpression(message, time)) {
@@ -601,7 +556,7 @@ function normalizeTimeRange(
     normalized = { ...time, from: range.from, to: range.to, needsClarification: false };
   } else if (time) {
     // Time was provided but didn't match any specific pattern — apply default window
-    const days = defaultDaysForOperations(operations);
+    const days = 90;
     const start = addDays(today, -days);
     range = {
       from: startOfDay(start),
@@ -734,22 +689,17 @@ function normalizeTagScope(
 
 function normalizeFilterScope(
   message: string,
-  operations: AiRetrievalOperation[],
   filters: AiRetrievalFilters,
   availableTags: string[],
   options: { autoAddExplicitTags?: boolean } = {}
 ): { filters: AiRetrievalFilters; needsClarification: boolean } {
   const tagResult = normalizeTagScope(message, filters, availableTags, options);
-  const timeResult = normalizeTimeRange(message, operations, tagResult.filters.time);
+  const timeResult = normalizeTimeRange(message, tagResult.filters.time);
   return {
     filters: {
       ...tagResult.filters,
       time: timeResult.time,
-      archived: normalizeArchivedScope(
-        operations,
-        tagResult.filters.archived,
-        tagResult.filters.archivedScopeSpecified
-      ),
+      archived: tagResult.filters.archived,
     },
     needsClarification: tagResult.needsClarification || timeResult.needsClarification,
   };
@@ -757,14 +707,13 @@ function normalizeFilterScope(
 
 function normalizeComparison(
   message: string,
-  operations: AiRetrievalOperation[],
   comparison: AiRetrievalComparison | null,
   availableTags: string[]
 ): { comparison: AiRetrievalComparison | null; needsClarification: boolean } {
   if (!comparison) return { comparison: null, needsClarification: false };
   let needsClarification = false;
   const groups = comparison.groups.map((group) => {
-    const result = normalizeFilterScope(message, operations, group.filters, availableTags, {
+    const result = normalizeFilterScope(message, group.filters, availableTags, {
       autoAddExplicitTags: false,
     });
     needsClarification = needsClarification || result.needsClarification;
@@ -828,13 +777,21 @@ function buildSummary(plan: AiRetrievalPlan): string[] {
     summary.push(`关键词：${plan.filters.semanticScope.join('、')}`);
   }
   if (plan.filters.sourceTypes.length === 1) {
-    summary.push(plan.filters.sourceTypes[0] === 'rote' ? '仅笔记' : '仅文章');
+    summary.push(plan.filters.sourceTypes[0] === 'rote' ? '内容类型：笔记' : '内容类型：文章');
+  } else {
+    summary.push('内容类型：笔记+文章');
   }
-  if (plan.filters.state !== 'all') {
-    summary.push(plan.filters.state === 'public' ? '公开内容' : '私密内容');
+  if (plan.filters.state === 'public') {
+    summary.push('可见性：公开');
+  } else if (plan.filters.state === 'private') {
+    summary.push('可见性：私密');
+  } else {
+    summary.push('可见性：私密+公开');
   }
   if (plan.filters.archived !== null) {
-    summary.push(plan.filters.archived ? '归档内容' : '未归档内容');
+    summary.push(plan.filters.archived ? '归档范围：仅归档' : '归档范围：未归档');
+  } else if (plan.filters.archivedScopeSpecified) {
+    summary.push('归档范围：全部');
   }
   if (plan.comparison) {
     summary.push(`对比：${plan.comparison.groups.map((group) => group.label).join(' / ')}`);
@@ -862,9 +819,6 @@ export function buildNewSearchPlan(
   availableTags: string[]
 ): AiRetrievalPlan {
   const message = patch?.query || '';
-  const operations: AiRetrievalOperation[] = patch?.operations?.length
-    ? patch.operations
-    : ['summarize'];
   const filters = createDefaultFilters();
   if (patch?.tags?.include) filters.tags.include = patch.tags.include;
   if (patch?.tags?.exclude) filters.tags.exclude = patch.tags.exclude;
@@ -903,7 +857,6 @@ export function buildNewSearchPlan(
     message,
     {
       originalMessage: message,
-      operations,
       query: message,
       filters: scopedFilters,
       comparison,
@@ -927,7 +880,6 @@ export function mergePlan(
   const merged = { ...previousPlan, originalMessage: patch.query || previousPlan.originalMessage };
 
   if (patch.query) merged.query = patch.query;
-  if (patch.operations) merged.operations = patch.operations;
   if (patch.semanticScope) {
     merged.filters = {
       ...merged.filters,
@@ -1048,18 +1000,8 @@ function normalizePlan(
   rawPlan: AiRetrievalPlan,
   availableTags: string[]
 ): AiRetrievalPlan {
-  const filterResult = normalizeFilterScope(
-    message,
-    rawPlan.operations,
-    rawPlan.filters,
-    availableTags
-  );
-  const comparisonResult = normalizeComparison(
-    message,
-    rawPlan.operations,
-    rawPlan.comparison,
-    availableTags
-  );
+  const filterResult = normalizeFilterScope(message, rawPlan.filters, availableTags);
+  const comparisonResult = normalizeComparison(message, rawPlan.comparison, availableTags);
   const normalized: AiRetrievalPlan = {
     ...rawPlan,
     originalMessage: message,
@@ -1068,7 +1010,6 @@ function normalizePlan(
   };
   const comparisonMissing =
     rawPlan.needsClarification &&
-    rawPlan.operations.includes('compare') &&
     /对比|相比|比较|变化|compare/i.test(message) &&
     (!comparisonResult.comparison || comparisonResult.comparison.groups.length < 2);
   const needsClarification =
@@ -1094,15 +1035,14 @@ Schema:
 {
   "intent": "chat_only" | "new_search" | "more" | "replace_filter" | "add_filter" | "exclude_filter" | "clarify",
   "patch": {
-    "query": string (optional - the semantic search query),
+    "query": string (optional - the semantic search query; write the user's real information need, not an empty string),
     "tags": {"include": string[], "exclude": string[]} (optional),
     "semanticScope": string[] (optional - soft topic keywords that are NOT hard tags),
     "timeExpression": string (optional - e.g. "最近90天", "本月"),
     "sourceTypes": ("rote" | "article")[] (optional),
-    "operations": ("summarize" | "compare" | "timeline" | "find_open_loops" | "analyze_mood" | "analyze_stress" | "analyze_personality")[] (optional),
     "archivedScope": "active" | "archived" | "all" | "unspecified" (optional - Rote lifecycle filter),
     "taskStatusScope": "open" | "closed" | "all" | "unspecified" (optional - Rote task/open-loop status),
-    "comparison": {"mode": "tag_groups" | "filter_groups" | "time", "groups": [{"label": string, "tags": string[] (optional), "timeExpression": string (optional), "archivedScope": string (optional), "taskStatusScope": string (optional)}]} (optional - required when operations includes "compare")
+    "comparison": {"mode": "tag_groups" | "filter_groups" | "time", "groups": [{"label": string, "tags": string[] (optional), "timeExpression": string (optional), "archivedScope": string (optional), "taskStatusScope": string (optional)}]} (optional - required for compare/comparison questions)
   },
   "confidence": number (0-1),
   "reasonCode": "greeting" | "thanks" | "explicit_tag" | "bare_tag" | "explicit_time" | "note_analysis" | "more_results" | "replace_filter" | "exclude_filter" | "ambiguous_retrieve" | "followup_needs_context"
@@ -1120,13 +1060,14 @@ INTENT RULES:
 
 PATCH RULES:
 - patch only fills fields that CHANGE. Do NOT copy the full plan.
+- The model decides the retrieval strategy with query, semanticScope, filters, comparison, and sourceTypes. There is no operation enum.
+- For broad analysis requests (MBTI/personality, mood, stress, style, timeline, review), write an evidence-seeking query and soft semanticScope values that can retrieve diverse supporting notes. Do not leave query empty unless this is a pure hard-filter search.
 - Bare tag names matching available tags → intent="new_search", patch.tags.include=["tagname"].
 - Topic words that are not explicit tags, such as 产品/生活/AI/技术, should go into patch.semanticScope instead of patch.tags unless they exactly match an available tag or the user explicitly says #tag/标签.
-- For operations: 没收尾/Flag/TODO/待办/还没做 → "find_open_loops"; 心境/情绪/心情 → "analyze_mood"; 压力/焦虑 → "analyze_stress"; MBTI/性格 → "analyze_personality"; 时间线 → "timeline"; 对比/比较 → "compare".
 - Rote domain scopes: archivedScope filters the note lifecycle ("active" = not archived, "archived" = archived notes, "all" = both). taskStatusScope describes task semantics ("open" = unfinished/open task, "closed" = completed/closed task, "all" = both).
 - Archived notes are considered closed/completed for task analysis. For open-loop/TODO/Flag queries, set patch.taskStatusScope="open". If the user explicitly asks for archived/completed tasks, set taskStatusScope="closed" or archivedScope="archived".
 - Do NOT set archivedScope just because the word "归档/archive" is the topic of the note or feature (e.g. "归档功能 bug"). In that case keep archivedScope="unspecified" or omit it and keep the word in query.
-- When operations includes "compare", you MUST also fill patch.comparison with mode="tag_groups" (for comparing tags) or mode="time" (for comparing time periods). Each group needs a label and its own tags/timeExpression.
+- For compare/comparison questions, fill patch.comparison with mode="tag_groups" (for comparing tags), mode="time" (for comparing time periods), or mode="filter_groups". Each group needs a label and its own tags/timeExpression/scopes.
 - 笔记/记录 → patch.sourceTypes=["rote"]; 文章/长文 → ["article"].
 
 CONFIDENCE:
@@ -1281,7 +1222,6 @@ export function createFastRetrievalPlan(
       message,
       {
         originalMessage: message,
-        operations: ['summarize'],
         query: stripped || '',
         filters,
         comparison: null,

--- a/server/utils/dbMethods/admin.ts
+++ b/server/utils/dbMethods/admin.ts
@@ -265,7 +265,12 @@ export async function getRoleStats() {
 // 按用户名或邮箱查找用户（用于初始化时校验是否已存在）
 export async function findUserByUsernameOrEmail(params: { username: string; email: string }) {
   const [user] = await db
-    .select({ id: users.id })
+    .select({
+      id: users.id,
+      username: users.username,
+      email: users.email,
+      role: users.role,
+    })
     .from(users)
     .where(or(eq(users.username, params.username), eq(users.email, params.email))!)
     .limit(1);

--- a/server/utils/dbMethods/ai.ts
+++ b/server/utils/dbMethods/ai.ts
@@ -601,8 +601,7 @@ async function processJob(job: EmbeddingJob, config: AiConfig): Promise<void> {
     const { embedding, usage } = await createEmbedding(config.embedding, chunk);
 
     if (usage) {
-      // Background log
-      logAiTokenUsage({
+      await logAiTokenUsage({
         userid: ownerId,
         model: config.embedding.model,
         type: 'embedding',
@@ -745,7 +744,7 @@ export async function semanticSearch(params: {
     usage = result.usage;
   }
   if (usage && params.ownerId) {
-    logAiTokenUsage({
+    await logAiTokenUsage({
       userid: params.ownerId,
       model: config.embedding.model,
       type: 'embedding',

--- a/server/utils/dbMethods/ai.ts
+++ b/server/utils/dbMethods/ai.ts
@@ -52,8 +52,9 @@ const DEFAULT_CHAT_LIMIT = 15;
 const DEFAULT_EVIDENCE_CONTEXT_BUDGET = 16_000;
 const DEFAULT_EVIDENCE_SNIPPET_LENGTH = 900;
 const MAX_EVIDENCE_SOURCE_COUNT = 18;
-const MIN_DEEP_SAMPLE_SIZE = 8;
 const MIN_COMPARISON_GROUP_SAMPLE_SIZE = 3;
+const MIN_EVIDENCE_SIMILARITY = 0.3;
+const MIN_FILTER_ONLY_EVIDENCE_SIMILARITY = 0;
 const LEGACY_NEEDS_MORE_TAG = '<needs_more/>';
 
 export type EvidenceSampleStatus = 'no_evidence' | 'limited_sample' | 'adequate';
@@ -63,6 +64,7 @@ export interface RetrievalContextDiagnostics {
   contextSourceCount: number;
   omittedSourceCount: number;
   minUsefulSourceCount: number;
+  minEvidenceSimilarity: number;
   sampleStatus: EvidenceSampleStatus;
   groupStats: Array<{
     label: string;
@@ -133,33 +135,33 @@ function vectorIndexName(dimensions: number): string {
   return `document_embeddings_embedding_hnsw_${dimensions}_idx`;
 }
 
-function isDeepAnalysisPlan(plan: AiRetrievalPlan): boolean {
-  const deepOperations = new Set([
-    'analyze_personality',
-    'analyze_mood',
-    'analyze_stress',
-    'find_open_loops',
-    'timeline',
-    'compare',
-  ]);
-  return plan.operations.some((operation) => deepOperations.has(operation));
+function resolveRetrievalLimit(requestedLimit?: number): number {
+  return requestedLimit || DEFAULT_CHAT_LIMIT;
 }
 
-function resolveRetrievalLimit(plan: AiRetrievalPlan, requestedLimit?: number): number {
-  const baseLimit = requestedLimit || DEFAULT_CHAT_LIMIT;
-  return isDeepAnalysisPlan(plan) ? Math.max(baseLimit, 40) : baseLimit;
-}
-
-function getMinUsefulSourceCount(plan: AiRetrievalPlan): number {
+function getMinUsefulSourceCount(plan: AiRetrievalPlan, targetSourceCount: number): number {
   if (plan.comparison?.groups.length) {
     return plan.comparison.groups.length * MIN_COMPARISON_GROUP_SAMPLE_SIZE;
   }
-  return isDeepAnalysisPlan(plan) ? MIN_DEEP_SAMPLE_SIZE : 1;
+  return Math.min(Math.max(targetSourceCount, 1), 12);
 }
 
 function classifySampleStatus(count: number, minUsefulCount: number): EvidenceSampleStatus {
   if (count <= 0) return 'no_evidence';
   return count < minUsefulCount ? 'limited_sample' : 'adequate';
+}
+
+function hasSemanticQuery(plan: AiRetrievalPlan): boolean {
+  return Boolean(plan.query.trim() || plan.filters.semanticScope.length);
+}
+
+function resolveEvidenceMinSimilarity(plan: AiRetrievalPlan): number {
+  return hasSemanticQuery(plan) ? MIN_EVIDENCE_SIMILARITY : MIN_FILTER_ONLY_EVIDENCE_SIMILARITY;
+}
+
+function getEvidenceQueryVariants(plan: AiRetrievalPlan): string[] {
+  const query = plan.query.trim();
+  return query ? [query] : [''];
 }
 
 function stripLegacyNeedsMoreTag(text: string): string {
@@ -931,6 +933,7 @@ export async function buildRetrievalContext(params: {
   ownerId: string;
   plan: AiRetrievalPlan;
   limit: number;
+  sourceLimit?: number;
   excludeIds?: string[];
 }): Promise<{
   sources: SemanticSearchResult[];
@@ -939,23 +942,39 @@ export async function buildRetrievalContext(params: {
 }> {
   const { plan } = params;
   const safeExcludeIds = sanitizeExcludeIds(params.excludeIds);
-  const minUsefulSourceCount = getMinUsefulSourceCount(plan);
-  const maxSnippetLength = isDeepAnalysisPlan(plan) ? 700 : DEFAULT_EVIDENCE_SNIPPET_LENGTH;
+  const minEvidenceSimilarity = resolveEvidenceMinSimilarity(plan);
+  const finalSourceLimit = normalizeLimit(params.sourceLimit ?? params.limit);
+  const minUsefulSourceCount = getMinUsefulSourceCount(plan, finalSourceLimit);
+  const maxSnippetLength = DEFAULT_EVIDENCE_SNIPPET_LENGTH;
   const hasComparisonGroups = Boolean(plan.comparison?.groups.length);
 
-  const baseSearch = async (filters: AiRetrievalFilters, limit: number) =>
-    semanticSearch({
-      query: plan.query,
-      ownerId: params.ownerId,
-      limit,
-      sourceTypes: filters.sourceTypes,
-      timeRange: filters.time?.normalizedRange || null,
-      tags: filters.tags,
-      semanticScope: filters.semanticScope,
-      state: filters.state,
-      archived: filters.archived,
-      excludeIds: safeExcludeIds,
-    });
+  const baseSearch = async (filters: AiRetrievalFilters, limit: number) => {
+    const bestBySource = new Map<string, SemanticSearchResult>();
+    for (const query of getEvidenceQueryVariants(plan)) {
+      const results = await semanticSearch({
+        query,
+        ownerId: params.ownerId,
+        limit,
+        sourceTypes: filters.sourceTypes,
+        timeRange: filters.time?.normalizedRange || null,
+        tags: filters.tags,
+        semanticScope: filters.semanticScope,
+        state: filters.state,
+        archived: filters.archived,
+        excludeIds: safeExcludeIds,
+      });
+      for (const source of results) {
+        const key = `${source.sourceType}:${source.sourceId}`;
+        const existing = bestBySource.get(key);
+        if (!existing || source.similarity > existing.similarity) {
+          bestBySource.set(key, source);
+        }
+      }
+    }
+    return Array.from(bestBySource.values())
+      .sort((a, b) => b.similarity - a.similarity)
+      .slice(0, limit);
+  };
 
   const groupedResults: Array<{ label: string; sources: SemanticSearchResult[] }> = [];
   if (plan.comparison?.groups.length) {
@@ -984,7 +1003,8 @@ export async function buildRetrievalContext(params: {
   });
   const sources = Array.from(sourceByKey.values())
     .sort((a, b) => b.similarity - a.similarity)
-    .slice(0, params.limit);
+    .filter((source) => source.similarity >= minEvidenceSimilarity)
+    .slice(0, finalSourceLimit);
 
   const contextSources: SemanticSearchResult[] = [];
   const contextBlocks: string[] = [];
@@ -1025,7 +1045,9 @@ export async function buildRetrievalContext(params: {
   );
   const groupStats = groupedResults.map((group) => {
     const groupKeys = new Set(
-      group.sources.map((source) => `${source.sourceType}:${source.sourceId}`)
+      group.sources
+        .filter((source) => source.similarity >= minEvidenceSimilarity)
+        .map((source) => `${source.sourceType}:${source.sourceId}`)
     );
     const groupMinUsefulCount = plan.comparison?.groups.length
       ? MIN_COMPARISON_GROUP_SAMPLE_SIZE
@@ -1050,6 +1072,7 @@ export async function buildRetrievalContext(params: {
     contextSourceCount: contextSources.length,
     omittedSourceCount: Math.max(sources.length - contextSources.length, 0),
     minUsefulSourceCount,
+    minEvidenceSimilarity,
     sampleStatus,
     groupStats,
   };
@@ -1063,7 +1086,8 @@ export async function buildRetrievalContext(params: {
 - Candidate sources found: ${diagnostics.candidateCount}
 - Sources included in answer context: ${diagnostics.contextSourceCount}
 - Omitted because of context budget: ${diagnostics.omittedSourceCount}
-- Minimum useful sources for this operation: ${diagnostics.minUsefulSourceCount}
+- Minimum useful sources for this scope: ${diagnostics.minUsefulSourceCount}
+- Minimum similarity for evidence: ${diagnostics.minEvidenceSimilarity.toFixed(3)}
 - Sample status: ${diagnostics.sampleStatus}
 ${groupSummary ? `\nGroup coverage:\n${groupSummary}` : ''}`;
   const context = `${evidenceSummary}\n\nEvidence:\n${
@@ -1116,7 +1140,6 @@ export function sanitizePreviousPlan(plan: any, availableTags: string[]): AiRetr
   const rawFilters = plan.filters && typeof plan.filters === 'object' ? plan.filters : {};
   return {
     originalMessage: String(plan.originalMessage || ''),
-    operations: Array.isArray(plan.operations) ? plan.operations : ['summarize'],
     query: String(plan.query || ''),
     filters: {
       time:
@@ -1231,7 +1254,7 @@ export async function prepareRoteChatContext(params: {
     return { config, messages: chatMessages, sources: [], plan };
   }
 
-  const limit = resolveRetrievalLimit(plan, params.limit);
+  const limit = resolveRetrievalLimit(params.limit);
 
   const { sources, context } = await buildRetrievalContext({
     ownerId: params.ownerId,
@@ -1241,9 +1264,8 @@ export async function prepareRoteChatContext(params: {
   });
 
   const scopeSummary = plan.summary?.length ? plan.summary.join('；') : '默认范围';
-  const operations = plan.operations.join(', ');
 
-  const prompt = `Retrieval scope: ${scopeSummary}\nOperations: ${operations}\n\nContext:\n${
+  const prompt = `Retrieval scope: ${scopeSummary}\n\nContext:\n${
     context || '(no relevant context found)'
   }\n\nQuestion:\n${plan.originalMessage || params.message}`;
 

--- a/server/utils/dbMethods/aiToken.ts
+++ b/server/utils/dbMethods/aiToken.ts
@@ -1,6 +1,11 @@
 import { aiTokenUsageLogs } from '../../drizzle/schema';
 import db from '../drizzle';
 
+function normalizeTokenCount(value: unknown): number {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric > 0 ? Math.floor(numeric) : 0;
+}
+
 export async function logAiTokenUsage(params: {
   userid: string;
   model: string;
@@ -10,8 +15,18 @@ export async function logAiTokenUsage(params: {
   totalTokens: number;
 }) {
   try {
-    if (params.totalTokens === 0) return;
-    await db.insert(aiTokenUsageLogs).values(params);
+    const promptTokens = normalizeTokenCount(params.promptTokens);
+    const completionTokens = normalizeTokenCount(params.completionTokens);
+    const totalTokens = normalizeTokenCount(params.totalTokens) || promptTokens + completionTokens;
+
+    if (totalTokens === 0) return;
+
+    await db.insert(aiTokenUsageLogs).values({
+      ...params,
+      promptTokens,
+      completionTokens,
+      totalTokens,
+    });
   } catch (error) {
     console.error('Failed to log AI token usage:', error);
   }

--- a/web/src/components/ai/AiMessageItem.tsx
+++ b/web/src/components/ai/AiMessageItem.tsx
@@ -5,16 +5,12 @@ import {
   ThinkingTrace,
 } from '@/components/ai/AiMessageStatus';
 import { cleanSourceText, getAiSourcePath } from '@/components/ai/AiSourceList';
+import AiStreamingMarkdown from '@/components/ai/AiStreamingMarkdown';
 import { Button } from '@/components/ui/button';
 import type { AiMemoryMessage } from '@/state/aiChat';
 import { Link as LinkIcon, Loader, Save } from 'lucide-react';
-import { Suspense, lazy } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
-
-export const preloadAiStreamingMarkdown = () => import('@/components/ai/AiStreamingMarkdown');
-
-const AiStreamingMarkdown = lazy(preloadAiStreamingMarkdown);
 
 function formatTokenBreakdown(message: AiMemoryMessage) {
   const usageByPhase = message.metrics?.usageByPhase;
@@ -92,19 +88,11 @@ export function AiMessageItem({
         )}
         {message.role === 'assistant' && !message.error ? (
           message.content ? (
-            <Suspense
-              fallback={
-                <div className="leading-7 wrap-break-word whitespace-pre-line">
-                  {message.content}
-                </div>
-              }
-            >
-              <AiStreamingMarkdown
-                content={message.content}
-                isStreaming={message.isStreaming}
-                sources={message.sources}
-              />
-            </Suspense>
+            <AiStreamingMarkdown
+              content={message.content}
+              isStreaming={message.isStreaming}
+              sources={message.sources}
+            />
           ) : (
             !hasAssistantStatus && (
               <div className="text-info flex items-center gap-2">

--- a/web/src/components/ai/AiMessageItem.tsx
+++ b/web/src/components/ai/AiMessageItem.tsx
@@ -24,6 +24,10 @@ export function AiMessageItem({
   saveAsNote: (message: AiMemoryMessage) => void;
 }) {
   const { t } = useTranslation('translation', { keyPrefix: 'pages.aiMemory' });
+  const hasAssistantStatus =
+    message.role === 'assistant' &&
+    ((message.timeline?.length || 0) > 0 ||
+      Boolean(message.thinking?.planning?.trim() || message.thinking?.answer?.trim()));
 
   return (
     <div className={`px-4 py-4 ${message.role === 'assistant' ? 'bg-foreground/2' : ''}`}>
@@ -87,14 +91,16 @@ export function AiMessageItem({
               />
             </Suspense>
           ) : (
-            <div className="text-info flex items-center gap-2">
-              <Loader className="size-4 animate-spin" />
-              {!message.plan
-                ? t('messages.thinking')
-                : !(message.sources && message.sources.length > 0)
-                  ? t('messages.searching')
-                  : t('messages.reading')}
-            </div>
+            !hasAssistantStatus && (
+              <div className="text-info flex items-center gap-2">
+                <Loader className="size-4 animate-spin" />
+                {!message.plan
+                  ? t('messages.thinking')
+                  : !(message.sources && message.sources.length > 0)
+                    ? t('messages.searching')
+                    : t('messages.reading')}
+              </div>
+            )
           )
         ) : (
           <div

--- a/web/src/components/ai/AiMessageItem.tsx
+++ b/web/src/components/ai/AiMessageItem.tsx
@@ -12,7 +12,22 @@ import { Suspense, lazy } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 
-const AiStreamingMarkdown = lazy(() => import('@/components/ai/AiStreamingMarkdown'));
+export const preloadAiStreamingMarkdown = () => import('@/components/ai/AiStreamingMarkdown');
+
+const AiStreamingMarkdown = lazy(preloadAiStreamingMarkdown);
+
+function formatTokenBreakdown(message: AiMemoryMessage) {
+  const usageByPhase = message.metrics?.usageByPhase;
+  if (!usageByPhase) return '';
+
+  return [
+    usageByPhase.planning ? `Plan ${usageByPhase.planning.total_tokens}` : '',
+    usageByPhase.tool_decision ? `Tool ${usageByPhase.tool_decision.total_tokens}` : '',
+    usageByPhase.answer ? `Answer ${usageByPhase.answer.total_tokens}` : '',
+  ]
+    .filter(Boolean)
+    .join(' / ');
+}
 
 export function AiMessageItem({
   message,
@@ -24,10 +39,10 @@ export function AiMessageItem({
   saveAsNote: (message: AiMemoryMessage) => void;
 }) {
   const { t } = useTranslation('translation', { keyPrefix: 'pages.aiMemory' });
+  const hasThinking = Object.values(message.thinking || {}).some((text) => text?.trim());
   const hasAssistantStatus =
-    message.role === 'assistant' &&
-    ((message.timeline?.length || 0) > 0 ||
-      Boolean(message.thinking?.planning?.trim() || message.thinking?.answer?.trim()));
+    message.role === 'assistant' && ((message.timeline?.length || 0) > 0 || hasThinking);
+  const tokenBreakdown = formatTokenBreakdown(message);
 
   return (
     <div className={`px-4 py-4 ${message.role === 'assistant' ? 'bg-foreground/2' : ''}`}>
@@ -54,7 +69,7 @@ export function AiMessageItem({
               }}
             >
               {message.sources?.map((source, index) => {
-                const cleanText = cleanSourceText(source.text);
+                const cleanText = source.preview || cleanSourceText(source.text || '');
                 const titleText =
                   source.metadata?.title ||
                   cleanText.slice(0, 30).replace(/\s+/g, ' ').trim() ||
@@ -139,7 +154,12 @@ export function AiMessageItem({
             {message.metrics.totalTime && (
               <span>Total: {(message.metrics.totalTime / 1000).toFixed(2)}s</span>
             )}
-            {message.metrics.usage && <span>Tokens: {message.metrics.usage.total_tokens}</span>}
+            {message.metrics.usage && (
+              <span>
+                Tokens: {message.metrics.usage.total_tokens}
+                {tokenBreakdown ? ` (${tokenBreakdown})` : ''}
+              </span>
+            )}
           </div>
         )}
         {message.role === 'assistant' && !message.isStreaming && !message.error && (

--- a/web/src/components/ai/AiMessageStatus.tsx
+++ b/web/src/components/ai/AiMessageStatus.tsx
@@ -13,7 +13,6 @@ export function AiStatusTitle({ children, icon }: { children: ReactNode; icon?: 
 }
 
 export function ScopeSummary({ message, title }: { message: AiMemoryMessage; title: string }) {
-  const { t } = useTranslation('translation', { keyPrefix: 'pages.aiMemory' });
   const summary = message.plan?.summary || [];
 
   if (summary.length > 0) {
@@ -27,19 +26,6 @@ export function ScopeSummary({ message, title }: { message: AiMemoryMessage; tit
             {item}
           </span>
         ))}
-      </div>
-    );
-  }
-
-  if (message.isStreaming && message.plan) {
-    return (
-      <div className="flex flex-wrap items-center gap-1.5 text-xs">
-        <Loader className="size-3 animate-spin" />
-        <span className="text-muted-foreground animate-pulse font-medium">
-          {message.plan.query
-            ? `${t('messages.searching')}: ${message.plan.query}`
-            : t('messages.searching')}
-        </span>
       </div>
     );
   }
@@ -176,21 +162,9 @@ export function ThinkingTrace({ message }: { message: AiMemoryMessage }) {
     { phase: 'planning' as const, text: message.thinking?.planning || '' },
     { phase: 'answer' as const, text: message.thinking?.answer || '' },
   ].filter((entry) => entry.text.trim().length > 0);
-  const hasContent = message.content.trim().length > 0;
   const isStreaming = message.isStreaming || false;
-  const hasAnswerThinking = entries.some((entry) => entry.phase === 'answer');
-  const shouldShowPendingAnswer =
-    isStreaming && !hasContent && !hasAnswerThinking && (entries.length === 0 || !!message.plan);
 
   if (entries.length === 0) {
-    if (shouldShowPendingAnswer) {
-      return (
-        <div className="space-y-1">
-          <ThinkingPendingLine title={t('thinkingTrace.answer')} />
-        </div>
-      );
-    }
-
     return null;
   }
 
@@ -218,7 +192,6 @@ export function ThinkingTrace({ message }: { message: AiMemoryMessage }) {
           />
         );
       })}
-      {shouldShowPendingAnswer && <ThinkingPendingLine title={t('thinkingTrace.answer')} />}
     </div>
   );
 }

--- a/web/src/components/ai/AiMessageStatus.tsx
+++ b/web/src/components/ai/AiMessageStatus.tsx
@@ -51,26 +51,30 @@ export function AgentTimeline({ message, title }: { message: AiMemoryMessage; ti
   const items = message.timeline || [];
   if (items.length === 0) return null;
 
-  const visibleItems = items.slice(-5);
+  const runningItems = items.filter((item) => item.status === 'running');
+  const currentItem = [...(runningItems.length ? runningItems : items)].sort(
+    (first, second) => second.updatedAt - first.updatedAt
+  )[0];
+
+  if (!currentItem) return null;
+
   return (
-    <div className="space-y-0.5 text-xs leading-5">
-      <div className="flex items-center gap-1.5">
-        <AiStatusTitle icon={<Workflow className="size-3 shrink-0" />}>{title}:</AiStatusTitle>
-      </div>
-      <div className="space-y-0.5">
-        {visibleItems.map((item) => (
-          <div key={item.id} className="text-muted-foreground flex min-w-0 items-center gap-1.5">
-            {item.status === 'done' ? (
-              <Check className="size-3 shrink-0" />
-            ) : item.status === 'error' ? (
-              <CircleAlert className="size-3 shrink-0" />
-            ) : (
-              <Loader className="size-3 shrink-0 animate-spin" />
-            )}
-            <span className="min-w-0 truncate">{item.message}</span>
-          </div>
-        ))}
-      </div>
+    <div className="flex min-w-0 items-center gap-1.5 text-xs leading-5">
+      <AiStatusTitle icon={<Workflow className="size-3 shrink-0" />}>{title}:</AiStatusTitle>
+      {currentItem.status === 'done' ? (
+        <Check className="text-muted-foreground size-3 shrink-0" />
+      ) : currentItem.status === 'error' ? (
+        <CircleAlert className="text-muted-foreground size-3 shrink-0" />
+      ) : (
+        <Loader className="text-muted-foreground size-3 shrink-0 animate-spin" />
+      )}
+      <span
+        className={`text-muted-foreground min-w-0 flex-1 truncate ${
+          currentItem.status === 'running' ? 'animate-pulse' : ''
+        }`}
+      >
+        {currentItem.message}
+      </span>
     </div>
   );
 }

--- a/web/src/components/ai/AiMessageStatus.tsx
+++ b/web/src/components/ai/AiMessageStatus.tsx
@@ -1,5 +1,5 @@
 import type { AiMemoryMessage } from '@/state/aiChat';
-import { Brain, Check, Loader, SlidersHorizontal, Workflow } from 'lucide-react';
+import { Brain, Check, CircleAlert, Loader, SlidersHorizontal, Workflow } from 'lucide-react';
 import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -62,6 +62,8 @@ export function AgentTimeline({ message, title }: { message: AiMemoryMessage; ti
           <div key={item.id} className="text-muted-foreground flex min-w-0 items-center gap-1.5">
             {item.status === 'done' ? (
               <Check className="size-3 shrink-0" />
+            ) : item.status === 'error' ? (
+              <CircleAlert className="size-3 shrink-0" />
             ) : (
               <Loader className="size-3 shrink-0 animate-spin" />
             )}

--- a/web/src/components/ai/AiMessageStatus.tsx
+++ b/web/src/components/ai/AiMessageStatus.tsx
@@ -1,5 +1,6 @@
 import type { AiMemoryMessage } from '@/state/aiChat';
-import { Brain, Check, CircleAlert, Loader, SlidersHorizontal, Workflow } from 'lucide-react';
+import type { AiRetrievalPlan, AiThinkingPhase } from '@/utils/aiApi';
+import { Brain, SlidersHorizontal, Workflow } from 'lucide-react';
 import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -12,8 +13,70 @@ export function AiStatusTitle({ children, icon }: { children: ReactNode; icon?: 
   );
 }
 
+function buildScopeSummary(plan: AiRetrievalPlan, t: ReturnType<typeof useTranslation>['t']) {
+  const summary: string[] = [];
+  if (plan.pagination === 'more') summary.push(t('scope.paginationMore'));
+
+  const range = plan.filters.time?.normalizedRange;
+  if (range) summary.push(t('scope.time', { label: range.label }));
+
+  if (plan.filters.tags.include.length) {
+    summary.push(
+      t('scope.tags', { tags: plan.filters.tags.include.map((tag) => `#${tag}`).join('、') })
+    );
+  }
+
+  if (plan.filters.tags.exclude.length) {
+    summary.push(
+      t('scope.excludeTags', {
+        tags: plan.filters.tags.exclude.map((tag) => `#${tag}`).join('、'),
+      })
+    );
+  }
+
+  if (plan.filters.semanticScope.length) {
+    summary.push(t('scope.semanticScope', { keywords: plan.filters.semanticScope.join('、') }));
+  }
+
+  const sourceTypes = plan.filters.sourceTypes;
+  if (sourceTypes.length === 1) {
+    summary.push(
+      sourceTypes[0] === 'rote' ? t('scope.sourceTypes.rote') : t('scope.sourceTypes.article')
+    );
+  } else {
+    summary.push(t('scope.sourceTypes.all'));
+  }
+
+  if (plan.filters.state === 'public') {
+    summary.push(t('scope.visibility.public'));
+  } else if (plan.filters.state === 'private') {
+    summary.push(t('scope.visibility.private'));
+  } else {
+    summary.push(t('scope.visibility.all'));
+  }
+
+  if (plan.filters.archived === true) {
+    summary.push(t('scope.archive.archived'));
+  } else if (plan.filters.archived === false) {
+    summary.push(t('scope.archive.active'));
+  } else if (plan.filters.archivedScopeSpecified) {
+    summary.push(t('scope.archive.all'));
+  }
+
+  if (plan.comparison) {
+    summary.push(
+      t('scope.comparison', {
+        groups: plan.comparison.groups.map((group) => group.label).join(' / '),
+      })
+    );
+  }
+
+  return summary;
+}
+
 export function ScopeSummary({ message, title }: { message: AiMemoryMessage; title: string }) {
-  const summary = message.plan?.summary || [];
+  const { t } = useTranslation('translation', { keyPrefix: 'pages.aiMemory' });
+  const summary = message.plan ? buildScopeSummary(message.plan, t) : [];
 
   if (summary.length > 0) {
     return (
@@ -38,7 +101,9 @@ export function AgentTimeline({ message, title }: { message: AiMemoryMessage; ti
   if (items.length === 0) return null;
 
   const runningItems = items.filter((item) => item.status === 'running');
-  const currentItem = [...(runningItems.length ? runningItems : items)].sort(
+  if (runningItems.length === 0) return null;
+
+  const currentItem = [...runningItems].sort(
     (first, second) => second.updatedAt - first.updatedAt
   )[0];
 
@@ -47,13 +112,6 @@ export function AgentTimeline({ message, title }: { message: AiMemoryMessage; ti
   return (
     <div className="flex min-w-0 items-center gap-1.5 text-xs leading-5">
       <AiStatusTitle icon={<Workflow className="size-3 shrink-0" />}>{title}:</AiStatusTitle>
-      {currentItem.status === 'done' ? (
-        <Check className="text-muted-foreground size-3 shrink-0" />
-      ) : currentItem.status === 'error' ? (
-        <CircleAlert className="text-muted-foreground size-3 shrink-0" />
-      ) : (
-        <Loader className="text-muted-foreground size-3 shrink-0 animate-spin" />
-      )}
       <span
         className={`text-muted-foreground min-w-0 flex-1 truncate ${
           currentItem.status === 'running' ? 'animate-pulse' : ''
@@ -64,8 +122,6 @@ export function AgentTimeline({ message, title }: { message: AiMemoryMessage; ti
     </div>
   );
 }
-
-type ThinkingPhase = 'planning' | 'answer';
 
 export function ThinkingPendingLine({ title }: { title: string }) {
   return (
@@ -86,7 +142,7 @@ export function ThinkingTraceEntry({
   isStreaming,
   onToggle,
 }: {
-  phase: ThinkingPhase;
+  phase: AiThinkingPhase;
   text: string;
   title: string;
   isExpanded: boolean;
@@ -95,6 +151,7 @@ export function ThinkingTraceEntry({
 }) {
   const { t } = useTranslation('translation', { keyPrefix: 'pages.aiMemory' });
   const lineRef = useRef<HTMLDivElement>(null);
+  const expandedRef = useRef<HTMLDivElement>(null);
   const inlineText = useMemo(() => text.replace(/\s+/g, ' ').trim(), [text]);
 
   useEffect(() => {
@@ -103,6 +160,13 @@ export function ThinkingTraceEntry({
     if (!line) return;
     line.scrollLeft = line.scrollWidth;
   }, [inlineText, isExpanded]);
+
+  useEffect(() => {
+    if (!isExpanded) return;
+    const expanded = expandedRef.current;
+    if (!expanded) return;
+    expanded.scrollTop = expanded.scrollHeight;
+  }, [text, isExpanded]);
 
   return (
     <div className="min-w-0">
@@ -128,21 +192,20 @@ export function ThinkingTraceEntry({
           </div>
         )}
         {isExpanded && <div className="min-w-0 flex-1" />}
-        {!isStreaming && (
-          <button
-            type="button"
-            aria-expanded={isExpanded}
-            aria-controls={`thinking-trace-${phase}`}
-            className="text-muted-foreground hover:text-foreground shrink-0 whitespace-nowrap opacity-70 transition-colors"
-            onClick={onToggle}
-          >
-            {isExpanded ? t('thinkingTrace.collapse') : t('thinkingTrace.expand')}
-          </button>
-        )}
+        <button
+          type="button"
+          aria-expanded={isExpanded}
+          aria-controls={`thinking-trace-${phase}`}
+          className="text-muted-foreground hover:text-foreground shrink-0 whitespace-nowrap opacity-70 transition-colors"
+          onClick={onToggle}
+        >
+          {isExpanded ? t('thinkingTrace.collapse') : t('thinkingTrace.expand')}
+        </button>
       </div>
-      {!isStreaming && isExpanded && (
+      {isExpanded && (
         <div
           id={`thinking-trace-${phase}`}
+          ref={expandedRef}
           className="text-muted-foreground mt-1 max-h-36 overflow-y-auto text-xs leading-5 whitespace-pre-wrap"
         >
           {text}
@@ -154,12 +217,19 @@ export function ThinkingTraceEntry({
 
 export function ThinkingTrace({ message }: { message: AiMemoryMessage }) {
   const { t } = useTranslation('translation', { keyPrefix: 'pages.aiMemory' });
-  const [expandedPhases, setExpandedPhases] = useState<Record<ThinkingPhase, boolean>>({
-    planning: false,
+  const [expandedPhases, setExpandedPhases] = useState<Record<AiThinkingPhase, boolean>>({
+    route_decision: false,
+    evidence_decision: false,
+    retrieval_planning: false,
     answer: false,
   });
   const entries = [
-    { phase: 'planning' as const, text: message.thinking?.planning || '' },
+    { phase: 'route_decision' as const, text: message.thinking?.route_decision || '' },
+    {
+      phase: 'retrieval_planning' as const,
+      text: message.thinking?.retrieval_planning || '',
+    },
+    { phase: 'evidence_decision' as const, text: message.thinking?.evidence_decision || '' },
     { phase: 'answer' as const, text: message.thinking?.answer || '' },
   ].filter((entry) => entry.text.trim().length > 0);
   const isStreaming = message.isStreaming || false;
@@ -171,8 +241,7 @@ export function ThinkingTrace({ message }: { message: AiMemoryMessage }) {
   return (
     <div className="space-y-1">
       {entries.map((entry) => {
-        const title =
-          entry.phase === 'planning' ? t('thinkingTrace.planning') : t('thinkingTrace.answer');
+        const title = t(`thinkingTrace.${entry.phase}`);
         const isExpanded = expandedPhases[entry.phase] || false;
 
         return (

--- a/web/src/components/ai/AiSourceList.tsx
+++ b/web/src/components/ai/AiSourceList.tsx
@@ -1,7 +1,12 @@
 import type { AiSemanticResult } from '@/utils/aiApi';
-import { useMemo } from 'react';
+import { type CSSProperties, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
+
+const sourceTextStyle: CSSProperties = {
+  overflowWrap: 'anywhere',
+  wordBreak: 'break-all',
+};
 
 function getSourcePath(source: AiSemanticResult) {
   return source.sourceType === 'article'
@@ -14,7 +19,7 @@ export function cleanSourceText(text: string): string {
 }
 
 function getSourcePreview(source: AiSemanticResult) {
-  return cleanSourceText(source.text).replace(/\s+/g, ' ');
+  return (source.preview || cleanSourceText(source.text || '')).replace(/\s+/g, ' ');
 }
 
 function getSimilarityPercent(source: AiSemanticResult) {
@@ -38,35 +43,46 @@ export function AiSourceList({
   const visibleSources = useMemo(() => sources || [], [sources]);
 
   return (
-    <div className={className}>
-      {title && <div className="px-4 py-3 text-sm font-semibold">{title}</div>}
+    <div className={`min-w-0 overflow-hidden ${className}`}>
+      {title && <div className="min-w-0 truncate px-4 py-3 text-sm font-semibold">{title}</div>}
       {visibleSources.length === 0 ? (
         <div className="text-info px-4 py-6 text-center text-sm font-light">
           {emptyLabel || t('empty')}
         </div>
       ) : (
-        <div className="divide-y">
+        <div className="min-w-0 divide-y overflow-hidden">
           {visibleSources.map((source, index) => {
             const titleText = source.metadata?.title || getSourcePreview(source) || t('untitled');
+            const previewText = getSourcePreview(source);
             return (
               <Link
                 key={`${source.sourceType}-${source.sourceId}`}
                 to={getSourcePath(source)}
-                className="hover:bg-foreground/3 block px-4 py-3 duration-200"
+                className="hover:bg-foreground/3 block max-w-full min-w-0 overflow-hidden px-4 py-3 duration-200"
               >
-                <div className="flex min-w-0 items-start gap-3">
-                  <div className="min-w-0 flex-1">
-                    <div className="text-info flex items-center gap-2 text-xs font-medium">
-                      <span className="font-mono">[{index + 1}]</span>
-                      <span className="font-medium">
+                <div className="flex max-w-full min-w-0 items-start gap-3 overflow-hidden">
+                  <div className="max-w-full min-w-0 flex-1 overflow-hidden">
+                    <div className="text-info flex min-w-0 items-center gap-2 text-xs font-medium">
+                      <span className="shrink-0 font-mono">[{index + 1}]</span>
+                      <span className="min-w-0 truncate font-medium">
                         {source.sourceType === 'article' ? t('article') : t('rote')}
                       </span>
-                      <span className="ml-auto font-mono">{getSimilarityPercent(source)}%</span>
+                      <span className="ml-auto shrink-0 font-mono">
+                        {getSimilarityPercent(source)}%
+                      </span>
                     </div>
-                    <div className="mt-1 line-clamp-1 text-sm">{titleText}</div>
+                    <div
+                      className="mt-1 line-clamp-2 max-w-full min-w-0 overflow-hidden text-sm leading-6 whitespace-normal"
+                      style={sourceTextStyle}
+                    >
+                      {titleText}
+                    </div>
                     {!compact && (
-                      <div className="text-info mt-1 line-clamp-2 text-xs font-light">
-                        {getSourcePreview(source)}
+                      <div
+                        className="text-info mt-1 line-clamp-2 max-w-full min-w-0 overflow-hidden text-xs leading-5 font-light whitespace-normal"
+                        style={sourceTextStyle}
+                      >
+                        {previewText}
                       </div>
                     )}
                   </div>

--- a/web/src/components/ai/AiStreamingMarkdown.tsx
+++ b/web/src/components/ai/AiStreamingMarkdown.tsx
@@ -30,7 +30,7 @@ function linkifyCitations(content: string, sources: AiSemanticResult[]): string 
     if (index < 0 || index >= sources.length) return match;
     const source = sources[index];
     const path = getAiSourcePath(source);
-    const cleanText = cleanSourceText(source.text);
+    const cleanText = source.preview || cleanSourceText(source.text || '');
     const title = source.metadata?.title || cleanText.slice(0, 30).replace(/\s+/g, ' ').trim();
     return `[\\[${numStr}\\]](${path} "${title}")`;
   });
@@ -72,8 +72,8 @@ function AiStreamingMarkdown({
       <Streamdown
         className="prose prose-neutral dark:prose-invert prose-p:my-2 prose-ul:my-2 prose-ol:my-2 prose-li:my-0 prose-pre:bg-muted prose-pre:text-foreground prose-code:wrap-break-word max-w-none text-sm leading-7 wrap-break-word"
         mode={isStreaming ? 'streaming' : 'static'}
-        animated={{ animation: 'blurIn' }}
-        isAnimating={isStreaming}
+        animated={false}
+        isAnimating={false}
         plugins={{ cjk }}
         linkSafety={{ enabled: false }}
         controls={{

--- a/web/src/components/layout/SideContentLayout.tsx
+++ b/web/src/components/layout/SideContentLayout.tsx
@@ -2,8 +2,8 @@ import type { ReactNode } from 'react';
 
 export function SideContentLayout({ children }: { children: ReactNode }) {
   return (
-    <div className="relative hidden w-72 shrink-0 md:block">
-      <div className="noScrollBar fixed top-0 hidden h-dvh w-72 divide-y overflow-y-scroll md:block">
+    <div className="relative hidden w-72 min-w-0 shrink-0 overflow-hidden md:block">
+      <div className="noScrollBar sticky top-0 hidden h-dvh w-full min-w-0 divide-y overflow-x-hidden overflow-y-scroll md:block">
         {children}
       </div>
     </div>

--- a/web/src/components/setup/SetupWizard.tsx
+++ b/web/src/components/setup/SetupWizard.tsx
@@ -296,15 +296,18 @@ export default function SetupWizard() {
 
       // 调用初始化 API
       const response = await setupSystem(setupData);
+      const responseBody = response.data;
 
-      if (response.data) {
-        toast.success(t('pages.setupWizard.toasts.initSuccess'));
+      if (responseBody?.data) {
+        toast.success(responseBody?.message || t('pages.setupWizard.toasts.initSuccess'));
         navigate('/landing', { replace: true });
       } else {
-        toast.error(t('pages.setupWizard.toasts.initFailed'));
+        toast.error(responseBody?.message || t('pages.setupWizard.toasts.initFailed'));
       }
-    } catch (_error: any) {
-      toast.error(t('pages.setupWizard.toasts.initFailed'));
+    } catch (error: any) {
+      toast.error(
+        error?.response?.data?.message || error?.message || t('pages.setupWizard.toasts.initFailed')
+      );
     } finally {
       setIsLoading(false);
     }

--- a/web/src/components/setup/SetupWizard.tsx
+++ b/web/src/components/setup/SetupWizard.tsx
@@ -296,13 +296,12 @@ export default function SetupWizard() {
 
       // 调用初始化 API
       const response = await setupSystem(setupData);
-      const responseBody = response.data;
 
-      if (responseBody?.data) {
-        toast.success(responseBody?.message || t('pages.setupWizard.toasts.initSuccess'));
+      if (response) {
+        toast.success(response.message || t('pages.setupWizard.toasts.initSuccess'));
         navigate('/landing', { replace: true });
       } else {
-        toast.error(responseBody?.message || t('pages.setupWizard.toasts.initFailed'));
+        toast.error(t('pages.setupWizard.toasts.initFailed'));
       }
     } catch (error: any) {
       toast.error(

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -378,6 +378,7 @@
       "sideBarTitle": "Memory Sources",
       "send": "Send",
       "clear": "Clear chat",
+      "backToBottom": "Back to bottom",
       "saveAsNote": "Save as note",
       "saved": "Saved",
       "savedNoteTitle": "AI Memory Answer",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -375,7 +375,7 @@
     },
     "aiMemory": {
       "title": "AI Memory",
-      "sideBarTitle": "Memory Sources",
+      "sideBarTitle": "Assistant Panel",
       "send": "Send",
       "clear": "Clear chat",
       "backToBottom": "Back to bottom",
@@ -406,6 +406,10 @@
         "ready": "Ready",
         "unverified": "Verify your email to use AI",
         "unavailable": "AI or vector index is not available"
+      },
+      "privacy": {
+        "title": "Conversation Note",
+        "description": "AI conversations stay in the current browser session and are not persisted to the database."
       },
       "sources": {
         "title": "Sources",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -413,13 +413,66 @@
         "empty": "No sources yet"
       },
       "scope": {
-        "title": "Scope"
+        "title": "Scope",
+        "paginationMore": "More results",
+        "time": "Time: {{label}}",
+        "tags": "Tags: {{tags}}",
+        "excludeTags": "Exclude tags: {{tags}}",
+        "semanticScope": "Keywords: {{keywords}}",
+        "sourceTypes": {
+          "rote": "Content: notes",
+          "article": "Content: articles",
+          "all": "Content: notes + articles"
+        },
+        "visibility": {
+          "private": "Visibility: private",
+          "public": "Visibility: public",
+          "all": "Visibility: private + public"
+        },
+        "archive": {
+          "active": "Archive: unarchived",
+          "archived": "Archive: archived only",
+          "all": "Archive: all"
+        },
+        "comparison": "Compare: {{groups}}"
       },
       "timeline": {
-        "title": "Progress"
+        "title": "Progress",
+        "sourcesFound": "Found {{count}} related source(s)",
+        "phases": {
+          "understanding": "Understanding the question",
+          "planning": "Deciding whether to read Rote",
+          "tool_calling": "Checking whether more evidence is needed",
+          "retrieving": "Retrieving records",
+          "reading": "Reading records",
+          "answering": "Organizing the answer"
+        },
+        "tools": {
+          "rote_search_notes": "Querying Rote",
+          "rote_get_note": "Reading a record",
+          "rote_find_related_notes": "Finding related records",
+          "rote_get_tags": "Loading tags",
+          "rote_skill_view": "Choosing workflow"
+        },
+        "toolStatus": {
+          "determining_scope": "Determining query scope",
+          "retrieving_sources": "Retrieving related records",
+          "reading_source": "Reading record content",
+          "finding_related": "Finding related records",
+          "loading_tags": "Loading tags"
+        },
+        "toolDone": {
+          "default": "Done",
+          "rote_get_note": "Record read",
+          "rote_find_related_notes": "Related records found",
+          "rote_get_tags": "Tags loaded",
+          "rote_skill_view": "Workflow selected"
+        }
       },
       "thinkingTrace": {
-        "planning": "Determining scope",
+        "route_decision": "Deciding whether to query Rote",
+        "evidence_decision": "Deciding whether more evidence is needed",
+        "retrieval_planning": "Determining query scope",
         "answer": "Thinking through answer",
         "separator": ": ",
         "expand": "View thoughts",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -428,6 +428,7 @@
         "thinking": "Thinking...",
         "searching": "Searching...",
         "reading": "Reading and generating...",
+        "interrupted": "Previous answer was interrupted",
         "askFailed": "Request failed",
         "saveSuccess": "Saved as note",
         "saveFailed": "Save failed"

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -378,6 +378,7 @@
       "sideBarTitle": "記憶ソース",
       "send": "送信",
       "clear": "チャットをクリア",
+      "backToBottom": "一番下へ戻る",
       "saveAsNote": "ノートとして保存",
       "saved": "保存済み",
       "savedNoteTitle": "AI メモリー回答",

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -413,13 +413,66 @@
         "empty": "まだソースがありません"
       },
       "scope": {
-        "title": "範囲"
+        "title": "範囲",
+        "paginationMore": "さらに表示",
+        "time": "時間：{{label}}",
+        "tags": "タグ：{{tags}}",
+        "excludeTags": "除外タグ：{{tags}}",
+        "semanticScope": "キーワード：{{keywords}}",
+        "sourceTypes": {
+          "rote": "種類：ノート",
+          "article": "種類：記事",
+          "all": "種類：ノート+記事"
+        },
+        "visibility": {
+          "private": "公開範囲：非公開",
+          "public": "公開範囲：公開",
+          "all": "公開範囲：非公開+公開"
+        },
+        "archive": {
+          "active": "アーカイブ：未アーカイブ",
+          "archived": "アーカイブ：アーカイブのみ",
+          "all": "アーカイブ：すべて"
+        },
+        "comparison": "比較：{{groups}}"
       },
       "timeline": {
-        "title": "進捗"
+        "title": "進捗",
+        "sourcesFound": "関連ソースを {{count}} 件見つけました",
+        "phases": {
+          "understanding": "質問を理解中",
+          "planning": "Rote を読む必要があるか判断中",
+          "tool_calling": "追加の根拠が必要か確認中",
+          "retrieving": "記録を検索中",
+          "reading": "記録を読み込み中",
+          "answering": "回答を整理中"
+        },
+        "tools": {
+          "rote_search_notes": "Rote を検索中",
+          "rote_get_note": "記録を読み込み中",
+          "rote_find_related_notes": "関連記録を検索中",
+          "rote_get_tags": "タグを読み込み中",
+          "rote_skill_view": "処理方法を選択中"
+        },
+        "toolStatus": {
+          "determining_scope": "検索範囲を確認中",
+          "retrieving_sources": "関連記録を検索中",
+          "reading_source": "記録内容を読み込み中",
+          "finding_related": "関連記録を検索中",
+          "loading_tags": "タグを読み込み中"
+        },
+        "toolDone": {
+          "default": "完了しました",
+          "rote_get_note": "記録を読み込みました",
+          "rote_find_related_notes": "関連記録を見つけました",
+          "rote_get_tags": "タグを読み込みました",
+          "rote_skill_view": "処理方法を決定しました"
+        }
       },
       "thinkingTrace": {
-        "planning": "範囲を確認中",
+        "route_decision": "Rote を検索するか判断中",
+        "evidence_decision": "追加の根拠が必要か判断中",
+        "retrieval_planning": "検索範囲を確認中",
         "answer": "回答を整理中",
         "separator": "：",
         "expand": "思考を見る",

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -428,6 +428,7 @@
         "thinking": "思考中...",
         "searching": "検索中...",
         "reading": "ソースを読んで生成中...",
+        "interrupted": "前回の回答は中断されました",
         "askFailed": "リクエスト失敗",
         "saveSuccess": "ノートとして保存しました",
         "saveFailed": "保存失敗"

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -375,7 +375,7 @@
     },
     "aiMemory": {
       "title": "AI メモリー",
-      "sideBarTitle": "記憶ソース",
+      "sideBarTitle": "アシスタントパネル",
       "send": "送信",
       "clear": "チャットをクリア",
       "backToBottom": "一番下へ戻る",
@@ -406,6 +406,10 @@
         "ready": "準備完了",
         "unverified": "メール確認後に AI を利用できます",
         "unavailable": "AI またはベクトル索引を利用できません"
+      },
+      "privacy": {
+        "title": "会話について",
+        "description": "AI との会話は現在のブラウザセッション内にのみ保存され、データベースには永続保存されません。"
       },
       "sources": {
         "title": "ソース",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -403,13 +403,66 @@
         "empty": "还没有来源"
       },
       "scope": {
-        "title": "范围"
+        "title": "范围",
+        "paginationMore": "查看更多",
+        "time": "时间：{{label}}",
+        "tags": "标签：{{tags}}",
+        "excludeTags": "排除标签：{{tags}}",
+        "semanticScope": "关键词：{{keywords}}",
+        "sourceTypes": {
+          "rote": "内容类型：笔记",
+          "article": "内容类型：文章",
+          "all": "内容类型：笔记+文章"
+        },
+        "visibility": {
+          "private": "可见性：私密",
+          "public": "可见性：公开",
+          "all": "可见性：私密+公开"
+        },
+        "archive": {
+          "active": "归档范围：未归档",
+          "archived": "归档范围：仅归档",
+          "all": "归档范围：全部"
+        },
+        "comparison": "对比：{{groups}}"
       },
       "timeline": {
-        "title": "进度"
+        "title": "进度",
+        "sourcesFound": "找到 {{count}} 条相关记录",
+        "phases": {
+          "understanding": "正在理解问题",
+          "planning": "正在判断是否需要读取记录",
+          "tool_calling": "正在确认是否需要更多证据",
+          "retrieving": "正在检索记录",
+          "reading": "正在读取记录",
+          "answering": "正在组织回答"
+        },
+        "tools": {
+          "rote_search_notes": "正在查询 Rote",
+          "rote_get_note": "正在读取记录",
+          "rote_find_related_notes": "正在查找相关记录",
+          "rote_get_tags": "正在读取标签",
+          "rote_skill_view": "正在选择处理方式"
+        },
+        "toolStatus": {
+          "determining_scope": "正在确定查询范围",
+          "retrieving_sources": "正在检索相关记录",
+          "reading_source": "正在读取记录内容",
+          "finding_related": "正在查找相关记录",
+          "loading_tags": "正在读取标签"
+        },
+        "toolDone": {
+          "default": "已完成",
+          "rote_get_note": "已读取记录",
+          "rote_find_related_notes": "已找到相关记录",
+          "rote_get_tags": "已读取标签",
+          "rote_skill_view": "已确定处理方式"
+        }
       },
       "thinkingTrace": {
-        "planning": "正在确定范围",
+        "route_decision": "正在判断是否需要查询 Rote",
+        "evidence_decision": "正在判断是否需要补查",
+        "retrieval_planning": "正在确定查询范围",
         "answer": "正在组织回答",
         "separator": "：",
         "expand": "查看思考",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -368,6 +368,7 @@
       "sideBarTitle": "记忆来源",
       "send": "发送",
       "clear": "清空对话",
+      "backToBottom": "回到底部",
       "saveAsNote": "保存为笔记",
       "saved": "已保存",
       "savedNoteTitle": "AI 记忆回答",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -418,6 +418,7 @@
         "thinking": "思考中...",
         "searching": "检索中...",
         "reading": "阅读并生成中...",
+        "interrupted": "上次回答已中断",
         "askFailed": "请求失败",
         "saveSuccess": "已保存为笔记",
         "saveFailed": "保存失败"

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -365,7 +365,7 @@
     },
     "aiMemory": {
       "title": "AI 记忆",
-      "sideBarTitle": "记忆来源",
+      "sideBarTitle": "助手面板",
       "send": "发送",
       "clear": "清空对话",
       "backToBottom": "回到底部",
@@ -396,6 +396,10 @@
         "ready": "已就绪",
         "unverified": "验证邮箱后可使用 AI",
         "unavailable": "AI 或向量索引暂不可用"
+      },
+      "privacy": {
+        "title": "对话说明",
+        "description": "AI 对话只保存在当前浏览器会话中，不会持久化写入数据库。"
       },
       "sources": {
         "title": "来源",

--- a/web/src/pages/ai/index.tsx
+++ b/web/src/pages/ai/index.tsx
@@ -1,4 +1,4 @@
-import { AiMessageItem, preloadAiStreamingMarkdown } from '@/components/ai/AiMessageItem';
+import { AiMessageItem } from '@/components/ai/AiMessageItem';
 import { AiSourceList, getAiSourcePath } from '@/components/ai/AiSourceList';
 import NavBar from '@/components/layout/navBar';
 import { SoftBottom } from '@/components/others/SoftBottom';
@@ -34,6 +34,7 @@ import {
   ArrowUpRight,
   BrainCircuit,
   BrainCog,
+  Info,
   Loader,
   RefreshCw,
   Send,
@@ -196,10 +197,6 @@ function AiMemoryPage() {
     if (isAutoScrollPaused) return;
     scrollToMessageEnd('auto');
   }, [messages, isSending, isAutoScrollPaused, scrollToMessageEnd]);
-
-  useEffect(() => {
-    void preloadAiStreamingMarkdown();
-  }, []);
 
   useEffect(() => {
     isMountedRef.current = true;
@@ -766,6 +763,13 @@ function AiMemoryPage() {
   const SideBar = () => (
     <div className="divide-y">
       <StatusBlock />
+      <div className="p-4">
+        <div className="flex min-w-0 items-center gap-2 text-sm font-semibold">
+          <Info className="size-4 shrink-0" />
+          <span className="min-w-0 truncate">{t('privacy.title')}</span>
+        </div>
+        <p className="text-info mt-2 text-xs leading-5">{t('privacy.description')}</p>
+      </div>
       <div className="p-4">
         <div className="text-sm font-semibold">{t('quick.title')}</div>
         <div className="relative mt-3 flex flex-col gap-2 pb-6">

--- a/web/src/pages/ai/index.tsx
+++ b/web/src/pages/ai/index.tsx
@@ -203,12 +203,14 @@ function AiMemoryPage() {
     );
   }
 
-  function mergeAgentState(state: Partial<AiAgentClientState>) {
+  function mergeAgentState(
+    state: Partial<AiAgentClientState>,
+    options: { replaceSeenSourceIds?: boolean } = {}
+  ) {
     const previous = agentStateRef.current;
-    const seenSourceIds = new Set([
-      ...(previous.seenSourceIds || []),
-      ...(state.seenSourceIds || []),
-    ]);
+    const seenSourceIds = options.replaceSeenSourceIds
+      ? new Set(state.seenSourceIds || [])
+      : new Set([...(previous.seenSourceIds || []), ...(state.seenSourceIds || [])]);
     agentStateRef.current = {
       ...previous,
       ...state,
@@ -325,8 +327,13 @@ function AiMemoryPage() {
             currentIsMoreRef.current = plan.pagination === 'more';
             if (!currentIsMoreRef.current) {
               seenSourceIdsRef.current.clear();
+              mergeAgentState(
+                { previousPlan: plan, seenSourceIds: [] },
+                { replaceSeenSourceIds: true }
+              );
+            } else {
+              mergeAgentState({ previousPlan: plan });
             }
-            mergeAgentState({ previousPlan: plan });
             const planTime = performance.now() - start;
             setMessages((prev) =>
               prev.map((message) =>
@@ -361,10 +368,13 @@ function AiMemoryPage() {
           },
           onSources: (sources) => {
             sources.forEach((s) => seenSourceIdsRef.current.add(`${s.sourceType}:${s.sourceId}`));
-            mergeAgentState({
-              lastSources: sources,
-              seenSourceIds: Array.from(seenSourceIdsRef.current),
-            });
+            mergeAgentState(
+              {
+                lastSources: sources,
+                seenSourceIds: Array.from(seenSourceIdsRef.current),
+              },
+              { replaceSeenSourceIds: !currentIsMoreRef.current }
+            );
             const sourcesTime = performance.now() - start;
             setMessages((prev) =>
               prev.map((message) =>
@@ -412,8 +422,14 @@ function AiMemoryPage() {
             );
           },
           onStatePatch: (state) => {
-            mergeAgentState(state);
-            if (state.seenSourceIds?.length) {
+            const nextState = currentIsMoreRef.current
+              ? state
+              : {
+                  ...state,
+                  seenSourceIds: Array.from(seenSourceIdsRef.current),
+                };
+            mergeAgentState(nextState, { replaceSeenSourceIds: !currentIsMoreRef.current });
+            if (currentIsMoreRef.current && state.seenSourceIds?.length) {
               state.seenSourceIds.forEach((id) => seenSourceIdsRef.current.add(id));
             }
           },

--- a/web/src/pages/ai/index.tsx
+++ b/web/src/pages/ai/index.tsx
@@ -14,6 +14,7 @@ import {
   getLatestAiSources,
   getSeenSourceIdsForActiveAiPlan,
   sanitizeAiChatMessages,
+  settleAiMessageTimeline,
 } from '@/state/aiChat';
 import {
   aiAgentStream,
@@ -416,19 +417,22 @@ function AiMemoryPage() {
             setMessagesForActiveRun(assistantId, (prev) =>
               prev.map((message) =>
                 message.id === assistantId
-                  ? {
-                      ...message,
-                      content: clarification.question,
-                      plan: clarification.pendingPlan,
-                      pendingPlan: clarification.pendingPlan,
-                      clarification: true,
-                      isStreaming: false,
-                      metrics: {
-                        ...message.metrics,
-                        planTime,
-                        totalTime: performance.now() - start,
+                  ? settleAiMessageTimeline(
+                      {
+                        ...message,
+                        content: clarification.question,
+                        plan: clarification.pendingPlan,
+                        pendingPlan: clarification.pendingPlan,
+                        clarification: true,
+                        isStreaming: false,
+                        metrics: {
+                          ...message.metrics,
+                          planTime,
+                          totalTime: performance.now() - start,
+                        },
                       },
-                    }
+                      'done'
+                    )
                   : message
               )
             );
@@ -513,12 +517,15 @@ function AiMemoryPage() {
         const totalTime = performance.now() - start;
         return prev.map((message) =>
           message.id === assistantId
-            ? {
-                ...message,
-                isStreaming: false,
-                pendingPlan: receivedClarification ? message.pendingPlan : undefined,
-                metrics: { ...message.metrics, totalTime },
-              }
+            ? settleAiMessageTimeline(
+                {
+                  ...message,
+                  isStreaming: false,
+                  pendingPlan: receivedClarification ? message.pendingPlan : undefined,
+                  metrics: { ...message.metrics, totalTime },
+                },
+                'done'
+              )
             : message
         );
       });
@@ -533,12 +540,15 @@ function AiMemoryPage() {
       setMessagesForActiveRun(assistantId, (prev) =>
         prev.map((message) =>
           message.id === assistantId
-            ? {
-                ...message,
-                content: streamContent || fallbackMessage,
-                error: streamContent ? message.error : true,
-                isStreaming: false,
-              }
+            ? settleAiMessageTimeline(
+                {
+                  ...message,
+                  content: streamContent || fallbackMessage,
+                  error: streamContent ? message.error : true,
+                  isStreaming: false,
+                },
+                'error'
+              )
             : message
         )
       );

--- a/web/src/pages/ai/index.tsx
+++ b/web/src/pages/ai/index.tsx
@@ -1,3 +1,4 @@
+import { AiMessageItem, preloadAiStreamingMarkdown } from '@/components/ai/AiMessageItem';
 import { AiSourceList, getAiSourcePath } from '@/components/ai/AiSourceList';
 import NavBar from '@/components/layout/navBar';
 import { SoftBottom } from '@/components/others/SoftBottom';
@@ -11,9 +12,9 @@ import {
   getCurrentAiAssistantSources,
   getAiSourceKey,
   getLatestAiAssistantPlan,
-  getLatestAiSources,
   getSeenSourceIdsForActiveAiPlan,
   mergeAiTokenUsage,
+  mergeAiTokenUsageByPhase,
   sanitizeAiChatMessages,
   settleAiMessageTimeline,
 } from '@/state/aiChat';
@@ -22,6 +23,7 @@ import {
   getAiStatus,
   type AiAgentClientState,
   type AiAgentPhase,
+  type AiAgentToolProgressStatus,
 } from '@/utils/aiApi';
 import { post } from '@/utils/api';
 import { useAPIGet } from '@/utils/fetcher';
@@ -56,7 +58,10 @@ import { toast } from 'sonner';
 type ActiveStream = {
   id: string;
   content: string;
+  targetContent: string;
   frame: number | null;
+  done: boolean;
+  drainResolver?: () => void;
 };
 
 type ActiveRun = {
@@ -66,6 +71,12 @@ type ActiveRun = {
 
 function createMessageId() {
   return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function getStreamRevealSize(backlog: number) {
+  if (backlog > 1200) return 240;
+  if (backlog > 500) return 160;
+  return 80;
 }
 
 function buildSavedNoteContent(message: AiMemoryMessage, sourceTitle: string) {
@@ -78,8 +89,6 @@ function buildSavedNoteContent(message: AiMemoryMessage, sourceTitle: string) {
     ? `${message.content}\n\n---\n${sourceTitle}\n${sourceLines}`
     : message.content;
 }
-
-import { AiMessageItem } from '@/components/ai/AiMessageItem';
 
 function AiMemoryPage() {
   const { t } = useTranslation('translation', { keyPrefix: 'pages.aiMemory' });
@@ -125,7 +134,6 @@ function AiMemoryPage() {
   );
 
   const visibleSources = useMemo(() => getCurrentAiAssistantSources(messages), [messages]);
-  const latestSources = useMemo(() => getLatestAiSources(messages), [messages]);
   const pendingPlan = useMemo(() => {
     const lastMessage = messages[messages.length - 1];
     return lastMessage?.role === 'assistant' && lastMessage.pendingPlan
@@ -138,6 +146,24 @@ function AiMemoryPage() {
   const unavailableText =
     status?.eligible === false ? t('status.unverified') : t('status.unavailable');
   const canSend = !isSending && !unavailable && input.trim().length > 0;
+
+  function getAgentPhaseLabel(phase: AiAgentPhase) {
+    return t(`timeline.phases.${phase}`);
+  }
+
+  function getToolStartedLabel(toolName: string) {
+    return t(`timeline.tools.${toolName}`, { defaultValue: toolName });
+  }
+
+  function getToolStatusLabel(status: AiAgentToolProgressStatus) {
+    return t(`timeline.toolStatus.${status}`);
+  }
+
+  function getToolFinishedLabel(toolName: string) {
+    return t(`timeline.toolDone.${toolName}`, {
+      defaultValue: t('timeline.toolDone.default'),
+    });
+  }
 
   const scrollToMessageEnd = useCallback((behavior: ScrollBehavior = 'smooth') => {
     messageEndRef.current?.scrollIntoView({ block: 'end', behavior });
@@ -172,6 +198,10 @@ function AiMemoryPage() {
   }, [messages, isSending, isAutoScrollPaused, scrollToMessageEnd]);
 
   useEffect(() => {
+    void preloadAiStreamingMarkdown();
+  }, []);
+
+  useEffect(() => {
     isMountedRef.current = true;
     return () => {
       isMountedRef.current = false;
@@ -201,7 +231,6 @@ function AiMemoryPage() {
       ...agentStateRef.current,
       previousPlan: getLatestAiAssistantPlan(messages),
       seenSourceIds,
-      lastSources: getLatestAiSources(messages),
       stateVersion: 1,
     };
   }, [messages, isSending]);
@@ -241,11 +270,28 @@ function AiMemoryPage() {
     if (!stream || stream.id !== assistantId) return;
 
     stream.frame = null;
+    const backlog = stream.targetContent.length - stream.content.length;
+    if (backlog > 0) {
+      stream.content = stream.targetContent.slice(
+        0,
+        stream.content.length + getStreamRevealSize(backlog)
+      );
+    }
     setMessagesForActiveRun(assistantId, (prev) =>
       prev.map((message) =>
         message.id === assistantId ? { ...message, content: stream.content } : message
       )
     );
+
+    if (stream.content.length < stream.targetContent.length) {
+      stream.frame = window.requestAnimationFrame(() => flushStreamContent(assistantId));
+      return;
+    }
+
+    if (stream.done) {
+      stream.drainResolver?.();
+      stream.drainResolver = undefined;
+    }
   }
 
   function queueStreamDelta(assistantId: string, text: string) {
@@ -253,10 +299,36 @@ function AiMemoryPage() {
     const stream = activeStreamRef.current;
     if (!stream || stream.id !== assistantId) return;
 
-    stream.content += text;
+    stream.targetContent += text;
     if (stream.frame === null) {
       stream.frame = window.requestAnimationFrame(() => flushStreamContent(assistantId));
     }
+  }
+
+  function drainStreamContent(assistantId: string): Promise<void> {
+    if (!isActiveRun(assistantId)) return Promise.resolve();
+    const stream = activeStreamRef.current;
+    if (!stream || stream.id !== assistantId) return Promise.resolve();
+
+    stream.done = true;
+    if (stream.content.length >= stream.targetContent.length) return Promise.resolve();
+
+    if (stream.frame === null) {
+      stream.frame = window.requestAnimationFrame(() => flushStreamContent(assistantId));
+    }
+    return new Promise((resolve) => {
+      let resolved = false;
+      const finish = () => {
+        if (resolved) return;
+        resolved = true;
+        if (stream.drainResolver === finish) {
+          stream.drainResolver = undefined;
+        }
+        resolve();
+      };
+      stream.drainResolver = finish;
+      window.setTimeout(finish, 3000);
+    });
   }
 
   function updateTimeline(
@@ -266,6 +338,7 @@ function AiMemoryPage() {
       type: 'progress' | 'tool';
       phase?: AiAgentPhase;
       toolName?: string;
+      toolStatus?: AiAgentToolProgressStatus;
       message: string;
       status?: 'running' | 'done' | 'error';
     }
@@ -282,6 +355,7 @@ function AiMemoryPage() {
           type: item.type,
           phase: item.phase,
           toolName: item.toolName,
+          toolStatus: item.toolStatus,
           message: item.message,
           status: item.status || 'running',
           updatedAt,
@@ -334,7 +408,13 @@ function AiMemoryPage() {
     let firstTokenTime: number | undefined;
 
     activeRunRef.current = { assistantId, controller };
-    activeStreamRef.current = { id: assistantId, content: '', frame: null };
+    activeStreamRef.current = {
+      id: assistantId,
+      content: '',
+      targetContent: '',
+      frame: null,
+      done: false,
+    };
     setMessages((prev) => [
       ...prev,
       {
@@ -362,7 +442,6 @@ function AiMemoryPage() {
       await aiAgentStream(
         {
           message: question,
-          limit: 8,
           pendingPlan: activePendingPlan,
           clarificationAnswer: activePendingPlan ? question : undefined,
           previousPlan,
@@ -372,7 +451,6 @@ function AiMemoryPage() {
             ...agentStateRef.current,
             previousPlan,
             seenSourceIds: excludeIds,
-            lastSources: latestSources,
             stateVersion: 1,
           },
         },
@@ -381,20 +459,12 @@ function AiMemoryPage() {
             if (!isActiveRun(assistantId)) return;
             mergeAgentState({ conversationId: runId });
           },
-          onProgress: (phase, message) => {
+          onProgress: (phase) => {
             updateTimeline(assistantId, {
               id: `progress-${phase}`,
               type: 'progress',
               phase,
-              message,
-            });
-          },
-          onHeartbeat: (phase, message) => {
-            updateTimeline(assistantId, {
-              id: `progress-${phase}`,
-              type: 'progress',
-              phase,
-              message: message || '...',
+              message: getAgentPhaseLabel(phase),
             });
           },
           onToolStarted: (toolName) => {
@@ -402,23 +472,25 @@ function AiMemoryPage() {
               id: `tool-${toolName}`,
               type: 'tool',
               toolName,
-              message: toolName,
+              message: getToolStartedLabel(toolName),
             });
           },
-          onToolProgress: (toolName, message) => {
+          onToolProgress: (toolName, status) => {
             updateTimeline(assistantId, {
               id: `tool-${toolName}`,
               type: 'tool',
               toolName,
-              message,
+              toolStatus: status,
+              message: getToolStatusLabel(status),
             });
           },
-          onToolFinished: (toolName, summary) => {
+          onToolFinished: (toolName) => {
+            if (toolName === 'rote_search_notes') return;
             updateTimeline(assistantId, {
               id: `tool-${toolName}`,
               type: 'tool',
               toolName,
-              message: summary || toolName,
+              message: getToolFinishedLabel(toolName),
               status: 'done',
             });
           },
@@ -475,12 +547,18 @@ function AiMemoryPage() {
             sources.forEach((source) => seenSourceIdsRef.current.add(getAiSourceKey(source)));
             mergeAgentState(
               {
-                lastSources: sources,
                 seenSourceIds: Array.from(seenSourceIdsRef.current),
               },
               { replaceSeenSourceIds: !currentIsMoreRef.current }
             );
             const sourcesTime = performance.now() - start;
+            updateTimeline(assistantId, {
+              id: 'tool-rote_search_notes',
+              type: 'tool',
+              toolName: 'rote_search_notes',
+              message: t('timeline.sourcesFound', { count: sources.length }),
+              status: 'done',
+            });
             setMessagesForActiveRun(assistantId, (prev) =>
               prev.map((message) =>
                 message.id === assistantId
@@ -518,7 +596,7 @@ function AiMemoryPage() {
             }
             queueStreamDelta(assistantId, text);
           },
-          onUsage: (usage) => {
+          onUsage: (usage, phase) => {
             setMessagesForActiveRun(assistantId, (prev) =>
               prev.map((message) =>
                 message.id === assistantId
@@ -527,6 +605,11 @@ function AiMemoryPage() {
                       metrics: {
                         ...message.metrics,
                         usage: mergeAiTokenUsage(message.metrics?.usage, usage),
+                        usageByPhase: mergeAiTokenUsageByPhase(
+                          message.metrics?.usageByPhase,
+                          phase,
+                          usage
+                        ),
                       },
                     }
                   : message
@@ -550,7 +633,7 @@ function AiMemoryPage() {
         controller.signal
       );
       if (!receivedClarification) {
-        flushStreamContent(assistantId);
+        await drainStreamContent(assistantId);
       }
       setMessagesForActiveRun(assistantId, (prev) => {
         const totalTime = performance.now() - start;
@@ -574,7 +657,8 @@ function AiMemoryPage() {
 
       const fallbackMessage =
         error?.response?.data?.message || error?.message || t('messages.askFailed');
-      const streamContent = activeStreamRef.current?.content || '';
+      const streamContent =
+        activeStreamRef.current?.targetContent || activeStreamRef.current?.content || '';
       flushStreamContent(assistantId);
       setMessagesForActiveRun(assistantId, (prev) =>
         prev.map((message) =>
@@ -652,22 +736,25 @@ function AiMemoryPage() {
   }
 
   const StatusBlock = () => (
-    <div className="flex items-center justify-between border-b p-4">
-      <div className="flex items-center gap-2 text-sm font-semibold">
+    <div className="flex min-w-0 items-center justify-between gap-3 border-b p-4">
+      <div className="flex min-w-0 items-center gap-2 text-sm font-semibold">
         {status?.available ? (
-          <ToggleRight className="size-4" />
+          <ToggleRight className="size-4 shrink-0" />
         ) : (
-          <ToggleLeft className="text-error size-4" />
+          <ToggleLeft className="text-error size-4 shrink-0" />
         )}
-        {t('status.title')}
+        <span className="min-w-0 truncate">{t('status.title')}</span>
       </div>
-      <div className="text-info flex items-center gap-2 text-xs">
+      <div className="text-info flex min-w-0 items-center justify-end gap-2 text-right text-xs">
         {isStatusLoading ? (
-          t('status.checking')
+          <span className="min-w-0 truncate">{t('status.checking')}</span>
         ) : status?.available ? (
-          t('status.ready')
+          <span className="min-w-0 truncate">{t('status.ready')}</span>
         ) : (
-          <button className="hover:text-theme duration-200" onClick={() => refreshStatus()}>
+          <button
+            className="hover:text-theme min-w-0 truncate duration-200"
+            onClick={() => refreshStatus()}
+          >
             {unavailableText}
           </button>
         )}
@@ -687,7 +774,7 @@ function AiMemoryPage() {
               key={prompt}
               type="button"
               variant="link"
-              className="h-auto cursor-pointer justify-start p-0 text-sm font-normal whitespace-normal underline"
+              className="h-auto w-full min-w-0 cursor-pointer justify-start p-0 text-left text-sm font-normal break-all whitespace-normal underline"
               disabled={isSending || unavailable}
               onClick={() => sendMessage(prompt, { ignorePendingPlan: true })}
             >
@@ -728,9 +815,9 @@ function AiMemoryPage() {
     <ContainerWithSideBar
       sidebar={<SideBar />}
       sidebarHeader={
-        <div className="flex items-center gap-2 p-3 text-lg font-semibold">
-          <BrainCog className="size-5" />
-          {t('sideBarTitle')}
+        <div className="flex min-w-0 items-center gap-2 p-3 text-lg font-semibold">
+          <BrainCog className="size-5 shrink-0" />
+          <span className="min-w-0 truncate">{t('sideBarTitle')}</span>
         </div>
       }
       hideSidebarToggleButton={true}

--- a/web/src/pages/ai/index.tsx
+++ b/web/src/pages/ai/index.tsx
@@ -6,7 +6,15 @@ import { Input } from '@/components/ui/input';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import ContainerWithSideBar from '@/layout/ContainerWithSideBar';
 import type { AiMemoryMessage } from '@/state/aiChat';
-import { aiChatMessagesAtom } from '@/state/aiChat';
+import {
+  aiChatMessagesAtom,
+  getCurrentAiAssistantSources,
+  getAiSourceKey,
+  getLatestAiAssistantPlan,
+  getLatestAiSources,
+  getSeenSourceIdsForActiveAiPlan,
+  sanitizeAiChatMessages,
+} from '@/state/aiChat';
 import {
   aiAgentStream,
   getAiStatus,
@@ -48,6 +56,11 @@ type ActiveStream = {
   frame: number | null;
 };
 
+type ActiveRun = {
+  assistantId: string;
+  controller: AbortController;
+};
+
 function createMessageId() {
   return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
 }
@@ -74,6 +87,9 @@ function AiMemoryPage() {
   const [isPromptsExpanded, setIsPromptsExpanded] = useState(false);
   const messageEndRef = useRef<HTMLDivElement>(null);
   const activeStreamRef = useRef<ActiveStream | null>(null);
+  const activeRunRef = useRef<ActiveRun | null>(null);
+  const isMountedRef = useRef(true);
+  const isSendingRef = useRef(false);
   const seenSourceIdsRef = useRef<Set<string>>(new Set());
   const agentStateRef = useRef<AiAgentClientState>({
     conversationId: createMessageId(),
@@ -104,10 +120,8 @@ function AiMemoryPage() {
     [t]
   );
 
-  const latestSources = useMemo(() => {
-    const assistantMessages = messages.filter((message) => message.role === 'assistant');
-    return assistantMessages[assistantMessages.length - 1]?.sources || [];
-  }, [messages]);
+  const visibleSources = useMemo(() => getCurrentAiAssistantSources(messages), [messages]);
+  const latestSources = useMemo(() => getLatestAiSources(messages), [messages]);
   const pendingPlan = useMemo(() => {
     const lastMessage = messages[messages.length - 1];
     return lastMessage?.role === 'assistant' && lastMessage.pendingPlan
@@ -125,16 +139,48 @@ function AiMemoryPage() {
     messageEndRef.current?.scrollIntoView({ block: 'end' });
   }, [messages, isSending]);
 
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+      activeRunRef.current?.controller.abort();
       if (activeStreamRef.current?.frame !== null && activeStreamRef.current?.frame !== undefined) {
         window.cancelAnimationFrame(activeStreamRef.current.frame);
       }
-    },
-    []
-  );
+    };
+  }, []);
+
+  useEffect(() => {
+    isSendingRef.current = isSending;
+  }, [isSending]);
+
+  useEffect(() => {
+    setMessages((prev) => sanitizeAiChatMessages(prev, t('messages.interrupted')));
+  }, [setMessages, t]);
+
+  useEffect(() => {
+    // Keep non-react refs aligned with persisted chat history after reload.
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
+    if (isSending) return;
+
+    const seenSourceIds = getSeenSourceIdsForActiveAiPlan(messages);
+    seenSourceIdsRef.current = new Set(seenSourceIds);
+    agentStateRef.current = {
+      ...agentStateRef.current,
+      previousPlan: getLatestAiAssistantPlan(messages),
+      seenSourceIds,
+      lastSources: getLatestAiSources(messages),
+      stateVersion: 1,
+    };
+  }, [messages, isSending]);
 
   const clearChat = useCallback(() => {
+    activeRunRef.current?.controller.abort();
+    activeRunRef.current = null;
+    isSendingRef.current = false;
+    activeStreamRef.current = null;
+    currentIsMoreRef.current = false;
+    setIsSending(false);
     setMessages([]);
     seenSourceIdsRef.current.clear();
     agentStateRef.current = {
@@ -144,12 +190,25 @@ function AiMemoryPage() {
     };
   }, [setMessages]);
 
+  function isActiveRun(assistantId: string) {
+    return activeRunRef.current?.assistantId === assistantId;
+  }
+
+  function setMessagesForActiveRun(
+    assistantId: string,
+    updater: (messages: AiMemoryMessage[]) => AiMemoryMessage[]
+  ) {
+    if (!isMountedRef.current || !isActiveRun(assistantId)) return;
+    setMessages(updater);
+  }
+
   function flushStreamContent(assistantId: string) {
+    if (!isActiveRun(assistantId)) return;
     const stream = activeStreamRef.current;
     if (!stream || stream.id !== assistantId) return;
 
     stream.frame = null;
-    setMessages((prev) =>
+    setMessagesForActiveRun(assistantId, (prev) =>
       prev.map((message) =>
         message.id === assistantId ? { ...message, content: stream.content } : message
       )
@@ -157,6 +216,7 @@ function AiMemoryPage() {
   }
 
   function queueStreamDelta(assistantId: string, text: string) {
+    if (!isActiveRun(assistantId)) return;
     const stream = activeStreamRef.current;
     if (!stream || stream.id !== assistantId) return;
 
@@ -177,8 +237,9 @@ function AiMemoryPage() {
       status?: 'running' | 'done' | 'error';
     }
   ) {
+    if (!isActiveRun(assistantId)) return;
     const updatedAt = Date.now();
-    setMessages((prev) =>
+    setMessagesForActiveRun(assistantId, (prev) =>
       prev.map((message) => {
         if (message.id !== assistantId) return message;
         const current = message.timeline || [];
@@ -220,7 +281,7 @@ function AiMemoryPage() {
 
   async function sendMessage(value: string, options: { ignorePendingPlan?: boolean } = {}) {
     const question = value.trim();
-    if (!question || isSending || unavailable) return;
+    if (!question || isSendingRef.current || unavailable) return;
 
     const validHistory = messages
       .filter((m) => !m.error && !m.isStreaming && m.content)
@@ -229,12 +290,16 @@ function AiMemoryPage() {
 
     const activePendingPlan = options.ignorePendingPlan ? null : pendingPlan;
     setInput('');
+    isSendingRef.current = true;
     setIsSending(true);
+    currentIsMoreRef.current = false;
     const assistantId = createMessageId();
+    const controller = new AbortController();
     let receivedClarification = false;
     const start = performance.now();
     let firstTokenTime: number | undefined;
 
+    activeRunRef.current = { assistantId, controller };
     activeStreamRef.current = { id: assistantId, content: '', frame: null };
     setMessages((prev) => [
       ...prev,
@@ -254,8 +319,7 @@ function AiMemoryPage() {
 
     try {
       // Build previousPlan from the last assistant message
-      const lastAssistantForPlan = [...messages].reverse().find((m) => m.role === 'assistant');
-      const previousPlan = options.ignorePendingPlan ? null : lastAssistantForPlan?.plan || null;
+      const previousPlan = options.ignorePendingPlan ? null : getLatestAiAssistantPlan(messages);
 
       // Always pass accumulated seen source IDs (server decides whether to use them)
       const excludeIds =
@@ -280,6 +344,7 @@ function AiMemoryPage() {
         },
         {
           onRunStarted: (runId) => {
+            if (!isActiveRun(assistantId)) return;
             mergeAgentState({ conversationId: runId });
           },
           onProgress: (phase, message) => {
@@ -324,6 +389,7 @@ function AiMemoryPage() {
             });
           },
           onPlan: (plan) => {
+            if (!isActiveRun(assistantId)) return;
             currentIsMoreRef.current = plan.pagination === 'more';
             if (!currentIsMoreRef.current) {
               seenSourceIdsRef.current.clear();
@@ -335,7 +401,7 @@ function AiMemoryPage() {
               mergeAgentState({ previousPlan: plan });
             }
             const planTime = performance.now() - start;
-            setMessages((prev) =>
+            setMessagesForActiveRun(assistantId, (prev) =>
               prev.map((message) =>
                 message.id === assistantId
                   ? { ...message, plan, metrics: { ...message.metrics, planTime } }
@@ -344,9 +410,10 @@ function AiMemoryPage() {
             );
           },
           onClarification: (clarification) => {
+            if (!isActiveRun(assistantId)) return;
             receivedClarification = true;
             const planTime = performance.now() - start;
-            setMessages((prev) =>
+            setMessagesForActiveRun(assistantId, (prev) =>
               prev.map((message) =>
                 message.id === assistantId
                   ? {
@@ -367,7 +434,8 @@ function AiMemoryPage() {
             );
           },
           onSources: (sources) => {
-            sources.forEach((s) => seenSourceIdsRef.current.add(`${s.sourceType}:${s.sourceId}`));
+            if (!isActiveRun(assistantId)) return;
+            sources.forEach((source) => seenSourceIdsRef.current.add(getAiSourceKey(source)));
             mergeAgentState(
               {
                 lastSources: sources,
@@ -376,7 +444,7 @@ function AiMemoryPage() {
               { replaceSeenSourceIds: !currentIsMoreRef.current }
             );
             const sourcesTime = performance.now() - start;
-            setMessages((prev) =>
+            setMessagesForActiveRun(assistantId, (prev) =>
               prev.map((message) =>
                 message.id === assistantId
                   ? { ...message, sources, metrics: { ...message.metrics, sourcesTime } }
@@ -385,7 +453,7 @@ function AiMemoryPage() {
             );
           },
           onThinking: (phase, text) => {
-            setMessages((prev) =>
+            setMessagesForActiveRun(assistantId, (prev) =>
               prev.map((message) =>
                 message.id === assistantId
                   ? {
@@ -400,9 +468,10 @@ function AiMemoryPage() {
             );
           },
           onDelta: (text) => {
+            if (!isActiveRun(assistantId)) return;
             if (!firstTokenTime) {
               firstTokenTime = performance.now() - start;
-              setMessages((prev) =>
+              setMessagesForActiveRun(assistantId, (prev) =>
                 prev.map((message) =>
                   message.id === assistantId
                     ? { ...message, metrics: { ...message.metrics, firstTokenTime } }
@@ -413,7 +482,7 @@ function AiMemoryPage() {
             queueStreamDelta(assistantId, text);
           },
           onUsage: (usage) => {
-            setMessages((prev) =>
+            setMessagesForActiveRun(assistantId, (prev) =>
               prev.map((message) =>
                 message.id === assistantId
                   ? { ...message, metrics: { ...message.metrics, usage } }
@@ -422,6 +491,7 @@ function AiMemoryPage() {
             );
           },
           onStatePatch: (state) => {
+            if (!isActiveRun(assistantId)) return;
             const nextState = currentIsMoreRef.current
               ? state
               : {
@@ -433,12 +503,13 @@ function AiMemoryPage() {
               state.seenSourceIds.forEach((id) => seenSourceIdsRef.current.add(id));
             }
           },
-        }
+        },
+        controller.signal
       );
       if (!receivedClarification) {
         flushStreamContent(assistantId);
       }
-      setMessages((prev) => {
+      setMessagesForActiveRun(assistantId, (prev) => {
         const totalTime = performance.now() - start;
         return prev.map((message) =>
           message.id === assistantId
@@ -452,11 +523,14 @@ function AiMemoryPage() {
         );
       });
     } catch (error: any) {
+      const aborted = controller.signal.aborted || error?.name === 'AbortError';
+      if (aborted) return;
+
       const fallbackMessage =
         error?.response?.data?.message || error?.message || t('messages.askFailed');
       const streamContent = activeStreamRef.current?.content || '';
       flushStreamContent(assistantId);
-      setMessages((prev) =>
+      setMessagesForActiveRun(assistantId, (prev) =>
         prev.map((message) =>
           message.id === assistantId
             ? {
@@ -478,7 +552,13 @@ function AiMemoryPage() {
       if (activeStreamRef.current?.id === assistantId) {
         activeStreamRef.current = null;
       }
-      setIsSending(false);
+      if (activeRunRef.current?.assistantId === assistantId) {
+        activeRunRef.current = null;
+      }
+      if (isMountedRef.current) {
+        isSendingRef.current = false;
+        setIsSending(false);
+      }
     }
   }
 
@@ -587,7 +667,7 @@ function AiMemoryPage() {
       </div>
       <ScrollArea className="max-h-[45dvh]">
         <AiSourceList
-          sources={latestSources}
+          sources={visibleSources}
           title={t('sources.title')}
           emptyLabel={t('sources.empty')}
         />

--- a/web/src/pages/ai/index.tsx
+++ b/web/src/pages/ai/index.tsx
@@ -13,6 +13,7 @@ import {
   getLatestAiAssistantPlan,
   getLatestAiSources,
   getSeenSourceIdsForActiveAiPlan,
+  mergeAiTokenUsage,
   sanitizeAiChatMessages,
   settleAiMessageTimeline,
 } from '@/state/aiChat';
@@ -26,6 +27,7 @@ import { post } from '@/utils/api';
 import { useAPIGet } from '@/utils/fetcher';
 import { useAtom } from 'jotai';
 import {
+  ArrowDown,
   ArrowDownLeft,
   ArrowUpRight,
   BrainCircuit,
@@ -86,6 +88,7 @@ function AiMemoryPage() {
   const [isSending, setIsSending] = useState(false);
   const [savingMessageId, setSavingMessageId] = useState<string | null>(null);
   const [isPromptsExpanded, setIsPromptsExpanded] = useState(false);
+  const [isAutoScrollPaused, setIsAutoScrollPaused] = useState(false);
   const messageEndRef = useRef<HTMLDivElement>(null);
   const activeStreamRef = useRef<ActiveStream | null>(null);
   const activeRunRef = useRef<ActiveRun | null>(null);
@@ -136,9 +139,37 @@ function AiMemoryPage() {
     status?.eligible === false ? t('status.unverified') : t('status.unavailable');
   const canSend = !isSending && !unavailable && input.trim().length > 0;
 
+  const scrollToMessageEnd = useCallback((behavior: ScrollBehavior = 'smooth') => {
+    messageEndRef.current?.scrollIntoView({ block: 'end', behavior });
+  }, []);
+
+  const returnToBottom = useCallback(() => {
+    setIsAutoScrollPaused(false);
+    scrollToMessageEnd();
+  }, [scrollToMessageEnd]);
+
   useEffect(() => {
-    messageEndRef.current?.scrollIntoView({ block: 'end' });
-  }, [messages, isSending]);
+    const handleScroll = () => {
+      const scrollRoot = document.documentElement;
+      const distanceToBottom = scrollRoot.scrollHeight - window.innerHeight - window.scrollY;
+      setIsAutoScrollPaused(distanceToBottom > 160);
+    };
+
+    handleScroll();
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    window.addEventListener('resize', handleScroll);
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+      window.removeEventListener('resize', handleScroll);
+    };
+  }, []);
+
+  useEffect(() => {
+    // Keep the chat pinned while the user has not intentionally scrolled away.
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
+    if (isAutoScrollPaused) return;
+    scrollToMessageEnd('auto');
+  }, [messages, isSending, isAutoScrollPaused, scrollToMessageEnd]);
 
   useEffect(() => {
     isMountedRef.current = true;
@@ -181,6 +212,7 @@ function AiMemoryPage() {
     isSendingRef.current = false;
     activeStreamRef.current = null;
     currentIsMoreRef.current = false;
+    setIsAutoScrollPaused(false);
     setIsSending(false);
     setMessages([]);
     seenSourceIdsRef.current.clear();
@@ -291,6 +323,7 @@ function AiMemoryPage() {
 
     const activePendingPlan = options.ignorePendingPlan ? null : pendingPlan;
     setInput('');
+    setIsAutoScrollPaused(false);
     isSendingRef.current = true;
     setIsSending(true);
     currentIsMoreRef.current = false;
@@ -489,7 +522,13 @@ function AiMemoryPage() {
             setMessagesForActiveRun(assistantId, (prev) =>
               prev.map((message) =>
                 message.id === assistantId
-                  ? { ...message, metrics: { ...message.metrics, usage } }
+                  ? {
+                      ...message,
+                      metrics: {
+                        ...message.metrics,
+                        usage: mergeAiTokenUsage(message.metrics?.usage, usage),
+                      },
+                    }
                   : message
               )
             );
@@ -772,6 +811,20 @@ function AiMemoryPage() {
           )}
           <div ref={messageEndRef} className="h-24 shrink-0" />
         </div>
+
+        {isAutoScrollPaused && messages.length > 0 && (
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            className="fixed right-4 bottom-28 z-20 size-8 rounded-full shadow-sm sm:bottom-16"
+            onClick={returnToBottom}
+            aria-label={t('backToBottom')}
+            title={t('backToBottom')}
+          >
+            <ArrowDown className="size-4" />
+          </Button>
+        )}
 
         <form
           className="bg-background sticky bottom-16 z-10 border-t px-3 py-1 sm:bottom-0"

--- a/web/src/state/aiChat.ts
+++ b/web/src/state/aiChat.ts
@@ -1,5 +1,13 @@
 import { atomWithStorage } from 'jotai/utils';
-import type { AiAgentPhase, AiRetrievalPlan, AiSemanticResult } from '@/utils/aiApi';
+import type {
+  AiAgentPhase,
+  AiAgentToolProgressStatus,
+  AiThinkingPhase,
+  AiTokenUsage,
+  AiRetrievalPlan,
+  AiSemanticResult,
+  AiUsagePhase,
+} from '@/utils/aiApi';
 
 export type AiMessageMetrics = {
   planTime?: number;
@@ -7,19 +15,17 @@ export type AiMessageMetrics = {
   firstTokenTime?: number;
   totalTime?: number;
   usage?: AiMessageTokenUsage;
+  usageByPhase?: Partial<Record<AiUsagePhase, AiMessageTokenUsage>>;
 };
 
-export type AiMessageTokenUsage = {
-  prompt_tokens: number;
-  completion_tokens: number;
-  total_tokens: number;
-};
+export type AiMessageTokenUsage = AiTokenUsage;
 
 export type AiMessageTimelineItem = {
   id: string;
   type: 'progress' | 'tool';
   phase?: AiAgentPhase;
   toolName?: string;
+  toolStatus?: AiAgentToolProgressStatus;
   message: string;
   status: 'running' | 'done' | 'error';
   updatedAt: number;
@@ -37,8 +43,7 @@ export type AiMemoryMessage = {
   saved?: boolean;
   metrics?: AiMessageMetrics;
   thinking?: {
-    planning?: string;
-    answer?: string;
+    [phase in AiThinkingPhase]?: string;
   };
   timeline?: AiMessageTimelineItem[];
   /** Transient — never persisted. */
@@ -57,6 +62,17 @@ export function mergeAiTokenUsage(
     prompt_tokens: (current?.prompt_tokens || 0) + (incoming.prompt_tokens || 0),
     completion_tokens: (current?.completion_tokens || 0) + (incoming.completion_tokens || 0),
     total_tokens: (current?.total_tokens || 0) + (incoming.total_tokens || 0),
+  };
+}
+
+export function mergeAiTokenUsageByPhase(
+  current: Partial<Record<AiUsagePhase, AiMessageTokenUsage>> | undefined,
+  phase: AiUsagePhase,
+  incoming: AiMessageTokenUsage
+): Partial<Record<AiUsagePhase, AiMessageTokenUsage>> {
+  return {
+    ...(current || {}),
+    [phase]: mergeAiTokenUsage(current?.[phase], incoming),
   };
 }
 
@@ -110,15 +126,6 @@ export function getLatestAiAssistantPlan(messages: AiMemoryMessage[]): AiRetriev
   return (
     [...messages].reverse().find((message) => message.role === 'assistant' && message.plan)?.plan ||
     null
-  );
-}
-
-export function getLatestAiSources(messages: AiMemoryMessage[]): AiSemanticResult[] {
-  return (
-    [...messages]
-      .reverse()
-      .find((message) => message.role === 'assistant' && (message.sources?.length || 0) > 0)
-      ?.sources || []
   );
 }
 

--- a/web/src/state/aiChat.ts
+++ b/web/src/state/aiChat.ts
@@ -13,6 +13,16 @@ export type AiMessageMetrics = {
   };
 };
 
+export type AiMessageTimelineItem = {
+  id: string;
+  type: 'progress' | 'tool';
+  phase?: AiAgentPhase;
+  toolName?: string;
+  message: string;
+  status: 'running' | 'done' | 'error';
+  updatedAt: number;
+};
+
 export type AiMemoryMessage = {
   id: string;
   role: 'user' | 'assistant';
@@ -28,21 +38,29 @@ export type AiMemoryMessage = {
     planning?: string;
     answer?: string;
   };
-  timeline?: Array<{
-    id: string;
-    type: 'progress' | 'tool';
-    phase?: AiAgentPhase;
-    toolName?: string;
-    message: string;
-    status: 'running' | 'done' | 'error';
-    updatedAt: number;
-  }>;
+  timeline?: AiMessageTimelineItem[];
   /** Transient — never persisted. */
   isStreaming?: boolean;
 };
 
 export function getAiSourceKey(source: AiSemanticResult): string {
   return `${source.sourceType}:${source.sourceId}`;
+}
+
+export function settleAiMessageTimeline(
+  message: AiMemoryMessage,
+  status: 'done' | 'error'
+): AiMemoryMessage {
+  if (!message.timeline?.some((entry) => entry.status === 'running')) {
+    return message;
+  }
+
+  return {
+    ...message,
+    timeline: message.timeline.map((entry) =>
+      entry.status === 'running' ? { ...entry, status } : entry
+    ),
+  };
 }
 
 export function sanitizeAiChatMessages(
@@ -66,12 +84,7 @@ export function sanitizeAiChatMessages(
 
     if (next.timeline?.some((entry) => entry.status === 'running')) {
       changed = true;
-      next = {
-        ...next,
-        timeline: next.timeline.map((entry) =>
-          entry.status === 'running' ? { ...entry, status: 'error' as const } : entry
-        ),
-      };
+      next = settleAiMessageTimeline(next, 'error');
     }
 
     return next;

--- a/web/src/state/aiChat.ts
+++ b/web/src/state/aiChat.ts
@@ -41,4 +41,82 @@ export type AiMemoryMessage = {
   isStreaming?: boolean;
 };
 
+export function getAiSourceKey(source: AiSemanticResult): string {
+  return `${source.sourceType}:${source.sourceId}`;
+}
+
+export function sanitizeAiChatMessages(
+  messages: AiMemoryMessage[],
+  interruptedContent: string
+): AiMemoryMessage[] {
+  let changed = false;
+  const nextMessages = messages.map((message) => {
+    let next = message;
+
+    if (next.isStreaming) {
+      changed = true;
+      const { isStreaming: _isStreaming, ...stableMessage } = next;
+      const wasInterruptedAssistant = stableMessage.role === 'assistant' && !stableMessage.content;
+      next = {
+        ...stableMessage,
+        content: wasInterruptedAssistant ? interruptedContent : stableMessage.content,
+        error: wasInterruptedAssistant ? true : stableMessage.error,
+      };
+    }
+
+    if (next.timeline?.some((entry) => entry.status === 'running')) {
+      changed = true;
+      next = {
+        ...next,
+        timeline: next.timeline.map((entry) =>
+          entry.status === 'running' ? { ...entry, status: 'error' as const } : entry
+        ),
+      };
+    }
+
+    return next;
+  });
+
+  return changed ? nextMessages : messages;
+}
+
+export function getLatestAiAssistantPlan(messages: AiMemoryMessage[]): AiRetrievalPlan | null {
+  return (
+    [...messages].reverse().find((message) => message.role === 'assistant' && message.plan)?.plan ||
+    null
+  );
+}
+
+export function getLatestAiSources(messages: AiMemoryMessage[]): AiSemanticResult[] {
+  return (
+    [...messages]
+      .reverse()
+      .find((message) => message.role === 'assistant' && (message.sources?.length || 0) > 0)
+      ?.sources || []
+  );
+}
+
+export function getCurrentAiAssistantSources(messages: AiMemoryMessage[]): AiSemanticResult[] {
+  return [...messages].reverse().find((message) => message.role === 'assistant')?.sources || [];
+}
+
+export function getSeenSourceIdsForActiveAiPlan(messages: AiMemoryMessage[]): string[] {
+  const ids: string[] = [];
+
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message.role !== 'assistant') continue;
+
+    if (message.sources?.length) {
+      ids.push(...message.sources.map(getAiSourceKey));
+    }
+
+    if (message.plan && message.plan.pagination !== 'more') {
+      break;
+    }
+  }
+
+  return Array.from(new Set(ids)).slice(0, 500);
+}
+
 export const aiChatMessagesAtom = atomWithStorage<AiMemoryMessage[]>('aiChatMessages', []);

--- a/web/src/state/aiChat.ts
+++ b/web/src/state/aiChat.ts
@@ -6,11 +6,13 @@ export type AiMessageMetrics = {
   sourcesTime?: number;
   firstTokenTime?: number;
   totalTime?: number;
-  usage?: {
-    prompt_tokens: number;
-    completion_tokens: number;
-    total_tokens: number;
-  };
+  usage?: AiMessageTokenUsage;
+};
+
+export type AiMessageTokenUsage = {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
 };
 
 export type AiMessageTimelineItem = {
@@ -45,6 +47,17 @@ export type AiMemoryMessage = {
 
 export function getAiSourceKey(source: AiSemanticResult): string {
   return `${source.sourceType}:${source.sourceId}`;
+}
+
+export function mergeAiTokenUsage(
+  current: AiMessageTokenUsage | undefined,
+  incoming: AiMessageTokenUsage
+): AiMessageTokenUsage {
+  return {
+    prompt_tokens: (current?.prompt_tokens || 0) + (incoming.prompt_tokens || 0),
+    completion_tokens: (current?.completion_tokens || 0) + (incoming.completion_tokens || 0),
+    total_tokens: (current?.total_tokens || 0) + (incoming.total_tokens || 0),
+  };
 }
 
 export function settleAiMessageTimeline(

--- a/web/src/utils/aiApi.ts
+++ b/web/src/utils/aiApi.ts
@@ -12,12 +12,13 @@ export interface AiStatus {
 }
 
 export interface AiSemanticResult {
-  id: string;
-  ownerId: string;
+  id?: string;
+  ownerId?: string;
   sourceType: AiSourceType;
   sourceId: string;
-  chunkIndex: number;
-  text: string;
+  chunkIndex?: number;
+  text?: string;
+  preview?: string;
   similarity: number;
   metadata: {
     title?: string;
@@ -36,15 +37,6 @@ export interface AiChatResponse {
   plan?: AiRetrievalPlan;
   clarification?: AiClarification;
 }
-
-export type AiRetrievalOperation =
-  | 'summarize'
-  | 'compare'
-  | 'timeline'
-  | 'find_open_loops'
-  | 'analyze_mood'
-  | 'analyze_stress'
-  | 'analyze_personality';
 
 export interface AiTimePlan {
   timeExpression: string | null;
@@ -76,11 +68,11 @@ export interface AiRetrievalFilters {
   sourceTypes: AiSourceType[];
   state: 'private' | 'public' | 'all';
   archived: boolean | null;
+  archivedScopeSpecified?: boolean;
 }
 
 export interface AiRetrievalPlan {
   originalMessage?: string;
-  operations: AiRetrievalOperation[];
   query: string;
   filters: AiRetrievalFilters;
   comparison: null | {
@@ -111,11 +103,30 @@ export type AiAgentPhase =
   | 'reading'
   | 'answering';
 
+export type AiAgentToolProgressStatus =
+  | 'determining_scope'
+  | 'retrieving_sources'
+  | 'reading_source'
+  | 'finding_related'
+  | 'loading_tags';
+
+export type AiUsagePhase = 'planning' | 'tool_decision' | 'answer';
+export type AiThinkingPhase =
+  | 'route_decision'
+  | 'evidence_decision'
+  | 'retrieval_planning'
+  | 'answer';
+
+export type AiTokenUsage = {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+};
+
 export interface AiAgentClientState {
   conversationId?: string;
   previousPlan?: AiRetrievalPlan | null;
   seenSourceIds?: string[];
-  lastSources?: AiSemanticResult[];
   selectedContext?: {
     currentRoteId?: string;
     currentArticleId?: string;
@@ -127,22 +138,18 @@ export interface AiAgentClientState {
 
 export type AiChatStreamHandlers = {
   onRunStarted?: (runId: string) => void;
-  onProgress?: (phase: AiAgentPhase, message: string) => void;
-  onHeartbeat?: (phase: AiAgentPhase, message?: string) => void;
+  onProgress?: (phase: AiAgentPhase) => void;
+  onHeartbeat?: (heartbeat: { phase: AiAgentPhase; seq: number; timestamp: string }) => void;
   onToolStarted?: (toolName: string, args?: unknown) => void;
-  onToolProgress?: (toolName: string, message: string) => void;
+  onToolProgress?: (toolName: string, status: AiAgentToolProgressStatus) => void;
   onToolFinished?: (toolName: string, summary?: string) => void;
   onPlan?: (plan: AiRetrievalPlan) => void;
   onClarification?: (clarification: AiClarification) => void;
   onSources?: (sources: AiSemanticResult[]) => void;
-  onThinking?: (phase: 'planning' | 'answer', text: string) => void;
+  onThinking?: (phase: AiThinkingPhase, text: string) => void;
   onDelta?: (text: string) => void;
   onStatePatch?: (state: Partial<AiAgentClientState>) => void;
-  onUsage?: (usage: {
-    prompt_tokens: number;
-    completion_tokens: number;
-    total_tokens: number;
-  }) => void;
+  onUsage?: (usage: AiTokenUsage, phase: AiUsagePhase) => void;
   onDone?: () => void;
   onError?: (message: string) => void;
 };
@@ -266,19 +273,23 @@ async function readAiStreamResponse(
       if (runId) handlers.onRunStarted?.(runId);
     } else if (parsed.event === 'progress') {
       const data = parsed.data as { phase?: AiAgentPhase; message?: string };
-      if (data.phase && typeof data.message === 'string') {
-        handlers.onProgress?.(data.phase, data.message);
-      }
+      if (data.phase) handlers.onProgress?.(data.phase);
     } else if (parsed.event === 'heartbeat') {
-      const data = parsed.data as { phase?: AiAgentPhase; message?: string };
-      if (data.phase) handlers.onHeartbeat?.(data.phase, data.message);
+      const data = parsed.data as { phase?: AiAgentPhase; seq?: number; timestamp?: string };
+      if (data.phase && typeof data.seq === 'number' && typeof data.timestamp === 'string') {
+        handlers.onHeartbeat?.({ phase: data.phase, seq: data.seq, timestamp: data.timestamp });
+      }
     } else if (parsed.event === 'tool_started') {
       const data = parsed.data as { toolName?: string; args?: unknown };
       if (data.toolName) handlers.onToolStarted?.(data.toolName, data.args);
     } else if (parsed.event === 'tool_progress') {
-      const data = parsed.data as { toolName?: string; message?: string };
-      if (data.toolName && typeof data.message === 'string') {
-        handlers.onToolProgress?.(data.toolName, data.message);
+      const data = parsed.data as {
+        toolName?: string;
+        status?: AiAgentToolProgressStatus;
+        message?: string;
+      };
+      if (data.toolName && data.status) {
+        handlers.onToolProgress?.(data.toolName, data.status);
       }
     } else if (parsed.event === 'tool_finished') {
       const data = parsed.data as { toolName?: string; summary?: string };
@@ -295,8 +306,14 @@ async function readAiStreamResponse(
       const sources = (parsed.data as { sources?: AiSemanticResult[] })?.sources;
       handlers.onSources?.(Array.isArray(sources) ? sources : []);
     } else if (parsed.event === 'thinking') {
-      const data = parsed.data as { phase?: 'planning' | 'answer'; text?: string };
-      if ((data.phase === 'planning' || data.phase === 'answer') && typeof data.text === 'string') {
+      const data = parsed.data as { phase?: AiThinkingPhase; text?: string };
+      if (
+        (data.phase === 'route_decision' ||
+          data.phase === 'evidence_decision' ||
+          data.phase === 'retrieval_planning' ||
+          data.phase === 'answer') &&
+        typeof data.text === 'string'
+      ) {
         handlers.onThinking?.(data.phase, data.text);
       }
     } else if (parsed.event === 'delta') {
@@ -306,12 +323,28 @@ async function readAiStreamResponse(
       const state = (parsed.data as { state?: Partial<AiAgentClientState> })?.state;
       if (state) handlers.onStatePatch?.(state);
     } else if (parsed.event === 'usage') {
-      const usage = parsed.data as {
-        prompt_tokens: number;
-        completion_tokens: number;
-        total_tokens: number;
+      const data = parsed.data as {
+        phase?: AiUsagePhase;
+        usage?: Partial<AiTokenUsage>;
       };
-      if (usage) handlers.onUsage?.(usage);
+      const rawUsage = data.usage;
+      const phase = data.phase;
+      if (
+        phase &&
+        rawUsage &&
+        typeof rawUsage.prompt_tokens === 'number' &&
+        typeof rawUsage.completion_tokens === 'number' &&
+        typeof rawUsage.total_tokens === 'number'
+      ) {
+        handlers.onUsage?.(
+          {
+            prompt_tokens: rawUsage.prompt_tokens,
+            completion_tokens: rawUsage.completion_tokens,
+            total_tokens: rawUsage.total_tokens,
+          },
+          phase
+        );
+      }
     } else if (parsed.event === 'done') {
       doneReceived = true;
       handlers.onDone?.();

--- a/web/src/utils/i18n.ts
+++ b/web/src/utils/i18n.ts
@@ -23,6 +23,9 @@ i18n.use(initReactI18next).init({
   fallbackLng: userLang,
   supportedLngs: ['en', 'zh', 'ja'],
   lng: ['en', 'zh', 'ja'].includes(userLang) ? userLang : 'en',
+  interpolation: {
+    escapeValue: false,
+  },
   react: {
     useSuspense: true,
     bindI18n: 'languageChanged',


### PR DESCRIPTION
## Summary
- Remove the hard-coded retrieval operation enum and let the AI agent choose query, semantic scope, filters, comparison groups, and source limits directly.
- Stream and separate agent thinking phases for route decisions, retrieval planning, evidence checks, and answer reasoning.
- Improve AI chat UI state handling: compact progress, end-state cleanup, token usage phases, source sidebar wrapping, markdown streaming, i18n interpolation, and auto-scroll behavior.
- Harden source/result handling by trimming exposed source payloads, applying final source limits, preserving comparison labels, and avoiding stale seen-source exclusions.

## Validation
- `cd server && bun run lint`
- `cd server && bun run build`
- `cd server && bun test tests/aiRetrievalPlanner.test.ts`
- `cd web && bun run lint`
- `cd web && bun run build`