### PR TITLE
Improve article image and PDF export

### DIFF
--- a/web/src/components/article/ArticleNavBarActions.tsx
+++ b/web/src/components/article/ArticleNavBarActions.tsx
@@ -2,7 +2,11 @@ import { useArticleExport } from '@/hooks/useArticleExport';
 import { downloadMarkdown } from '@/utils/downloadMarkdown';
 import { formatBytes } from '@/utils/main';
 import { Download, FileText, Image as ImageIcon, Loader, TextInitialIcon } from 'lucide-react';
+import type { MouseEvent, PointerEvent } from 'react';
+import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
+
+const PDF_LONG_PRESS_MS = 800;
 
 interface Author {
   nickname?: string;
@@ -23,7 +27,55 @@ export default function ArticleNavBarActions({
 }: ArticleNavBarActionsProps) {
   const { t } = useTranslation('translation', { keyPrefix: 'article.editor' });
   const { t: tActions } = useTranslation('translation', { keyPrefix: 'article.actions' });
-  const { exporting, handleExportImage } = useArticleExport();
+  const { exporting, handleExportImage, handleExportPdf } = useArticleExport();
+  const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const didLongPressRef = useRef(false);
+
+  useEffect(
+    () => () => {
+      if (longPressTimerRef.current) {
+        clearTimeout(longPressTimerRef.current);
+      }
+    },
+    []
+  );
+
+  const clearLongPressTimer = () => {
+    if (longPressTimerRef.current) {
+      clearTimeout(longPressTimerRef.current);
+      longPressTimerRef.current = null;
+    }
+  };
+
+  const startPdfLongPress = (e: PointerEvent<HTMLDivElement>) => {
+    if (exporting) return;
+    if (e.pointerType === 'mouse' && e.button !== 0) return;
+
+    didLongPressRef.current = false;
+    clearLongPressTimer();
+    longPressTimerRef.current = setTimeout(() => {
+      didLongPressRef.current = true;
+      longPressTimerRef.current = null;
+      if (navigator.vibrate) {
+        try {
+          navigator.vibrate(20);
+        } catch {}
+      }
+      void handleExportPdf({ title, content, author });
+    }, PDF_LONG_PRESS_MS);
+  };
+
+  const handleMarkdownClick = (e: MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+
+    if (didLongPressRef.current) {
+      e.preventDefault();
+      didLongPressRef.current = false;
+      return;
+    }
+
+    downloadMarkdown(content, title);
+  };
 
   return (
     <>
@@ -53,12 +105,24 @@ export default function ArticleNavBarActions({
               })}
         </div>
         <div
-          className="group hidden cursor-pointer items-center gap-2 px-2 lg:flex"
-          onClick={(e) => {
-            e.stopPropagation();
-            downloadMarkdown(content, title);
+          className={`group hidden cursor-pointer items-center gap-2 px-2 select-none lg:flex ${
+            exporting ? 'opacity-50' : ''
+          }`}
+          onClick={handleMarkdownClick}
+          onPointerDown={startPdfLongPress}
+          onPointerUp={clearLongPressTimer}
+          onPointerCancel={clearLongPressTimer}
+          onPointerLeave={clearLongPressTimer}
+          onContextMenu={(e) => e.preventDefault()}
+          style={{
+            WebkitUserSelect: 'none',
+            userSelect: 'none',
+            WebkitTouchCallout: 'none',
           }}
-          title={t('download', { defaultValue: 'Download Markdown' })}
+          title={`${t('download', { defaultValue: 'Download Markdown' })} / ${tActions(
+            'longPressExportPdf',
+            { defaultValue: 'Long press to export PDF' }
+          )}`}
         >
           <FileText className="size-3 group-hover:hidden" />
           <Download className="hidden size-3 group-hover:block" />

--- a/web/src/hooks/__tests__/useArticleExport.test.ts
+++ b/web/src/hooks/__tests__/useArticleExport.test.ts
@@ -27,6 +27,8 @@ vi.mock('html-to-image', () => ({
 // Mock HTMLCanvasElement for the master canvas chunking logic
 HTMLCanvasElement.prototype.getContext = vi.fn().mockReturnValue({
   drawImage: vi.fn(),
+  fillRect: vi.fn(),
+  getImageData: vi.fn().mockReturnValue({ data: new Uint8ClampedArray([0, 0, 0, 255]) }),
 });
 HTMLCanvasElement.prototype.toBlob = vi.fn().mockImplementation((cb) => {
   cb(makePNGBlob());
@@ -153,31 +155,77 @@ describe('useArticleExport', () => {
     expect(mockToBlob).not.toHaveBeenCalled();
   });
 
-  it('captures at correct scale accounting for devicePixelRatio', async () => {
+  it('captures at the shared high quality scale', async () => {
     cardWidth = 720;
     cardHeight = 800;
-    // Area = 576000. MAX = 16777216. maxAreaScale = 5.39. maxDimScale = 8192/800 = 10.24.
-    // safeScale = 5.39. DPR = 2. Capped at 4.
     const { result } = renderHook(() => useArticleExport());
     await act(async () => {
       await result.current.handleExportImage({ title: 'T', content: 'C' });
     });
     const [, opts] = mockToBlob.mock.calls[0];
     expect(opts.pixelRatio).toBe(4);
+    expect(opts.canvasWidth).toBe(opts.width);
+    expect(opts.canvasHeight).toBe(opts.height);
+    expect(opts.skipAutoScale).toBe(true);
   });
 
-  it('reduces scale for tall articles', async () => {
+  it('keeps scale and slices tall articles', async () => {
     cardWidth = 720;
     cardHeight = 25000;
-    // Area = 18000000. MAX = 160000000. maxAreaScale = sqrt(160M/18M) = 2.98
-    // maxDimScale = 32767/25000 = 1.31
-    // safeScale = 1.31
     const { result } = renderHook(() => useArticleExport());
     await act(async () => {
       await result.current.handleExportImage({ title: 'T', content: 'C' });
     });
-    const [, opts] = mockToBlob.mock.calls[0];
-    expect(opts.pixelRatio).toBe(2.5);
+    expect(mockToBlob.mock.calls.length).toBeGreaterThan(1);
+    const pixelRatios = mockToBlob.mock.calls.map(([, opts]) => (opts as any).pixelRatio);
+    const outputHeights = mockToBlob.mock.calls.map(([, opts]) => (opts as any).height * 4);
+    const skipAutoScaleFlags = mockToBlob.mock.calls.map(([, opts]) => (opts as any).skipAutoScale);
+    expect(pixelRatios.every((pixelRatio) => pixelRatio === 4)).toBe(true);
+    expect(outputHeights.every((height) => height <= 32767)).toBe(true);
+    expect(outputHeights.some((height) => height > 16384)).toBe(true);
+    expect(skipAutoScaleFlags.every(Boolean)).toBe(true);
+    expect(mockToastSuccess).toHaveBeenCalledWith('exportSplitSuccess');
+  });
+
+  it('uses original filename for a single image and suffixes sliced images', async () => {
+    const downloads: string[] = [];
+    const orig = document.createElement.bind(document);
+    vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      if (tag === 'a') {
+        const a = orig('a');
+        let filename = '';
+        Object.defineProperty(a, 'download', {
+          get: () => filename,
+          set: (value) => {
+            filename = value;
+            downloads.push(value);
+          },
+          configurable: true,
+        });
+        Object.defineProperty(a, 'click', { value: vi.fn() });
+        return a;
+      }
+      return orig(tag);
+    });
+
+    const { result } = renderHook(() => useArticleExport());
+    await act(async () => {
+      await result.current.handleExportImage({ title: 'Short', content: 'C' });
+    });
+
+    expect(downloads).toEqual(['Short.png']);
+
+    downloads.length = 0;
+    cardHeight = 25000;
+    mockToBlob.mockClear();
+
+    await act(async () => {
+      await result.current.handleExportImage({ title: 'Long', content: 'C' });
+    });
+
+    expect(downloads[0]).toBe('Long-1.png');
+    expect(downloads[downloads.length - 1]).toMatch(/^Long-\d+\.png$/);
+    vi.restoreAllMocks();
   });
 
   it('downloads valid PNG', async () => {

--- a/web/src/hooks/__tests__/useArticleExport.test.ts
+++ b/web/src/hooks/__tests__/useArticleExport.test.ts
@@ -15,6 +15,7 @@ function makePNGBlob(size = 1024): Blob {
 const mockToBlob = vi.fn();
 const mockToastSuccess = vi.fn();
 const mockToastError = vi.fn();
+const mockPrint = vi.fn();
 
 let cardWidth = 720;
 let cardHeight = 800;
@@ -114,6 +115,11 @@ beforeEach(() => {
     writable: true,
     configurable: true,
   });
+  Object.defineProperty(window, 'print', {
+    value: mockPrint,
+    writable: true,
+    configurable: true,
+  });
 
   mockToBlob.mockResolvedValue(makePNGBlob());
 
@@ -145,6 +151,7 @@ describe('useArticleExport', () => {
     const { result } = renderHook(() => useArticleExport());
     expect(result.current.exporting).toBe(false);
     expect(typeof result.current.handleExportImage).toBe('function');
+    expect(typeof result.current.handleExportPdf).toBe('function');
   });
 
   it('does nothing with empty content', async () => {
@@ -248,6 +255,23 @@ describe('useArticleExport', () => {
     expect(mockClick).toHaveBeenCalled();
     expect(mockToastSuccess).toHaveBeenCalled();
     vi.restoreAllMocks();
+  });
+
+  it('prints article PDF without capturing PNG', async () => {
+    let printContainer: Element | null = null;
+    mockPrint.mockImplementationOnce(() => {
+      printContainer = document.querySelector('.print-container.article-print-container');
+    });
+
+    const { result } = renderHook(() => useArticleExport());
+    await act(async () => {
+      await result.current.handleExportPdf({ title: 'Art', content: 'Text' });
+    });
+
+    expect(mockPrint).toHaveBeenCalled();
+    expect(printContainer).not.toBeNull();
+    expect(mockToBlob).not.toHaveBeenCalled();
+    expect(mockToastSuccess).toHaveBeenCalledWith('exportPdfSuccess');
   });
 
   it('cleans up DOM after export', async () => {

--- a/web/src/hooks/useAiAnswerExport.tsx
+++ b/web/src/hooks/useAiAnswerExport.tsx
@@ -40,6 +40,7 @@ export function useAiAnswerExport() {
     setExporting(true);
     let cleanupOffscreenContainers: () => void = () => {};
     let logExportError: (step: string, error?: unknown) => void = () => {};
+    let cleanupRenderedElement: (() => void) | undefined;
 
     try {
       const [{ createRoot }, exportImage, { default: AiAnswerExportCard }] = await Promise.all([
@@ -48,13 +49,11 @@ export function useAiAnswerExport() {
         import('@/components/ai/AiAnswerExportCard'),
       ]);
       const {
-        calculateScale,
-        captureElementToPng,
         cleanupOffscreenContainers: cleanup,
-        downloadBlob,
+        exportElementToPng,
         logExport,
         logExportError: logError,
-        waitForImagesToLoad,
+        renderOffscreenExportElement,
         toDataURL,
       } = exportImage;
       cleanupOffscreenContainers = cleanup;
@@ -74,29 +73,27 @@ export function useAiAnswerExport() {
         }
       }
 
-      const container = document.createElement('div');
-      container.className = 'ai-answer-export-container';
-      container.style.cssText = 'position:absolute;left:-9999px;top:0;';
-      document.body.appendChild(container);
-
-      const root = createRoot(container);
-      await new Promise<void>((resolve) => {
-        root.render(
-          <AiAnswerExportCard
-            content={content}
-            sources={sources}
-            sourceTitle={sourceTitle}
-            author={resolvedAuthor}
-            onReady={resolve}
-          />
-        );
+      const {
+        container,
+        element: cardEl,
+        cleanup: cleanupElement,
+      } = await renderOffscreenExportElement({
+        className: 'ai-answer-export-container',
+        render: (container, onReady) => {
+          const root = createRoot(container);
+          root.render(
+            <AiAnswerExportCard
+              content={content}
+              sources={sources}
+              sourceTitle={sourceTitle}
+              author={resolvedAuthor}
+              onReady={onReady}
+            />
+          );
+          return () => root.unmount();
+        },
       });
-
-      const cardEl = container.firstElementChild as HTMLElement;
-      if (!cardEl) throw new Error('Card not rendered');
-
-      await new Promise((resolve) => setTimeout(resolve, 100));
-      await waitForImagesToLoad(cardEl);
+      cleanupRenderedElement = cleanupElement;
 
       if (format === 'pdf') {
         container.classList.add('print-container');
@@ -107,17 +104,22 @@ export function useAiAnswerExport() {
         logExport(`[${exportId}] Done AI answer PDF`);
         toast.success(t('exportSuccess'));
       } else {
-        const rect = cardEl.getBoundingClientRect();
-        const scale = calculateScale(rect.width, rect.height);
-        const blob = await captureElementToPng(cardEl, scale);
-        downloadBlob(blob, `${getAiAnswerFilename(content)}.png`);
-        logExport(`[${exportId}] Done AI answer PNG`, { sizeKB: (blob.size / 1024).toFixed(0) });
-        toast.success(t('exportSuccess'));
+        const result = await exportElementToPng(cardEl, `${getAiAnswerFilename(content)}.png`);
+        logExport(`[${exportId}] Done AI answer PNG`, {
+          mode: result.mode,
+          files: result.files,
+          outputPixels: `${result.outputWidth}x${result.outputHeight}`,
+          sizeKB: (result.totalSize / 1024).toFixed(0),
+        });
+        toast.success(
+          result.files > 1 ? t('exportSplitSuccess', { count: result.files }) : t('exportSuccess')
+        );
       }
     } catch (error) {
       logExportError(`[${exportId}] Failed AI answer ${format}`, error);
       toast.error(t('exportFailed'));
     } finally {
+      cleanupRenderedElement?.();
       cleanupOffscreenContainers();
       setExporting(false);
     }

--- a/web/src/hooks/useArticleExport.tsx
+++ b/web/src/hooks/useArticleExport.tsx
@@ -1,13 +1,11 @@
 import ExportCard from '@/components/article/ExportCard';
 import {
-  captureElementToPng,
   cleanupOffscreenContainers,
-  calculateScale,
-  downloadBlob,
+  exportElementToPng,
   logExport,
   logExportError,
+  renderOffscreenExportElement,
   toDataURL,
-  waitForImagesToLoad,
 } from '@/utils/exportImage';
 import { useState } from 'react';
 import { createRoot } from 'react-dom/client';
@@ -37,6 +35,7 @@ export function useArticleExport() {
     if (exporting) return;
 
     setExporting(true);
+    let cleanupRenderedElement: (() => void) | undefined;
 
     try {
       logExport(`[${exportId}] Start`, {
@@ -53,48 +52,45 @@ export function useArticleExport() {
         }
       }
 
-      const container = document.createElement('div');
-      container.style.cssText = 'position:fixed;left:-9999px;top:0;';
-      document.body.appendChild(container);
-
-      const root = createRoot(container);
-      await new Promise<void>((resolve) => {
-        root.render(
-          <ExportCard
-            title={title || 'Untitled'}
-            content={content}
-            author={resolvedAuthor}
-            onReady={resolve}
-          />
-        );
+      const { element: cardEl, cleanup } = await renderOffscreenExportElement({
+        render: (container, onReady) => {
+          const root = createRoot(container);
+          root.render(
+            <ExportCard
+              title={title || 'Untitled'}
+              content={content}
+              author={resolvedAuthor}
+              onReady={onReady}
+            />
+          );
+          return () => root.unmount();
+        },
       });
-
-      const cardEl = container.firstElementChild as HTMLElement;
-      if (!cardEl) throw new Error('Card not rendered');
-
-      await new Promise((r) => setTimeout(r, 100));
-      await waitForImagesToLoad(cardEl);
+      cleanupRenderedElement = cleanup;
 
       const rect = cardEl.getBoundingClientRect();
-      const dpr = window.devicePixelRatio || 1;
-      const scale = calculateScale(rect.width, rect.height);
 
       logExport(`[${exportId}] Capturing`, {
         size: `${rect.width}x${rect.height}`,
-        dpr,
-        scale,
-        outputPixels: `${rect.width * scale}x${rect.height * scale}`,
+        dpr: window.devicePixelRatio || 1,
       });
 
-      const blob = await captureElementToPng(cardEl, scale);
-      downloadBlob(blob, `${title || 'article'}.png`);
+      const result = await exportElementToPng(cardEl, `${title || 'article'}.png`);
 
-      logExport(`[${exportId}] Done`, { sizeKB: (blob.size / 1024).toFixed(0) });
-      toast.success(t('exportSuccess'));
+      logExport(`[${exportId}] Done`, {
+        mode: result.mode,
+        files: result.files,
+        outputPixels: `${result.outputWidth}x${result.outputHeight}`,
+        sizeKB: (result.totalSize / 1024).toFixed(0),
+      });
+      toast.success(
+        result.files > 1 ? t('exportSplitSuccess', { count: result.files }) : t('exportSuccess')
+      );
     } catch (e) {
       logExportError(`[${exportId}] Failed`, e);
       toast.error(t('exportFailed'));
     } finally {
+      cleanupRenderedElement?.();
       cleanupOffscreenContainers();
       setExporting(false);
     }

--- a/web/src/hooks/useArticleExport.tsx
+++ b/web/src/hooks/useArticleExport.tsx
@@ -28,6 +28,41 @@ export function useArticleExport() {
   const [exporting, setExporting] = useState(false);
   const { t } = useTranslation('translation', { keyPrefix: 'article.actions' });
 
+  const resolveAuthor = async (author?: Author) => {
+    if (!author?.avatar) return author;
+
+    try {
+      return { ...author, avatar: await toDataURL(author.avatar) };
+    } catch {
+      return { ...author, avatar: '/DefaultAvatar.svg' };
+    }
+  };
+
+  const renderArticleExportCard = async ({
+    title,
+    content,
+    author,
+    className,
+  }: UseArticleExportOptions & { className?: string }) => {
+    const resolvedAuthor = await resolveAuthor(author);
+
+    return renderOffscreenExportElement({
+      className,
+      render: (container, onReady) => {
+        const root = createRoot(container);
+        root.render(
+          <ExportCard
+            title={title || 'Untitled'}
+            content={content}
+            author={resolvedAuthor}
+            onReady={onReady}
+          />
+        );
+        return () => root.unmount();
+      },
+    });
+  };
+
   const handleExportImage = async ({ title, content, author }: UseArticleExportOptions) => {
     const exportId = Math.random().toString(36).slice(2, 8);
 
@@ -43,28 +78,10 @@ export function useArticleExport() {
         contentLength: content.length,
       });
 
-      let resolvedAuthor = author;
-      if (author?.avatar) {
-        try {
-          resolvedAuthor = { ...author, avatar: await toDataURL(author.avatar) };
-        } catch {
-          resolvedAuthor = { ...author, avatar: '/DefaultAvatar.svg' };
-        }
-      }
-
-      const { element: cardEl, cleanup } = await renderOffscreenExportElement({
-        render: (container, onReady) => {
-          const root = createRoot(container);
-          root.render(
-            <ExportCard
-              title={title || 'Untitled'}
-              content={content}
-              author={resolvedAuthor}
-              onReady={onReady}
-            />
-          );
-          return () => root.unmount();
-        },
+      const { element: cardEl, cleanup } = await renderArticleExportCard({
+        title,
+        content,
+        author,
       });
       cleanupRenderedElement = cleanup;
 
@@ -96,5 +113,42 @@ export function useArticleExport() {
     }
   };
 
-  return { exporting, handleExportImage };
+  const handleExportPdf = async ({ title, content, author }: UseArticleExportOptions) => {
+    const exportId = Math.random().toString(36).slice(2, 8);
+
+    if (!content) return;
+    if (exporting) return;
+
+    setExporting(true);
+    let cleanupRenderedElement: (() => void) | undefined;
+
+    try {
+      logExport(`[${exportId}] Start PDF`, {
+        title: title?.slice(0, 40),
+        contentLength: content.length,
+      });
+
+      const { cleanup } = await renderArticleExportCard({
+        title,
+        content,
+        author,
+        className: 'print-container article-print-container',
+      });
+      cleanupRenderedElement = cleanup;
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      window.print();
+      logExport(`[${exportId}] Done PDF`);
+      toast.success(t('exportPdfSuccess'));
+    } catch (e) {
+      logExportError(`[${exportId}] Failed PDF`, e);
+      toast.error(t('exportFailed'));
+    } finally {
+      cleanupRenderedElement?.();
+      cleanupOffscreenContainers();
+      setExporting(false);
+    }
+  };
+
+  return { exporting, handleExportImage, handleExportPdf };
 }

--- a/web/src/hooks/useNoteExport.tsx
+++ b/web/src/hooks/useNoteExport.tsx
@@ -1,14 +1,12 @@
 import NoteExportCard from '@/components/rote/NoteExportCard';
 import type { Attachment } from '@/types/main';
 import {
-  captureElementToPng,
   cleanupOffscreenContainers,
-  calculateScale,
-  downloadBlob,
+  exportElementToPng,
   logExport,
   logExportError,
+  renderOffscreenExportElement,
   toDataURL,
-  waitForImagesToLoad,
 } from '@/utils/exportImage';
 import { useState } from 'react';
 import { createRoot } from 'react-dom/client';
@@ -50,6 +48,7 @@ export function useNoteExport() {
     if (exporting) return;
 
     setExporting(true);
+    let cleanupRenderedElement: (() => void) | undefined;
 
     try {
       logExport(`[${exportId}] Start`, {
@@ -67,52 +66,49 @@ export function useNoteExport() {
         }
       }
 
-      const container = document.createElement('div');
-      container.style.cssText = 'position:fixed;left:-9999px;top:0;';
-      document.body.appendChild(container);
-
-      const root = createRoot(container);
-      await new Promise<void>((resolve) => {
-        root.render(
-          <NoteExportCard
-            title={title}
-            content={content}
-            noteId={noteId}
-            tags={tags}
-            attachments={attachments}
-            articleTitle={articleTitle}
-            author={resolvedAuthor}
-            onReady={resolve}
-          />
-        );
+      const { element: cardEl, cleanup } = await renderOffscreenExportElement({
+        render: (container, onReady) => {
+          const root = createRoot(container);
+          root.render(
+            <NoteExportCard
+              title={title}
+              content={content}
+              noteId={noteId}
+              tags={tags}
+              attachments={attachments}
+              articleTitle={articleTitle}
+              author={resolvedAuthor}
+              onReady={onReady}
+            />
+          );
+          return () => root.unmount();
+        },
       });
-
-      const cardEl = container.firstElementChild as HTMLElement;
-      if (!cardEl) throw new Error('Card not rendered');
-
-      await new Promise((r) => setTimeout(r, 100));
-      await waitForImagesToLoad(cardEl);
+      cleanupRenderedElement = cleanup;
 
       const rect = cardEl.getBoundingClientRect();
-      const dpr = window.devicePixelRatio || 1;
-      const scale = calculateScale(rect.width, rect.height);
 
       logExport(`[${exportId}] Capturing`, {
         size: `${rect.width}x${rect.height}`,
-        dpr,
-        scale,
-        outputPixels: `${rect.width * scale}x${rect.height * scale}`,
+        dpr: window.devicePixelRatio || 1,
       });
 
-      const blob = await captureElementToPng(cardEl, scale);
-      downloadBlob(blob, `${title || 'note'}.png`);
+      const result = await exportElementToPng(cardEl, `${title || 'note'}.png`);
 
-      logExport(`[${exportId}] Done`, { sizeKB: (blob.size / 1024).toFixed(0) });
-      toast.success(t('exportSuccess'));
+      logExport(`[${exportId}] Done`, {
+        mode: result.mode,
+        files: result.files,
+        outputPixels: `${result.outputWidth}x${result.outputHeight}`,
+        sizeKB: (result.totalSize / 1024).toFixed(0),
+      });
+      toast.success(
+        result.files > 1 ? t('exportSplitSuccess', { count: result.files }) : t('exportSuccess')
+      );
     } catch (e) {
       logExportError(`[${exportId}] Failed`, e);
       toast.error(t('exportFailed'));
     } finally {
+      cleanupRenderedElement?.();
       cleanupOffscreenContainers();
       setExporting(false);
     }

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -454,6 +454,7 @@
         "exportPdf": "Print / Save PDF",
         "exporting": "Exporting...",
         "exportSuccess": "Image downloaded",
+        "exportSplitSuccess": "Content is long, downloaded as {{count}} images",
         "exportFailed": "Export failed"
       },
       "inputPlaceholder": "Ask your Rote...",
@@ -1279,6 +1280,7 @@
       "exportImage": "Export Image",
       "exporting": "Exporting...",
       "exportSuccess": "Image downloaded",
+      "exportSplitSuccess": "Content is long, downloaded as {{count}} images",
       "exportFailed": "Export failed"
     },
     "roteList": {
@@ -1361,6 +1363,7 @@
       "exportImage": "Export Image",
       "exporting": "Exporting...",
       "exportSuccess": "Image downloaded",
+      "exportSplitSuccess": "Content is long, downloaded as {{count}} images",
       "exportFailed": "Export failed"
     },
     "selection": {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1364,6 +1364,8 @@
       "exporting": "Exporting...",
       "exportSuccess": "Image downloaded",
       "exportSplitSuccess": "Content is long, downloaded as {{count}} images",
+      "exportPdfSuccess": "PDF print dialog opened",
+      "longPressExportPdf": "Long press to export PDF",
       "exportFailed": "Export failed"
     },
     "selection": {

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -1364,6 +1364,8 @@
       "exporting": "エクスポート中...",
       "exportSuccess": "画像をダウンロードしました",
       "exportSplitSuccess": "内容が長いため、{{count}}枚の画像としてダウンロードしました",
+      "exportPdfSuccess": "PDF印刷ダイアログを開きました",
+      "longPressExportPdf": "長押しでPDFをエクスポート",
       "exportFailed": "エクスポートに失敗しました"
     },
     "selection": {

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -454,6 +454,7 @@
         "exportPdf": "PDFを印刷 / 保存",
         "exporting": "生成中...",
         "exportSuccess": "画像をダウンロードしました",
+        "exportSplitSuccess": "内容が長いため、{{count}}枚の画像としてダウンロードしました",
         "exportFailed": "エクスポートに失敗しました"
       },
       "inputPlaceholder": "Rote に質問...",
@@ -1279,6 +1280,7 @@
       "exportImage": "画像をエクスポート",
       "exporting": "エクスポート中...",
       "exportSuccess": "画像をダウンロードしました",
+      "exportSplitSuccess": "内容が長いため、{{count}}枚の画像としてダウンロードしました",
       "exportFailed": "エクスポート失敗"
     },
     "roteList": {
@@ -1361,6 +1363,7 @@
       "exportImage": "画像をエクスポート",
       "exporting": "エクスポート中...",
       "exportSuccess": "画像をダウンロードしました",
+      "exportSplitSuccess": "内容が長いため、{{count}}枚の画像としてダウンロードしました",
       "exportFailed": "エクスポートに失敗しました"
     },
     "selection": {

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1350,6 +1350,8 @@
       "exporting": "导出中...",
       "exportSuccess": "图片已下载",
       "exportSplitSuccess": "内容较长，已拆分为 {{count}} 张图片下载",
+      "exportPdfSuccess": "已打开 PDF 打印窗口",
+      "longPressExportPdf": "长按导出 PDF",
       "exportFailed": "导出失败"
     },
     "selection": {

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -440,6 +440,7 @@
         "exportPdf": "打印 / 导出 PDF",
         "exporting": "生成中...",
         "exportSuccess": "图片已下载",
+        "exportSplitSuccess": "内容较长，已拆分为 {{count}} 张图片下载",
         "exportFailed": "导出失败"
       },
       "inputPlaceholder": "问问你的 Rote...",
@@ -1265,6 +1266,7 @@
       "exportImage": "导出图片",
       "exporting": "导出中...",
       "exportSuccess": "图片已下载",
+      "exportSplitSuccess": "内容较长，已拆分为 {{count}} 张图片下载",
       "exportFailed": "导出失败"
     },
     "roteList": {
@@ -1347,6 +1349,7 @@
       "exportImage": "导出图片",
       "exporting": "导出中...",
       "exportSuccess": "图片已下载",
+      "exportSplitSuccess": "内容较长，已拆分为 {{count}} 张图片下载",
       "exportFailed": "导出失败"
     },
     "selection": {

--- a/web/src/styles/index.css
+++ b/web/src/styles/index.css
@@ -159,6 +159,39 @@ html {
     width: 100% !important;
     display: block !important;
   }
+  .print-container.article-print-container {
+    width: 720px !important;
+    max-width: 100% !important;
+    margin: 0 auto !important;
+    background: #fff !important;
+    box-sizing: border-box !important;
+  }
+  .print-container.article-print-container > * {
+    width: 720px !important;
+    max-width: 100% !important;
+    box-sizing: border-box !important;
+    margin: 0 auto !important;
+  }
+  .print-container.article-print-container .prose {
+    max-width: none !important;
+    overflow: hidden !important;
+  }
+  .print-container.article-print-container .prose pre {
+    max-width: 100% !important;
+    overflow-x: hidden !important;
+    white-space: pre-wrap !important;
+    overflow-wrap: anywhere !important;
+    word-break: break-word !important;
+  }
+  .print-container.article-print-container .prose pre code {
+    white-space: inherit !important;
+    overflow-wrap: inherit !important;
+    word-break: inherit !important;
+  }
+  .print-container.article-print-container .prose code {
+    overflow-wrap: anywhere !important;
+    word-break: break-word !important;
+  }
   @page {
     margin: 0.5cm;
   }

--- a/web/src/utils/exportImage.ts
+++ b/web/src/utils/exportImage.ts
@@ -1,26 +1,260 @@
 import { toBlob } from 'html-to-image';
 
-function getCanvasLimits() {
+const DEFAULT_EXPORT_SCALE = 4;
+const MIN_SAFE_OUTPUT_HEIGHT = 2048;
+const SLICE_DOWNLOAD_DELAY_MS = 80;
+const EXPORT_CONTAINER_CLASS = 'export-render-container';
+const SLICE_VIEWPORT_CLASS = 'export-slice-viewport';
+
+interface CanvasLimitHints {
+  MAX_AREA: number;
+  MAX_DIM: number;
+  safeMaxOutputHeight: number;
+  safetyFactor: number;
+  reason: string;
+}
+
+interface CanvasHeightSupport {
+  canUseFullHeight: boolean;
+  maxOutputHeight: number;
+  capability: 'probed' | 'estimated';
+  reason: string;
+}
+
+interface CaptureOptions {
+  backgroundColor?: string;
+  scale?: number;
+}
+
+export interface ExportPngPart {
+  blob: Blob;
+  cssHeight: number;
+  outputHeight: number;
+  index: number;
+  total: number;
+}
+
+export interface ExportPngResult {
+  files: number;
+  mode: 'single' | 'sliced';
+  scale: number;
+  outputWidth: number;
+  outputHeight: number;
+  maxSliceOutputHeight: number;
+  sliceCssHeight: number;
+  totalSize: number;
+  capability: 'probed' | 'estimated';
+  reason: string;
+}
+
+export interface OffscreenExportElement {
+  container: HTMLElement;
+  element: HTMLElement;
+  cleanup: () => void;
+}
+
+interface RenderOffscreenExportElementOptions {
+  className?: string;
+  render: (container: HTMLElement, onReady: () => void) => (() => void) | void;
+}
+
+class BlankCaptureError extends Error {
+  constructor() {
+    super('Blank image capture');
+    this.name = 'BlankCaptureError';
+  }
+}
+
+function getCanvasLimits(): CanvasLimitHints {
   let maxArea = 160000000;
   let maxDim = 32767;
+  let safetyFactor = 0.9;
+  let reason = 'default';
 
-  if (typeof navigator !== 'undefined' && typeof window !== 'undefined') {
-    const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
-      navigator.userAgent
-    );
+  if (typeof navigator === 'undefined' || typeof window === 'undefined') {
+    return {
+      MAX_AREA: maxArea,
+      MAX_DIM: maxDim,
+      safeMaxOutputHeight: Math.floor(maxDim * safetyFactor),
+      safetyFactor,
+      reason,
+    };
+  }
 
-    if (isMobile) {
-      // 移动端更严格的内存和 Canvas 限制
-      maxArea = 67108864; // 8192 * 8192
-      maxDim = 16384;
-    } else {
-      // PC 端适当放宽限制 (268M 像素面积)
-      maxArea = 268435456; // 16384 * 16384
-      maxDim = 32767;
+  const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+    navigator.userAgent
+  );
+  const deviceMemory = (navigator as Navigator & { deviceMemory?: number }).deviceMemory;
+
+  if (isMobile) {
+    maxArea = 67108864;
+    maxDim = 16384;
+    safetyFactor = 0.85;
+    reason = 'mobile';
+  } else {
+    maxArea = 268435456;
+    maxDim = 32767;
+    safetyFactor = 0.92;
+    reason = 'desktop';
+  }
+
+  if (typeof deviceMemory === 'number') {
+    if (deviceMemory <= 2) {
+      maxArea = Math.min(maxArea, 33554432);
+      maxDim = Math.min(maxDim, 8192);
+      safetyFactor = Math.min(safetyFactor, 0.8);
+      reason += '-low-memory';
+    } else if (deviceMemory <= 4) {
+      maxArea = Math.min(maxArea, 67108864);
+      maxDim = Math.min(maxDim, 16384);
+      safetyFactor = Math.min(safetyFactor, 0.85);
+      reason += '-medium-memory';
     }
   }
 
-  return { MAX_AREA: maxArea, MAX_DIM: maxDim };
+  return {
+    MAX_AREA: maxArea,
+    MAX_DIM: maxDim,
+    safeMaxOutputHeight: Math.floor(maxDim * safetyFactor),
+    safetyFactor,
+    reason,
+  };
+}
+
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForFontsToLoad() {
+  if (typeof document === 'undefined' || !document.fonts?.ready) return;
+
+  await Promise.race([document.fonts.ready, delay(3000)]);
+}
+
+function getRawMaxOutputHeight(outputWidth: number, limits: CanvasLimitHints) {
+  const areaHeight = Math.floor(limits.MAX_AREA / Math.max(1, outputWidth));
+  return Math.max(MIN_SAFE_OUTPUT_HEIGHT, Math.min(limits.MAX_DIM, areaHeight));
+}
+
+function getEstimatedMaxOutputHeight(outputWidth: number, limits: CanvasLimitHints) {
+  const rawHeight = getRawMaxOutputHeight(outputWidth, limits);
+  return Math.max(
+    MIN_SAFE_OUTPUT_HEIGHT,
+    Math.min(limits.safeMaxOutputHeight, Math.floor(rawHeight * limits.safetyFactor))
+  );
+}
+
+function probeCanvasSize(width: number, height: number): boolean | undefined {
+  if (typeof document === 'undefined') return undefined;
+
+  const canvas = document.createElement('canvas');
+  const canvasWidth = Math.max(1, Math.floor(width));
+  const canvasHeight = Math.max(1, Math.floor(height));
+
+  try {
+    canvas.width = canvasWidth;
+    canvas.height = canvasHeight;
+
+    if (canvas.width !== canvasWidth || canvas.height !== canvasHeight) {
+      return false;
+    }
+
+    const ctx = canvas.getContext('2d', { willReadFrequently: true });
+
+    if (!ctx || typeof ctx.fillRect !== 'function' || typeof ctx.getImageData !== 'function') {
+      return undefined;
+    }
+
+    ctx.fillStyle = '#000';
+    ctx.fillRect(canvasWidth - 1, canvasHeight - 1, 1, 1);
+    return ctx.getImageData(canvasWidth - 1, canvasHeight - 1, 1, 1).data[3] > 0;
+  } catch {
+    return false;
+  } finally {
+    canvas.width = 1;
+    canvas.height = 1;
+  }
+}
+
+function getCanvasHeightSupport(
+  outputWidth: number,
+  desiredOutputHeight: number
+): CanvasHeightSupport {
+  const limits = getCanvasLimits();
+  const rawMaxHeight = getRawMaxOutputHeight(outputWidth, limits);
+  const estimatedMaxHeight = getEstimatedMaxOutputHeight(outputWidth, limits);
+
+  if (desiredOutputHeight <= rawMaxHeight) {
+    const directProbe = probeCanvasSize(outputWidth, desiredOutputHeight);
+    if (directProbe === true) {
+      return {
+        canUseFullHeight: true,
+        maxOutputHeight: desiredOutputHeight,
+        capability: 'probed',
+        reason: limits.reason,
+      };
+    }
+
+    if (directProbe === undefined && desiredOutputHeight <= estimatedMaxHeight) {
+      return {
+        canUseFullHeight: true,
+        maxOutputHeight: desiredOutputHeight,
+        capability: 'estimated',
+        reason: limits.reason,
+      };
+    }
+  }
+
+  const highestCandidate = Math.min(desiredOutputHeight, rawMaxHeight);
+  const highProbe = probeCanvasSize(outputWidth, highestCandidate);
+
+  if (highProbe === true) {
+    return {
+      canUseFullHeight: false,
+      maxOutputHeight: highestCandidate,
+      capability: 'probed',
+      reason: limits.reason,
+    };
+  }
+
+  if (highProbe === undefined) {
+    return {
+      canUseFullHeight: false,
+      maxOutputHeight: Math.min(highestCandidate, estimatedMaxHeight),
+      capability: 'estimated',
+      reason: limits.reason,
+    };
+  }
+
+  let low = MIN_SAFE_OUTPUT_HEIGHT;
+  let high = highestCandidate;
+  let best = 0;
+
+  while (low <= high) {
+    const candidateHeight = Math.floor((low + high) / 2);
+    const probe = probeCanvasSize(outputWidth, candidateHeight);
+
+    if (probe === true) {
+      best = candidateHeight;
+      low = candidateHeight + 1;
+    } else if (probe === undefined && candidateHeight <= estimatedMaxHeight) {
+      return {
+        canUseFullHeight: false,
+        maxOutputHeight: candidateHeight,
+        capability: 'estimated',
+        reason: limits.reason,
+      };
+    } else {
+      high = candidateHeight - 1;
+    }
+  }
+
+  return {
+    canUseFullHeight: false,
+    maxOutputHeight: best || Math.min(MIN_SAFE_OUTPUT_HEIGHT, estimatedMaxHeight),
+    capability: best ? 'probed' : 'estimated',
+    reason: limits.reason,
+  };
 }
 
 export function logExport(step: string, data?: Record<string, unknown>) {
@@ -81,47 +315,78 @@ export async function waitForImagesToLoad(container: HTMLElement) {
   await Promise.all(promises);
 }
 
-export function calculateScale(width: number, height: number) {
-  const { MAX_AREA, MAX_DIM } = getCanvasLimits();
-  const currentArea = width * height;
-  const maxAreaScale = Math.sqrt(MAX_AREA / currentArea);
-  const maxDimScale = Math.min(MAX_DIM / width, MAX_DIM / height);
-  const safeScale = Math.min(maxAreaScale, maxDimScale);
-
-  let scale = 4;
-  if (scale > safeScale) {
-    scale = Math.floor(safeScale * 2) / 2;
-    if (scale < 1) scale = 1;
-  }
-
-  // eslint-disable-next-line no-console
-  console.log('[calculateScale]', {
-    width,
-    height,
-    currentArea,
-    MAX_AREA,
-    MAX_DIM,
-    maxAreaScale,
-    maxDimScale,
-    safeScale,
-    finalScale: scale,
-    devicePixelRatio: typeof window !== 'undefined' ? window.devicePixelRatio : 'unknown',
-  });
-
-  return scale;
+export function calculateScale(_width: number, _height: number) {
+  return DEFAULT_EXPORT_SCALE;
 }
 
-export async function captureElementToPng(el: HTMLElement, scale: number): Promise<Blob> {
+function getElementRect(el: HTMLElement) {
   const rect = el.getBoundingClientRect();
+  const width = Math.ceil(rect.width);
+  const height = Math.ceil(rect.height);
 
-  // 直接全量生成图片，不再通过 translate 切片。
-  // 切片时的 transform: translateY 容易触发 Chromium 超过 2000px 的合成层降级（1x 分辨率光栅化），导致文字模糊。
-  // 因为在上一步 calculateScale 中已经保证了生成尺寸一定在安全范围内，直接生成即可。
-  const finalBlob = await toBlob(el, {
+  if (width <= 0 || height <= 0) {
+    throw new Error(`Invalid export size ${width}x${height}`);
+  }
+
+  return { width, height };
+}
+
+async function getCapturePlan(el: HTMLElement, options: CaptureOptions | undefined) {
+  const { width, height } = getElementRect(el);
+  const scale = options?.scale ?? DEFAULT_EXPORT_SCALE;
+  const outputWidth = Math.ceil(width * scale);
+  const outputHeight = Math.ceil(height * scale);
+  const support = getCanvasHeightSupport(outputWidth, outputHeight);
+
+  if (support.canUseFullHeight) {
+    return {
+      mode: 'single' as const,
+      scale,
+      width,
+      height,
+      outputWidth,
+      outputHeight,
+      maxSliceOutputHeight: outputHeight,
+      sliceCssHeight: height,
+      sliceCount: 1,
+      capability: support.capability,
+      reason: support.reason,
+    };
+  }
+
+  const sliceCssHeight = Math.max(1, Math.floor(support.maxOutputHeight / scale));
+
+  return {
+    mode: 'sliced' as const,
+    scale,
+    width,
+    height,
+    outputWidth,
+    outputHeight,
+    maxSliceOutputHeight: support.maxOutputHeight,
+    sliceCssHeight,
+    sliceCount: Math.ceil(height / sliceCssHeight),
+    capability: support.capability,
+    reason: support.reason,
+  };
+}
+
+async function captureNodeToPng(
+  el: HTMLElement,
+  width: number,
+  height: number,
+  scale: number,
+  backgroundColor: string,
+  style?: Partial<CSSStyleDeclaration>
+) {
+  const blob = await toBlob(el, {
     pixelRatio: scale,
-    backgroundColor: '#ffffff',
-    width: rect.width,
-    height: rect.height,
+    backgroundColor,
+    width,
+    height,
+    canvasWidth: width,
+    canvasHeight: height,
+    skipAutoScale: true,
     style: {
       left: '0',
       top: '0',
@@ -129,11 +394,211 @@ export async function captureElementToPng(el: HTMLElement, scale: number): Promi
       transformOrigin: 'top left',
       WebkitFontSmoothing: 'antialiased',
       MozOsxFontSmoothing: 'grayscale',
+      ...style,
     } as any,
   });
 
-  if (!finalBlob || finalBlob.size === 0) throw new Error('Empty image');
-  return finalBlob;
+  if (!blob || blob.size === 0) throw new Error('Empty image');
+  return blob;
+}
+
+async function captureElementSliceToPng(
+  el: HTMLElement,
+  width: number,
+  fullHeight: number,
+  sliceTop: number,
+  sliceHeight: number,
+  scale: number,
+  backgroundColor: string
+) {
+  return captureNodeToPng(el, width, sliceHeight, scale, backgroundColor, {
+    height: `${fullHeight}px`,
+    marginTop: `-${sliceTop}px`,
+    overflow: 'visible',
+  });
+}
+
+async function isLikelyBlankPng(blob: Blob) {
+  if (typeof document === 'undefined' || typeof createImageBitmap === 'undefined') return false;
+
+  let bitmap: ImageBitmap | undefined;
+
+  try {
+    bitmap = await createImageBitmap(blob);
+    const canvas = document.createElement('canvas');
+    canvas.width = Math.min(64, bitmap.width);
+    canvas.height = Math.min(256, bitmap.height);
+
+    const ctx = canvas.getContext('2d', { willReadFrequently: true });
+    if (!ctx || typeof ctx.getImageData !== 'function') return false;
+
+    ctx.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
+
+    const data = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
+    let visiblePixels = 0;
+
+    for (let index = 0; index < data.length; index += 4) {
+      const alpha = data[index + 3];
+      const red = data[index];
+      const green = data[index + 1];
+      const blue = data[index + 2];
+
+      if (alpha > 16 && (red < 253 || green < 253 || blue < 253)) {
+        visiblePixels += 1;
+      }
+    }
+
+    return visiblePixels === 0;
+  } catch {
+    return false;
+  } finally {
+    bitmap?.close();
+  }
+}
+
+export async function captureElementToPng(el: HTMLElement, scale: number): Promise<Blob> {
+  const { width, height } = getElementRect(el);
+  return captureNodeToPng(el, width, height, scale, '#ffffff');
+}
+
+function createSlicedPlan(
+  plan: Awaited<ReturnType<typeof getCapturePlan>>,
+  maxSliceOutputHeight: number
+) {
+  const safeMaxSliceOutputHeight = Math.max(
+    MIN_SAFE_OUTPUT_HEIGHT,
+    Math.min(plan.outputHeight, maxSliceOutputHeight)
+  );
+  const sliceCssHeight = Math.max(1, Math.floor(safeMaxSliceOutputHeight / plan.scale));
+
+  return {
+    ...plan,
+    mode: 'sliced' as const,
+    maxSliceOutputHeight: safeMaxSliceOutputHeight,
+    sliceCssHeight,
+    sliceCount: Math.ceil(plan.height / sliceCssHeight),
+  };
+}
+
+async function captureSlicedParts(
+  el: HTMLElement,
+  plan: Awaited<ReturnType<typeof getCapturePlan>>,
+  backgroundColor: string
+) {
+  const parts: ExportPngPart[] = [];
+
+  for (let index = 0; index < plan.sliceCount; index += 1) {
+    const sliceTop = index * plan.sliceCssHeight;
+    const sliceHeight = Math.min(plan.sliceCssHeight, plan.height - sliceTop);
+    const blob = await captureElementSliceToPng(
+      el,
+      plan.width,
+      plan.height,
+      sliceTop,
+      sliceHeight,
+      plan.scale,
+      backgroundColor
+    );
+
+    if (await isLikelyBlankPng(blob)) {
+      throw new BlankCaptureError();
+    }
+
+    parts.push({
+      blob,
+      cssHeight: sliceHeight,
+      outputHeight: Math.ceil(sliceHeight * plan.scale),
+      index,
+      total: plan.sliceCount,
+    });
+  }
+
+  return parts;
+}
+
+export async function captureElementToPngParts(
+  el: HTMLElement,
+  options?: CaptureOptions
+): Promise<{ parts: ExportPngPart[]; result: Omit<ExportPngResult, 'files' | 'totalSize'> }> {
+  await waitForFontsToLoad();
+
+  const backgroundColor = options?.backgroundColor ?? '#ffffff';
+  let plan = await getCapturePlan(el, options);
+
+  logExport('Capture plan', {
+    mode: plan.mode,
+    cssSize: `${plan.width}x${plan.height}`,
+    outputPixels: `${plan.outputWidth}x${plan.outputHeight}`,
+    scale: plan.scale,
+    maxSliceOutputHeight: plan.maxSliceOutputHeight,
+    sliceCssHeight: plan.sliceCssHeight,
+    sliceCount: plan.sliceCount,
+    capability: plan.capability,
+    reason: plan.reason,
+  });
+
+  if (plan.mode === 'single') {
+    const blob = await captureNodeToPng(el, plan.width, plan.height, plan.scale, backgroundColor);
+    if (await isLikelyBlankPng(blob)) {
+      plan = createSlicedPlan(plan, Math.floor(plan.outputHeight / 2));
+    } else {
+      return {
+        parts: [
+          {
+            blob,
+            cssHeight: plan.height,
+            outputHeight: plan.outputHeight,
+            index: 0,
+            total: 1,
+          },
+        ],
+        result: {
+          mode: plan.mode,
+          scale: plan.scale,
+          outputWidth: plan.outputWidth,
+          outputHeight: plan.outputHeight,
+          maxSliceOutputHeight: plan.maxSliceOutputHeight,
+          sliceCssHeight: plan.sliceCssHeight,
+          capability: plan.capability,
+          reason: plan.reason,
+        },
+      };
+    }
+  }
+
+  let activePlan = createSlicedPlan(plan, plan.maxSliceOutputHeight);
+
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    try {
+      const parts = await captureSlicedParts(el, activePlan, backgroundColor);
+      return {
+        parts,
+        result: {
+          mode: activePlan.mode,
+          scale: activePlan.scale,
+          outputWidth: activePlan.outputWidth,
+          outputHeight: activePlan.outputHeight,
+          maxSliceOutputHeight: activePlan.maxSliceOutputHeight,
+          sliceCssHeight: activePlan.sliceCssHeight,
+          capability: activePlan.capability,
+          reason: activePlan.reason,
+        },
+      };
+    } catch (error) {
+      if (!(error instanceof BlankCaptureError)) throw error;
+
+      const nextMaxSliceOutputHeight = Math.floor(activePlan.maxSliceOutputHeight / 2);
+      if (nextMaxSliceOutputHeight < MIN_SAFE_OUTPUT_HEIGHT) throw error;
+
+      logExport('Blank slice detected, retrying with smaller slices', {
+        previousMaxSliceOutputHeight: activePlan.maxSliceOutputHeight,
+        nextMaxSliceOutputHeight,
+      });
+      activePlan = createSlicedPlan(activePlan, nextMaxSliceOutputHeight);
+    }
+  }
+
+  throw new BlankCaptureError();
 }
 
 export function downloadBlob(blob: Blob, filename: string) {
@@ -145,10 +610,84 @@ export function downloadBlob(blob: Blob, filename: string) {
   URL.revokeObjectURL(url);
 }
 
+function getPartFilename(filename: string, index: number, total: number) {
+  const normalizedFilename = filename.trim() || 'export.png';
+  const pngFilename = normalizedFilename.toLowerCase().endsWith('.png')
+    ? normalizedFilename
+    : `${normalizedFilename}.png`;
+
+  if (total === 1) return pngFilename;
+
+  return pngFilename.replace(/\.png$/i, `-${index + 1}.png`);
+}
+
+export async function exportElementToPng(
+  el: HTMLElement,
+  filename: string,
+  options?: CaptureOptions
+): Promise<ExportPngResult> {
+  const { parts, result } = await captureElementToPngParts(el, options);
+
+  for (const part of parts) {
+    downloadBlob(part.blob, getPartFilename(filename, part.index, part.total));
+    if (parts.length > 1) await delay(SLICE_DOWNLOAD_DELAY_MS);
+  }
+
+  return {
+    ...result,
+    files: parts.length,
+    totalSize: parts.reduce((total, part) => total + part.blob.size, 0),
+  };
+}
+
+export async function renderOffscreenExportElement({
+  className,
+  render,
+}: RenderOffscreenExportElementOptions): Promise<OffscreenExportElement> {
+  const container = document.createElement('div');
+  container.className = [EXPORT_CONTAINER_CLASS, className].filter(Boolean).join(' ');
+  container.style.cssText = 'position:fixed;left:-9999px;top:0;';
+  document.body.appendChild(container);
+
+  let cleanupRender: (() => void) | undefined;
+
+  try {
+    await new Promise<void>((resolve) => {
+      cleanupRender = render(container, resolve) || undefined;
+    });
+
+    const element = container.firstElementChild as HTMLElement | null;
+    if (!element) throw new Error('Card not rendered');
+
+    await delay(100);
+    await waitForImagesToLoad(element);
+    await waitForFontsToLoad();
+
+    return {
+      container,
+      element,
+      cleanup: () => {
+        cleanupRender?.();
+        container.remove();
+      },
+    };
+  } catch (error) {
+    cleanupRender?.();
+    container.remove();
+    throw error;
+  }
+}
+
 export function cleanupOffscreenContainers() {
   document.body
     .querySelectorAll(
-      '.ai-answer-export-container, [style*="left:-9999px"], [style*="left: -9999px"]'
+      [
+        `.${EXPORT_CONTAINER_CLASS}`,
+        `.${SLICE_VIEWPORT_CLASS}`,
+        '.ai-answer-export-container',
+        '[style*="left:-9999px"]',
+        '[style*="left: -9999px"]',
+      ].join(',')
     )
     .forEach((el) => el.remove());
 }


### PR DESCRIPTION
## Summary
- unify article/note/AI image export behavior with high-quality dynamic slicing
- add long-press article Markdown action to export PDF via the shared article export card
- align PDF print layout with image export and wrap long code blocks
- fix export-related locale keys across zh/en/ja

## Validation
- bun run test -- useArticleExport
- bun run lint
- bun run build