### PR TITLE
Fix AI agent direct replies

### DIFF
--- a/server/utils/ai/agent/prompt.ts
+++ b/server/utils/ai/agent/prompt.ts
@@ -34,9 +34,9 @@ ${getNativeRoteSkillSummary()}
 
 ## Language
 
-- Answer in the same language as the user's latest message.
-- If the user writes Chinese, answer in Chinese.
-- Do not switch to English unless the user asks for English.
+- Answer in the active conversation language, not mechanically by the latest short message.
+- If the conversation is in Chinese and the latest user message is a brief acknowledgement, confirmation, or ambiguous follow-up, keep answering in Chinese.
+- Switch languages only when the user clearly asks for another language or continues substantive discussion in that language.
 
 ## Sources
 
@@ -58,7 +58,7 @@ If the user asks to organize, edit, tag, merge, or create notes, provide a propo
 
 export function buildFinalAnswerInstruction(): string {
   return `Use the gathered Rote tool results to answer the user's latest request.
-Answer in the same language as the user's latest message. If the user wrote Chinese, answer in Chinese.
+Answer in the active conversation language. If the conversation is in Chinese and the latest user message is only a brief acknowledgement or ambiguous follow-up, keep answering in Chinese.
 Keep the answer concise and grounded in sources.
 Cite source numbers like [1] whenever you rely on Rote content.
 If there is not enough evidence, say so instead of inventing.`;

--- a/server/utils/ai/agent/runtime.ts
+++ b/server/utils/ai/agent/runtime.ts
@@ -182,6 +182,16 @@ async function streamFinalAnswer(ctx: RoteAgentContext, messages: ChatMessage[])
   return emittedText;
 }
 
+async function emitAssistantContent(
+  ctx: RoteAgentContext,
+  content?: string | null
+): Promise<boolean> {
+  const text = content?.trim();
+  if (!text) return false;
+  await ctx.emit({ type: 'delta', text });
+  return true;
+}
+
 function isLikelyChinese(text: string): boolean {
   return /[\u3400-\u9fff]/.test(text);
 }
@@ -270,6 +280,7 @@ export async function runRoteAgentStream(params: {
 
     const toolCalls = assistantMessage.tool_calls || [];
     if (!toolCalls.length) {
+      emittedText = await emitAssistantContent(ctx, assistantMessage.content);
       break;
     }
 


### PR DESCRIPTION
## Summary
- Reuse the assistant content from the tool-decision turn when the agent chooses not to call any tools.
- Avoid the unnecessary second final-answer model call for direct replies.
- Preserve the active conversation language for brief acknowledgements or ambiguous follow-ups, instead of switching by the latest short message.

## Validation
- `cd server && bun run lint`
- `cd server && bun run build`