### PR TITLE
Clarify Docker AI vector deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,23 +23,57 @@
 - **Self-Hosted Deployment**: One-click deployment using Docker or Dokploy
 - **Separated Architecture**: Frontend and backend use separated architecture design, deploy only the services you need
 - **Markdown Articles**: Standalone Article support, can be referenced by notes, offering a pure writing and reading experience
+- **AI Memory**: Optional AI chat over your own notes and articles, with semantic search, related notes, streamed responses, and source references
+- **Admin-Controlled AI**: AI, vector storage, automatic indexing, and public semantic discovery are disabled by default and must be explicitly enabled by an administrator
 - **iOS Client**: More elegant App client
 
 ### Quick Start
 
 #### Method 1: Using Docker Hub Image
 
-Copy [docker-compose.yml](https://github.com/Rabithua/Rote/blob/main/docker-compose.yml) to your server with Docker and Docker Compose installed
+Copy [docker-compose.yml](docker-compose.yml) to your server with Docker and Docker Compose installed
 
 > Note: If you use a reverse proxy, VITE_API_BASE should be your backend address after the reverse proxy
+>
+> Rote now uses `pgvector/pgvector:pg17-trixie` by default. It behaves like PostgreSQL 17 and additionally supports the optional AI vector extension. Plain `postgres:17` is only a temporary compatibility path and may not be supported by future Rote versions.
+>
+> `latest` is the stable image. If you are reading the develop branch documentation or testing unreleased AI Memory features, use `IMAGE_TAG=develop`.
 
 ```bash
-# Use latest version (default config file)
-VITE_API_BASE=http://<your-ip-address>:18000 docker-compose up -d
+# 1. Create a .env file beside docker-compose.yml
+cat > .env <<'EOF'
+VITE_API_BASE=http://YOUR_SERVER_IP:18000
+POSTGRES_PASSWORD=change_this_password
+EOF
 
-# Use specific version
-IMAGE_TAG=v1.0.0 docker-compose up -d
+# 2. Replace YOUR_SERVER_IP and change_this_password before first start.
+#    Use a strong URL-safe password. Avoid characters such as @ : / # % in POSTGRES_PASSWORD.
+#    Keep this password unchanged after the database volume has been initialized.
+
+# 3. Start Rote with the latest stable image
+docker compose up -d
 ```
+
+Optional `.env` values:
+
+```bash
+# Use a specific version
+IMAGE_TAG=v1.0.0
+
+# Use the develop branch image for testing unreleased features
+IMAGE_TAG=develop
+
+# Use plain PostgreSQL without pgvector.
+# Compatibility-only; future Rote versions may require pgvector-capable PostgreSQL.
+POSTGRES_IMAGE=postgres:17
+```
+
+After the containers are running:
+
+1. Open `http://<your-ip-address>:18001`.
+2. Complete the setup page and create the first administrator account.
+3. Sign in and configure site settings from the Admin dashboard.
+4. Optional: if your image tag includes AI Memory support, open `Admin -> AI Settings` to configure chat and embedding providers, enable pgvector, and backfill existing notes/articles.
 
 #### Method 2: Using Dokploy (Recommended)
 
@@ -58,6 +92,12 @@ The iOS app can connect to your self-hosted backend.
 2. Set `API Base` to your public backend URL (or reverse-proxy URL).
 3. Continue with the normal login flow.
 
+### AI Memory
+
+AI Memory is optional and disabled by default. It is available in the `develop` image and will be available in stable images after the next release that includes AI Memory. Administrators can enable it from `Admin -> AI Settings` after configuring chat and embedding providers. Rote supports OpenAI-compatible providers, including OpenAI, OpenRouter, Ollama / LM Studio, DeepSeek, SiliconFlow, DashScope / Qwen, Zhipu GLM, Moonshot / Kimi, Volcengine Ark, Tencent Hunyuan, Baidu Qianfan, and custom OpenAI-compatible endpoints.
+
+Only authenticated, email-verified users can use AI features. AI conversations stay in the current browser session and are not persisted to the database. Notes and articles are indexed only when AI vector storage and automatic indexing are enabled by an administrator.
+
 ### Detailed Instructions
 
 For more deployment options and configuration instructions, please check the documentation in the `doc/` directory:
@@ -65,6 +105,7 @@ For more deployment options and configuration instructions, please check the doc
 - [Self-Hosted Deployment Guide](https://rote.ink/doc/selfhosted) - Complete deployment and configuration guide
 - [API Documentation](doc/userguide/API-ENDPOINTS.md) - API interface usage guide
 - [API Key Guide](doc/userguide/API-KEY-GUIDE.md) - How to use API Key
+- [AI Vector Migration Guide](doc/userguide/AI-VECTOR-MIGRATION.zh.md) - Upgrade an existing self-hosted database to AI Memory and pgvector support (Chinese)
 
 ### Video Tutorials (Bilibili)
 

--- a/doc/README.zh.md
+++ b/doc/README.zh.md
@@ -23,23 +23,57 @@
 - **自托管部署**：使用 Docker 或者 Dokploy 一键部署
 - **分离架构**：前后端采用分离的架构设计，按需部署你需要的服务
 - **Markdown 文章**：独立文章支持，可被笔记引用，提供纯粹的读写体验
+- **AI 记忆**：可选的 AI 对话、语义搜索、相关笔记、流式回答和来源引用，基于你自己的笔记与文章工作
+- **管理员控制 AI**：AI、向量存储、自动索引和公开 Explore 语义发现默认关闭，必须由管理员显式启用
 - **iOS 客户端**：更优雅的 App 客户端
 
 ### 快速开始
 
 #### 方式一：使用 Docker Hub 镜像
 
-复制 [docker-compose.yml](https://github.com/Rabithua/Rote/blob/main/docker-compose.yml) 到你的已经装好 Docker 和 Docker Compose 的服务器
+复制 [docker-compose.yml](../docker-compose.yml) 到你的已经装好 Docker 和 Docker Compose 的服务器
 
 > 注意：如果你使用反向代理的话，VITE_API_BASE 应该是你反向代理后的后端地址
+>
+> Rote 现在默认使用 `pgvector/pgvector:pg17-trixie`。它保持 PostgreSQL 17 行为，并额外支持可选的 AI 向量扩展。普通 `postgres:17` 只作为临时兼容路径，后续 Rote 版本可能不再支持。
+>
+> `latest` 是稳定版镜像。如果你正在阅读 develop 分支文档，或者测试尚未发布的 AI 记忆能力，请使用 `IMAGE_TAG=develop`。
 
 ```bash
-# 使用最新版本（默认配置文件）
-VITE_API_BASE=http://<your-ip-address>:18000 docker-compose up -d
+# 1. 在 docker-compose.yml 旁边创建 .env 文件
+cat > .env <<'EOF'
+VITE_API_BASE=http://YOUR_SERVER_IP:18000
+POSTGRES_PASSWORD=change_this_password
+EOF
 
-# 使用特定版本
-IMAGE_TAG=v1.0.0 docker-compose up -d
+# 2. 首次启动前，请替换 YOUR_SERVER_IP 和 change_this_password。
+#    请使用高强度且 URL 安全的数据库密码，避免在 POSTGRES_PASSWORD 中使用 @ : / # % 等字符。
+#    数据库卷初始化后，请保持这个密码不变。
+
+# 3. 使用最新稳定镜像启动 Rote
+docker compose up -d
 ```
+
+可选 `.env` 配置：
+
+```bash
+# 使用特定版本
+IMAGE_TAG=v1.0.0
+
+# 使用 develop 分支镜像测试尚未发布的新功能
+IMAGE_TAG=develop
+
+# 不使用 pgvector，继续使用普通 PostgreSQL
+# 仅作为兼容路径；后续 Rote 版本可能要求使用支持 pgvector 的 PostgreSQL。
+POSTGRES_IMAGE=postgres:17
+```
+
+容器启动后：
+
+1. 打开 `http://<your-ip-address>:18001`。
+2. 在初始化页面创建第一个管理员账号。
+3. 登录后进入管理员后台完成站点配置。
+4. 可选：如果当前镜像包含 AI 记忆能力，进入 `管理 -> AI 相关` 配置对话模型和向量模型，启用 pgvector，并为存量笔记/文章建立索引。
 
 #### 方式二：使用 Dokploy（推荐）
 
@@ -57,6 +91,12 @@ iOS App 支持连接到你自部署的后端。
 1. 在登录页连续点击顶部欢迎文字，会弹出配置框。
 2. 将 `API Base` 修改为你自部署后端的公网地址（或反向代理地址）。
 3. 按正常流程登录即可。
+
+### AI 记忆
+
+AI 记忆是可选能力，默认关闭。它已经可以在 `develop` 镜像中使用，并会在包含 AI 记忆的下一个稳定版发布后进入稳定镜像。管理员可以在 `管理 -> AI 相关` 配置对话模型和向量模型后启用。Rote 支持 OpenAI-compatible 供应商，包括 OpenAI、OpenRouter、Ollama / LM Studio、DeepSeek、SiliconFlow、DashScope / Qwen、Zhipu GLM、Moonshot / Kimi、Volcengine Ark、Tencent Hunyuan、Baidu Qianfan，以及自定义 OpenAI-compatible 接口。
+
+只有已登录且邮箱已验证的用户可以使用 AI 功能。AI 对话只保存在当前浏览器会话中，不会持久化写入数据库。只有在管理员开启 AI 向量存储和自动索引后，笔记与文章才会进入向量索引。
 
 ### 详细说明
 

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -5,7 +5,7 @@ services:
       dockerfile: Dockerfile
     environment:
       # 基础配置 - 必需
-      - POSTGRESQL_URL=postgresql://rote:${POSTGRES_PASSWORD:-rote_password_123}@rote-postgres:5432/rote
+      - POSTGRESQL_URL=postgresql://rote:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env before first start}@rote-postgres:5432/rote
     ports:
       - "18000:3000"
     depends_on:
@@ -27,25 +27,25 @@ services:
       dockerfile: Dockerfile
       args:
         # 构建时传递 VITE_API_BASE（构建时注入到代码中）
-        - VITE_API_BASE=${VITE_API_BASE:-http://localhost:18000}
+        - VITE_API_BASE=${VITE_API_BASE:?Set VITE_API_BASE to your public backend URL, for example http://your-domain.com}
     ports:
       - "18001:80"
     depends_on:
       - rote-backend
     environment:
       # 运行时环境变量，用于启动脚本注入配置（如果需要覆盖构建时配置）
-      - VITE_API_BASE=${VITE_API_BASE:-http://localhost:18000}
+      - VITE_API_BASE=${VITE_API_BASE:?Set VITE_API_BASE to your public backend URL, for example http://your-domain.com}
     restart: unless-stopped
 
   rote-postgres:
     # pgvector image keeps Postgres 17 behavior and adds the optional vector extension.
-    # To keep using plain Postgres, set POSTGRES_IMAGE=postgres:17 before docker compose up.
+    # Plain postgres:17 is a compatibility-only path and may not be supported by future Rote versions.
     image: ${POSTGRES_IMAGE:-pgvector/pgvector:pg17-trixie}
     container_name: rote-postgres
     restart: unless-stopped
     environment:
       POSTGRES_USER: rote
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-rote_password_123}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env before first start}
       POSTGRES_DB: rote
     volumes:
       - rote-postgres-data:/var/lib/postgresql/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,29 +1,38 @@
 # Docker Compose configuration using pre-built images from Docker Hub
-# Usage: docker-compose up -d
+# Usage:
+# 1. Create a .env file beside this compose file.
+# 2. Set VITE_API_BASE=http://YOUR_SERVER_IP:18000 in .env.
+# 3. Set POSTGRES_PASSWORD=change_this_password in .env.
+# 4. Run docker compose up -d.
 #
-# To use a specific version, set IMAGE_TAG environment variable:
-# IMAGE_TAG=v1.0.0 docker-compose up -d
+# Optional .env values:
+# IMAGE_TAG=v1.0.0
+# IMAGE_TAG=develop
+# POSTGRES_IMAGE=postgres:17
+#   Compatibility-only path. Future Rote versions may require pgvector-capable Postgres.
 #
 # Available tags:
 # - latest: Latest stable release (supports multi-platform: amd64, arm64)
 # - release: Latest stable release (same as latest)
-# - develop: Latest from develop branch (supports multi-platform: amd64, arm64)
+# - develop: Latest from develop branch; use this for unreleased features documented on develop
 # - main: Latest from main branch
 # - v1.0.0: Specific version (if released)
 #
 # ⚠️ IMPORTANT ⚠️
 # Don't forget to set VITE_API_BASE
-# Example: VITE_API_BASE=http://<your-ip-address>:18000 or VITE_API_BASE=http://<your-domain>
+# Example: VITE_API_BASE=http://YOUR_SERVER_IP:18000 or VITE_API_BASE=https://your-domain.com
 # Note: If you use a reverse proxy, VITE_API_BASE should be your backend address after the reverse proxy
 
 services:
   rote-backend:
+    # latest is intentionally the stable default. Use IMAGE_TAG=develop to test
+    # unreleased features before they are promoted to the stable image.
     image: rabithua/rote-backend:${IMAGE_TAG:-latest}
     pull_policy: always
     container_name: rote-backend
     environment:
       # 基础配置 - 必需
-      - POSTGRESQL_URL=postgresql://rote:${POSTGRES_PASSWORD:-rote_password_123}@rote-postgres:5432/rote
+      - POSTGRESQL_URL=postgresql://rote:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env before first start}@rote-postgres:5432/rote
     ports:
       - "18000:3000"
     depends_on:
@@ -40,6 +49,7 @@ services:
       ]
 
   rote-frontend:
+    # Keep this tag aligned with rote-backend by using the same IMAGE_TAG value.
     image: rabithua/rote-frontend:${IMAGE_TAG:-latest}
     pull_policy: always
     container_name: rote-frontend
@@ -48,18 +58,18 @@ services:
     depends_on:
       - rote-backend
     environment:
-      - VITE_API_BASE=${VITE_API_BASE:-http://<your-ip-address>:18000}
+      - VITE_API_BASE=${VITE_API_BASE:?Set VITE_API_BASE to your public backend URL, for example http://your-domain.com}
     restart: unless-stopped
 
   rote-postgres:
     # pgvector image keeps Postgres 17 behavior and adds the optional vector extension.
-    # To keep using plain Postgres, set POSTGRES_IMAGE=postgres:17 before docker-compose up.
+    # Plain postgres:17 is a compatibility-only path and may not be supported by future Rote versions.
     image: ${POSTGRES_IMAGE:-pgvector/pgvector:pg17-trixie}
     container_name: rote-postgres
     restart: unless-stopped
     environment:
       POSTGRES_USER: rote
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-rote_password_123}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env before first start}
       POSTGRES_DB: rote
     volumes:
       - rote-postgres-data:/var/lib/postgresql/data


### PR DESCRIPTION
## Summary
- document AI Memory and pgvector deployment expectations in English and Chinese READMEs
- require VITE_API_BASE and POSTGRES_PASSWORD in compose instead of silently using broken defaults
- clarify that plain postgres:17 is compatibility-only and may not be supported by future Rote versions
- align docker-compose.build.yml with the same required environment behavior

## Validation
- git diff --check
- docker compose -f docker-compose.yml config fails when VITE_API_BASE is missing
- docker compose -f docker-compose.yml config fails when POSTGRES_PASSWORD is missing
- VITE_API_BASE=http://localhost:18000 POSTGRES_PASSWORD=strong_url_safe_password docker compose -f docker-compose.yml config
- VITE_API_BASE=http://localhost:18000 POSTGRES_PASSWORD=strong_url_safe_password docker compose -f docker-compose.build.yml config
- IMAGE_TAG=develop POSTGRES_IMAGE=postgres:17 VITE_API_BASE=http://localhost:18000 POSTGRES_PASSWORD=strong_url_safe_password docker compose -f docker-compose.yml config