### PR TITLE
Improve frontend error handling

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { Toaster } from '@/components/ui/sonner';
 import { useSiteStatus } from '@/hooks/useSiteStatus';
 import { bootstrapAuthAtom } from '@/state/profile';
+import { getHttpStatus } from '@/utils/error';
 import { Helmet, HelmetProvider } from '@dr.pogodin/react-helmet';
 import { useSetAtom } from 'jotai';
 import React from 'react';
@@ -31,7 +32,8 @@ const AppWrapper = () => (
       <SWRConfig
         value={{
           onErrorRetry: (error, key, _config, _revalidate, { retryCount }) => {
-            if ([404, 401, 403].includes(error.status)) return;
+            const status = getHttpStatus(error);
+            if (status && [404, 401, 403].includes(status)) return;
             if (key === 'profile') return;
             if (retryCount >= 3) return;
           },

--- a/web/src/components/others/PageRequestError.tsx
+++ b/web/src/components/others/PageRequestError.tsx
@@ -1,0 +1,34 @@
+import { Button } from '@/components/ui/button';
+import { getErrorMessage, getHttpStatus } from '@/utils/error';
+import { RefreshCw } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+interface PageRequestErrorProps {
+  error?: unknown;
+  onRetry: () => void;
+}
+
+export default function PageRequestError({ error, onRetry }: PageRequestErrorProps) {
+  const { t } = useTranslation('translation', { keyPrefix: 'pages.error' });
+  const status = getHttpStatus(error);
+  const message = getErrorMessage(error);
+
+  return (
+    <div className="flex min-h-[50vh] items-center justify-center px-6">
+      <div className="flex max-w-md flex-col items-center gap-3 text-center">
+        <p className="text-lg font-semibold">{t('loadFailed')}</p>
+        <p className="text-muted-foreground text-sm">{t('loadFailedDesc')}</p>
+        {(status || message) && (
+          <div className="bg-muted text-muted-foreground w-full rounded-md border px-3 py-2 text-left font-mono text-xs break-words">
+            {status && <div className="text-foreground font-semibold">HTTP {status}</div>}
+            {message && <div>{message}</div>}
+          </div>
+        )}
+        <Button variant="outline" onClick={onRetry}>
+          <RefreshCw className="size-4" />
+          {t('retry')}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -4,11 +4,7 @@
       "poem": "",
       "headingBefore": "A note repository like",
       "headingAfter": " 🤔",
-      "linksItems": [
-        "Login",
-        "",
-        "GitHub"
-      ],
+      "linksItems": ["Login", "", "GitHub"],
       "dashboard": "Dashboard",
       "star": "Stars",
       "fork": "Forks",
@@ -180,8 +176,13 @@
       }
     },
     "error": {
-      "pageNotFound": "Page not found or an error occurred",
+      "pageNotFound": "Page not found",
       "pageNotFoundDesc": "Sorry, we couldn't find the page you were looking for",
+      "pageError": "Something went wrong",
+      "pageErrorDesc": "An unexpected error occurred while loading this page. Please try again.",
+      "loadFailed": "Failed to load content",
+      "loadFailedDesc": "Content is temporarily unavailable. Check your connection and try again.",
+      "retry": "Retry",
       "back": "Back",
       "goHome": "Go home"
     },

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -4,11 +4,7 @@
       "poem": "",
       "headingBefore": "",
       "headingAfter": " のようなノートリポジトリ 🤔",
-      "linksItems": [
-        "ログイン",
-        "",
-        "GitHub"
-      ],
+      "linksItems": ["ログイン", "", "GitHub"],
       "dashboard": "ダッシュボード",
       "star": "スター",
       "fork": "フォーク",
@@ -73,7 +69,11 @@
           },
           "debug": {
             "title": "検索プロセス",
-            "items": ["ツール 1 回：rote_search_notes", "ヒット数：20", "終了理由：agent_search_tool"]
+            "items": [
+              "ツール 1 回：rote_search_notes",
+              "ヒット数：20",
+              "終了理由：agent_search_tool"
+            ]
           },
           "thinking": {
             "route": {
@@ -180,8 +180,13 @@
       }
     },
     "error": {
-      "pageNotFound": "ページが見つからないか、エラーが発生しました",
+      "pageNotFound": "ページが見つかりません",
       "pageNotFoundDesc": "申し訳ございませんが、お探しのページが見つかりませんでした",
+      "pageError": "ページでエラーが発生しました",
+      "pageErrorDesc": "ページの読み込み中に予期しないエラーが発生しました。もう一度お試しください。",
+      "loadFailed": "コンテンツを読み込めませんでした",
+      "loadFailedDesc": "現在コンテンツを取得できません。接続を確認してもう一度お試しください。",
+      "retry": "再試行",
       "back": "戻る",
       "goHome": "ホームへ"
     },

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -166,8 +166,13 @@
       }
     },
     "error": {
-      "pageNotFound": "页面未找到或发生错误",
+      "pageNotFound": "页面未找到",
       "pageNotFoundDesc": "抱歉，我们无法找到您要访问的页面",
+      "pageError": "页面发生错误",
+      "pageErrorDesc": "页面加载时出现了意外错误，请重试。",
+      "loadFailed": "内容加载失败",
+      "loadFailedDesc": "暂时无法获取内容，请检查网络后重试。",
+      "retry": "重试",
       "back": "返回",
       "goHome": "回到首页"
     },

--- a/web/src/pages/404/index.tsx
+++ b/web/src/pages/404/index.tsx
@@ -2,7 +2,7 @@ import { Button } from '@/components/ui/button';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 
-export default function ErrorPage() {
+export default function NotFoundPage() {
   const { t } = useTranslation('translation', { keyPrefix: 'pages.error' });
   const navigate = useNavigate();
   const location = useLocation();
@@ -20,7 +20,7 @@ export default function ErrorPage() {
       <main className="bg-background flex h-dvh place-items-center items-center justify-center px-6">
         <div className="flex flex-col gap-2">
           <p className="text-primary bg-black bg-clip-text font-mono text-[100px] font-semibold lg:text-[200px] dark:text-white">
-            40X
+            404
           </p>
           <h1 className="text-primary/90 text-base font-bold tracking-tight lg:text-2xl dark:text-white/90">
             {t('pageNotFound')}

--- a/web/src/pages/article/[articleid].tsx
+++ b/web/src/pages/article/[articleid].tsx
@@ -2,12 +2,14 @@ import ArticleNavBarActions from '@/components/article/ArticleNavBarActions';
 import { VerifiedIcon } from '@/components/icons/Verified';
 import NavBar from '@/components/layout/navBar';
 import LoadingPlaceholder from '@/components/others/LoadingPlaceholder';
+import PageRequestError from '@/components/others/PageRequestError';
 import UserAvatar from '@/components/others/UserAvatar';
 import { Button } from '@/components/ui/button';
 import { useArticleActions } from '@/hooks/useArticleActions';
 import ContainerWithSideBar from '@/layout/ContainerWithSideBar';
 import { profileAtom } from '@/state/profile';
 import { API_URL, get } from '@/utils/api';
+import { isNotFoundError } from '@/utils/error';
 import { useAPIGet } from '@/utils/fetcher';
 import { parseMarkdownMeta } from '@/utils/markdownParser';
 import { useAtomValue } from 'jotai';
@@ -35,17 +37,21 @@ function ArticleDetailPage() {
   const {
     data: article,
     isLoading,
+    error,
     mutate,
     isValidating,
-  } = useAPIGet<any>(articleid || '', () => get('/articles/' + articleid).then((res) => res.data), {
-    onError: (err: any) => {
-      const hasResponse = err?.response !== undefined;
-      const status = err?.response?.status;
-      if (!hasResponse || (status && status >= 400)) {
-        navigate('/404');
-      }
-    },
-  });
+  } = useAPIGet<any>(
+    articleid ? `/articles/${articleid}` : null,
+    () => get('/articles/' + articleid).then((res) => res.data),
+    {
+      revalidateOnFocus: false,
+      onError: (err: unknown) => {
+        if (isNotFoundError(err)) {
+          navigate('/404', { replace: true });
+        }
+      },
+    }
+  );
 
   const refreshData = () => {
     if (isLoading || isValidating) {
@@ -64,6 +70,28 @@ function ArticleDetailPage() {
 
   // 判断是否为作者
   const isAuthor = profile && article?.author && profile.username === article.author.username;
+
+  const hasValidArticle = Boolean(
+    article && typeof article === 'object' && article.id && typeof article.content === 'string'
+  );
+  const hasLoadFailure = Boolean(
+    (error && !hasValidArticle) || (!isLoading && !error && !hasValidArticle)
+  );
+
+  if (hasLoadFailure) {
+    if (isNotFoundError(error)) {
+      return null;
+    }
+
+    return (
+      <PageRequestError
+        error={error}
+        onRetry={() => {
+          void mutate();
+        }}
+      />
+    );
+  }
 
   const SideBar = () =>
     isLoading ? (

--- a/web/src/pages/error/index.tsx
+++ b/web/src/pages/error/index.tsx
@@ -1,0 +1,42 @@
+import { Button } from '@/components/ui/button';
+import NotFoundPage from '@/pages/404';
+import { getErrorMessage, getHttpStatus } from '@/utils/error';
+import { useTranslation } from 'react-i18next';
+import { isRouteErrorResponse, useNavigate, useRouteError } from 'react-router-dom';
+
+export default function RouteErrorPage() {
+  const { t } = useTranslation('translation', { keyPrefix: 'pages.error' });
+  const navigate = useNavigate();
+  const error = useRouteError();
+  const status = getHttpStatus(error) ?? 500;
+  const message = getErrorMessage(error);
+
+  if (isRouteErrorResponse(error) && error.status === 404) {
+    return <NotFoundPage />;
+  }
+
+  return (
+    <main className="bg-background flex h-dvh items-center justify-center px-6">
+      <div className="flex max-w-lg flex-col gap-2">
+        <p className="text-primary font-mono text-[100px] font-semibold lg:text-[200px]">
+          {status}
+        </p>
+        <h1 className="text-primary/90 text-base font-bold tracking-tight lg:text-2xl">
+          {t('pageError')}
+        </h1>
+        <p className="text-muted-foreground text-xs font-light">{t('pageErrorDesc')}</p>
+        {message && (
+          <div className="bg-muted text-muted-foreground mt-2 max-w-lg rounded-md border px-3 py-2 font-mono text-xs break-words">
+            {message}
+          </div>
+        )}
+        <div className="mt-4 flex gap-2">
+          <Button variant="outline" onClick={() => window.location.reload()}>
+            {t('retry')}
+          </Button>
+          <Button onClick={() => navigate('/')}>{t('goHome')}</Button>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/web/src/pages/rote/[roteid].tsx
+++ b/web/src/pages/rote/[roteid].tsx
@@ -2,6 +2,7 @@ import { VerifiedIcon } from '@/components/icons/Verified';
 import { RelatedNotesBlock } from '@/components/ai/RelatedNotesBlock';
 import NavBar from '@/components/layout/navBar';
 import LoadingPlaceholder from '@/components/others/LoadingPlaceholder';
+import PageRequestError from '@/components/others/PageRequestError';
 import UserAvatar from '@/components/others/UserAvatar';
 import RoteItem from '@/components/rote/roteItem';
 import ContainerWithSideBar from '@/layout/ContainerWithSideBar';
@@ -10,6 +11,7 @@ import { profileAtom } from '@/state/profile';
 
 import type { Rote } from '@/types/main';
 import { API_URL, get } from '@/utils/api';
+import { isNotFoundError } from '@/utils/error';
 import { useAPIGet } from '@/utils/fetcher';
 import { useAtomValue } from 'jotai';
 import { Navigation, RefreshCw, Rss } from 'lucide-react';
@@ -30,22 +32,17 @@ function SingleRotePage() {
     error,
     mutate,
     isValidating,
-  } = useAPIGet<Rote>(roteid || '', () => get('/notes/' + roteid).then((res) => res.data), {
-    onError: (err: any) => {
-      // 捕获所有错误情况，包括：
-      // 1. 网络错误（后端挂掉、连接超时等）- 没有 response
-      // 2. HTTP 错误状态码（404, 500, 502, 503 等）
-      // 3. 业务错误（返回的数据格式不正确）
-      const hasResponse = err?.response !== undefined;
-      const status = err?.response?.status;
-
-      // 如果是网络错误（没有 response）或任何错误状态码（>= 400），都跳转404
-      // 这包括：后端挂掉、连接超时、404、500、502、503 等所有错误情况
-      if (!hasResponse || (status && status >= 400)) {
-        navigate('/404');
-      }
-    },
-  });
+  } = useAPIGet<Rote>(
+    roteid ? `/notes/${roteid}` : null,
+    () => get('/notes/' + roteid).then((res) => res.data),
+    {
+      onError: (err: unknown) => {
+        if (isNotFoundError(err)) {
+          navigate('/404', { replace: true });
+        }
+      },
+    }
+  );
 
   const refreshData = () => {
     if (isLoading || isValidating) {
@@ -60,29 +57,34 @@ function SingleRotePage() {
     }
   }, [roteid, navigate]);
 
-  // 验证返回的数据是否有效
-  // 如果数据加载完成但没有有效的笔记信息，也跳转404
-  useEffect(() => {
-    // 只有在加载完成且没有错误时才验证数据
-    // 如果 error 存在，onError 已经处理了跳转，这里不需要再处理
-    if (!isLoading && !error) {
-      // 验证笔记信息是否有效：至少需要有 id、content 和 author
-      // 如果返回的数据不是预期的笔记信息格式，也跳转404
-      if (
-        !rote ||
-        typeof rote !== 'object' ||
-        !rote.id ||
-        !rote.content ||
-        !rote.author ||
-        !rote.author.username
-      ) {
-        navigate('/404');
-      }
-    }
-  }, [isLoading, error, rote, navigate]);
-
   if (!roteid) {
     return null;
+  }
+
+  const hasValidRote = Boolean(
+    rote &&
+    typeof rote === 'object' &&
+    rote.id &&
+    typeof rote.content === 'string' &&
+    rote.author?.username
+  );
+  const hasLoadFailure = Boolean(
+    (error && !hasValidRote) || (!isLoading && !error && !hasValidRote)
+  );
+
+  if (hasLoadFailure) {
+    if (isNotFoundError(error)) {
+      return null;
+    }
+
+    return (
+      <PageRequestError
+        error={error}
+        onRetry={() => {
+          void mutate();
+        }}
+      />
+    );
   }
 
   const isOwner = Boolean(profile?.username && rote?.author?.username === profile.username);

--- a/web/src/pages/user/[username].tsx
+++ b/web/src/pages/user/[username].tsx
@@ -3,18 +3,19 @@ import { VerifiedIcon } from '@/components/icons/Verified';
 import UserSidebarLinks from '@/components/common/UserSidebarLinks';
 import NavBar from '@/components/layout/navBar';
 import LoadingPlaceholder from '@/components/others/LoadingPlaceholder';
+import PageRequestError from '@/components/others/PageRequestError';
 import UserAvatar from '@/components/others/UserAvatar';
 import RoteList from '@/components/rote/roteList';
 import ContainerWithSideBar from '@/layout/ContainerWithSideBar';
 import type { ApiGetRotesParams, Profile, Rotes } from '@/types/main';
 import { API_URL, get } from '@/utils/api';
+import { isNotFoundError } from '@/utils/error';
 import { useAPIGet, useAPIInfinite } from '@/utils/fetcher';
 import { getRotesV2 } from '@/utils/roteApi';
 import { Helmet } from '@dr.pogodin/react-helmet';
 import Linkify from 'linkify-react';
 import { Globe2, RefreshCw, Stars } from 'lucide-react';
 import moment from 'moment';
-import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 
@@ -26,36 +27,25 @@ function UserPage() {
     data: userInfo,
     isLoading,
     error,
-  } = useAPIGet<Profile>(username, () => get('/users/' + username).then((res) => res.data), {
-    onError: (err: any) => {
-      // 捕获所有错误情况，包括：
-      // 1. 网络错误（后端挂掉、连接超时等）- 没有 response
-      // 2. HTTP 错误状态码（404, 500, 502, 503 等）
-      // 3. 业务错误（返回的数据格式不正确）
-      const hasResponse = err?.response !== undefined;
-      const status = err?.response?.status;
-
-      // 如果是网络错误（没有 response）或任何错误状态码（>= 400），都跳转404
-      // 这包括：后端挂掉、连接超时、404、500、502、503 等所有错误情况
-      if (!hasResponse || (status && status >= 400)) {
-        navigate('/404');
-      }
-    },
-  });
-
-  // 验证返回的数据是否有效
-  // 如果数据加载完成但没有有效的用户信息，也跳转404
-  useEffect(() => {
-    // 只有在加载完成且没有错误时才验证数据
-    // 如果 error 存在，onError 已经处理了跳转，这里不需要再处理
-    if (!isLoading && !error) {
-      // 验证用户信息是否有效：至少需要有 id 和 username
-      // 如果返回的数据不是预期的用户信息格式，也跳转404
-      if (!userInfo || typeof userInfo !== 'object' || !userInfo.id || !userInfo.username) {
-        navigate('/404');
-      }
+    mutate: mutateUser,
+  } = useAPIGet<Profile>(
+    username ? `/users/${username}` : null,
+    () => get('/users/' + username).then((res) => res.data),
+    {
+      onError: (err: unknown) => {
+        if (isNotFoundError(err)) {
+          navigate('/404', { replace: true });
+        }
+      },
     }
-  }, [isLoading, error, userInfo, navigate]);
+  );
+
+  const hasValidUser = Boolean(
+    userInfo && typeof userInfo === 'object' && userInfo.id && userInfo.username
+  );
+  const hasLoadFailure = Boolean(
+    (error && !hasValidUser) || (!isLoading && !error && !hasValidUser)
+  );
 
   const getPropsUserPublic = (
     pageIndex: number,
@@ -87,9 +77,19 @@ function UserPage() {
     mutate();
   };
 
-  // 如果数据无效，不渲染内容（useEffect 会处理跳转）
-  if (!isLoading && (!userInfo || !userInfo.id || !userInfo.username)) {
-    return null;
+  if (hasLoadFailure) {
+    if (isNotFoundError(error)) {
+      return null;
+    }
+
+    return (
+      <PageRequestError
+        error={error}
+        onRetry={() => {
+          void mutateUser();
+        }}
+      />
+    );
   }
 
   return isLoading ? (

--- a/web/src/route/main.tsx
+++ b/web/src/route/main.tsx
@@ -5,7 +5,7 @@ import { useAuthState } from '@/state/profile';
 import { createBrowserRouter, Navigate, Outlet, RouterProvider } from 'react-router-dom';
 import { ProtectedRoute } from './protectedRoute';
 
-import ErrorPage from '@/pages/404';
+import NotFoundPage from '@/pages/404';
 import AdminDashboard from '@/pages/admin';
 import AiMemoryPage from '@/pages/ai';
 import PrivacyPolicyPage from '@/pages/app/privacy';
@@ -15,6 +15,7 @@ import ArticleDetailPage from '@/pages/article/[articleid]';
 import ArticleEditPage from '@/pages/article/edit';
 import SelfhostedGuidePage from '@/pages/doc/selfhosted';
 import ExperimentPage from '@/pages/experiment';
+import RouteErrorPage from '@/pages/error';
 import ExplorePage from '@/pages/explore';
 import MineFilter from '@/pages/filter';
 import HomePage from '@/pages/home';
@@ -63,7 +64,7 @@ export default function GlobalRouterProvider() {
   const router = createBrowserRouter([
     {
       element: <RootLayout />,
-      errorElement: <ErrorPage />,
+      errorElement: <RouteErrorPage />,
       children: [
         {
           path: 'landing',
@@ -75,7 +76,7 @@ export default function GlobalRouterProvider() {
         },
         {
           path: '404',
-          element: <ErrorPage />,
+          element: <NotFoundPage />,
         },
         {
           path: 'setup',
@@ -118,7 +119,7 @@ export default function GlobalRouterProvider() {
                   <HomePage />
                 </ProtectedRoute>
               ),
-              errorElement: <ErrorPage />,
+              errorElement: <RouteErrorPage />,
             },
             {
               path: 'filter',
@@ -127,7 +128,7 @@ export default function GlobalRouterProvider() {
                   <MineFilter />
                 </ProtectedRoute>
               ),
-              errorElement: <ErrorPage />,
+              errorElement: <RouteErrorPage />,
             },
             {
               path: 'ai',
@@ -136,7 +137,7 @@ export default function GlobalRouterProvider() {
                   <AiMemoryPage />
                 </ProtectedRoute>
               ),
-              errorElement: <ErrorPage />,
+              errorElement: <RouteErrorPage />,
             },
             {
               path: 'profile',
@@ -145,7 +146,7 @@ export default function GlobalRouterProvider() {
                   <ProfilePage />
                 </ProtectedRoute>
               ),
-              errorElement: <ErrorPage />,
+              errorElement: <RouteErrorPage />,
             },
             {
               path: 'profile/setting',
@@ -154,16 +155,16 @@ export default function GlobalRouterProvider() {
                   <SettingsPage />
                 </ProtectedRoute>
               ),
-              errorElement: <ErrorPage />,
+              errorElement: <RouteErrorPage />,
             },
             {
               path: 'explore',
               element: <ExplorePage />,
-              errorElement: <ErrorPage />,
+              errorElement: <RouteErrorPage />,
             },
             {
               path: 'admin',
-              errorElement: <ErrorPage />,
+              errorElement: <RouteErrorPage />,
               element: (
                 <ProtectedRoute>
                   <AdminDashboard />
@@ -172,7 +173,7 @@ export default function GlobalRouterProvider() {
             },
             {
               path: 'rote',
-              errorElement: <ErrorPage />,
+              errorElement: <RouteErrorPage />,
               children: [
                 {
                   path: ':roteid',
@@ -182,7 +183,7 @@ export default function GlobalRouterProvider() {
             },
             {
               path: 'article',
-              errorElement: <ErrorPage />,
+              errorElement: <RouteErrorPage />,
               children: [
                 {
                   path: 'new',
@@ -208,7 +209,7 @@ export default function GlobalRouterProvider() {
             },
             {
               path: 'archived',
-              errorElement: <ErrorPage />,
+              errorElement: <RouteErrorPage />,
               element: (
                 <ProtectedRoute>
                   <ArchivedPage />
@@ -217,7 +218,7 @@ export default function GlobalRouterProvider() {
             },
             {
               path: 'experiment',
-              errorElement: <ErrorPage />,
+              errorElement: <RouteErrorPage />,
               element: (
                 <ProtectedRoute>
                   <ExperimentPage />
@@ -227,13 +228,13 @@ export default function GlobalRouterProvider() {
             {
               path: ':username',
               element: <UserPage />,
-              errorElement: <ErrorPage />,
+              errorElement: <RouteErrorPage />,
             },
           ],
         },
         {
           path: '*',
-          element: <ErrorPage />,
+          element: <NotFoundPage />,
         },
       ],
     },

--- a/web/src/utils/error.ts
+++ b/web/src/utils/error.ts
@@ -1,0 +1,68 @@
+const MAX_ERROR_MESSAGE_LENGTH = 500;
+
+function normalizeErrorMessage(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const message = value.trim();
+  if (!message) {
+    return undefined;
+  }
+
+  return message.slice(0, MAX_ERROR_MESSAGE_LENGTH);
+}
+
+export function getHttpStatus(error: unknown): number | undefined {
+  if (!error || typeof error !== 'object') {
+    return undefined;
+  }
+
+  if ('status' in error && typeof error.status === 'number') {
+    return error.status;
+  }
+
+  const response = 'response' in error ? error.response : undefined;
+  if (!response || typeof response !== 'object' || !('status' in response)) {
+    return undefined;
+  }
+
+  return typeof response.status === 'number' ? response.status : undefined;
+}
+
+export function getErrorMessage(error: unknown): string | undefined {
+  if (!error || typeof error !== 'object') {
+    return normalizeErrorMessage(error);
+  }
+
+  const response = 'response' in error ? error.response : undefined;
+  const responseData =
+    response && typeof response === 'object' && 'data' in response ? response.data : undefined;
+  const responseMessage =
+    responseData && typeof responseData === 'object' && 'message' in responseData
+      ? responseData.message
+      : responseData;
+
+  const routeData = 'data' in error ? error.data : undefined;
+  const routeMessage =
+    routeData && typeof routeData === 'object' && 'message' in routeData
+      ? routeData.message
+      : routeData;
+
+  const message =
+    normalizeErrorMessage(responseMessage) ??
+    normalizeErrorMessage(routeMessage) ??
+    ('message' in error ? normalizeErrorMessage(error.message) : undefined) ??
+    ('statusText' in error ? normalizeErrorMessage(error.statusText) : undefined);
+
+  const code = 'code' in error ? normalizeErrorMessage(error.code) : undefined;
+  if (message && code && !message.includes(code)) {
+    return `${message} (${code})`;
+  }
+
+  return message ?? code;
+}
+
+export function isNotFoundError(error: unknown): boolean {
+  return getHttpStatus(error) === 404;
+}


### PR DESCRIPTION
## Description

Fix frontend error handling so runtime and request failures are no longer presented as missing pages.

- Separate route-level runtime errors from the 404 page
- Only redirect detail pages to 404 for confirmed HTTP 404 responses
- Prevent article detail pages from revalidating on window focus and unexpectedly leaving the page
- Show retryable request error states with safe, specific error details such as HTTP status, backend messages, and network error codes
- Apply consistent handling to article, note, and user detail pages

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Code passes ESLint checks (`cd web && bun run lint`)
- [x] Frontend builds successfully (`cd web && bun run build`)
- [x] Functionality works correctly
- [x] No existing functionality is broken
- [x] Browser verified that a failed article request stays on the article URL, displays `Network Error (ERR_NETWORK)`, and remains retryable
- [x] Browser verified that the explicit `/404` route still displays the dedicated 404 page

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

The production build still reports the repository's existing large-chunk and mixed dynamic/static import warnings; this change does not introduce them.