### PR TITLE
Refresh expired access tokens before requests

### DIFF
--- a/web/src/utils/__tests__/api.test.ts
+++ b/web/src/utils/__tests__/api.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { authService } from '../auth';
+
+type RequestConfig = {
+  baseURL?: string;
+  headers: Record<string, string>;
+};
+
+type RequestInterceptor = (config: RequestConfig) => Promise<RequestConfig>;
+
+const axiosMocks = vi.hoisted(() => {
+  const state: { requestInterceptor?: RequestInterceptor } = {};
+  const mockPost = vi.fn();
+  const mockApi = {
+    interceptors: {
+      request: {
+        use: vi.fn((interceptor: RequestInterceptor) => {
+          state.requestInterceptor = interceptor;
+        }),
+      },
+      response: {
+        use: vi.fn(),
+      },
+    },
+    request: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  };
+
+  return {
+    state,
+    mockPost,
+    mockApi,
+  };
+});
+
+vi.mock('axios', () => ({
+  default: {
+    create: vi.fn(() => axiosMocks.mockApi),
+    post: axiosMocks.mockPost,
+  },
+}));
+
+await import('../api');
+
+function createToken(expiresAt: number): string {
+  return `header.${btoa(JSON.stringify({ exp: expiresAt }))}.signature`;
+}
+
+describe('API authentication request interceptor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('refreshes an expired access token before sending an optional-auth request', async () => {
+    const expiredAccessToken = createToken(Math.floor(Date.now() / 1000) - 60);
+    const validRefreshToken = createToken(Math.floor(Date.now() / 1000) + 3600);
+    const newAccessToken = createToken(Math.floor(Date.now() / 1000) + 900);
+    const newRefreshToken = createToken(Math.floor(Date.now() / 1000) + 7200);
+
+    authService.setTokens(expiredAccessToken, validRefreshToken);
+    axiosMocks.mockPost.mockResolvedValue({
+      data: {
+        data: {
+          accessToken: newAccessToken,
+          refreshToken: newRefreshToken,
+        },
+      },
+    });
+
+    const config = await axiosMocks.state.requestInterceptor?.({ headers: {} });
+
+    expect(axiosMocks.mockPost).toHaveBeenCalledTimes(1);
+    expect(config?.headers.Authorization).toBe(`Bearer ${newAccessToken}`);
+    expect(authService.getAccessToken()).toBe(newAccessToken);
+  });
+
+  it('shares one token refresh across concurrent requests', async () => {
+    const expiredAccessToken = createToken(Math.floor(Date.now() / 1000) - 60);
+    const validRefreshToken = createToken(Math.floor(Date.now() / 1000) + 3600);
+    const newAccessToken = createToken(Math.floor(Date.now() / 1000) + 900);
+    const newRefreshToken = createToken(Math.floor(Date.now() / 1000) + 7200);
+
+    authService.setTokens(expiredAccessToken, validRefreshToken);
+    axiosMocks.mockPost.mockResolvedValue({
+      data: {
+        data: {
+          accessToken: newAccessToken,
+          refreshToken: newRefreshToken,
+        },
+      },
+    });
+
+    const configs = await Promise.all([
+      axiosMocks.state.requestInterceptor?.({ headers: {} }),
+      axiosMocks.state.requestInterceptor?.({ headers: {} }),
+    ]);
+
+    expect(axiosMocks.mockPost).toHaveBeenCalledTimes(1);
+    expect(
+      configs.every((config) => config?.headers.Authorization === `Bearer ${newAccessToken}`)
+    ).toBe(true);
+  });
+});

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -71,19 +71,52 @@ const api = axios.create({
   withCredentials: true,
 });
 
+let refreshPromise: Promise<string> | null = null;
+
+function clearExpiredSession() {
+  authService.clearTokens();
+  if (localStorage.getItem('profile')) {
+    localStorage.removeItem('profile');
+    window.location.href = '/login';
+  }
+}
+
+function refreshAccessTokenOnce(): Promise<string> {
+  if (!refreshPromise) {
+    refreshPromise = refreshAccessToken().finally(() => {
+      refreshPromise = null;
+    });
+  }
+
+  return refreshPromise;
+}
+
 // 请求拦截器
 api.interceptors.request.use(
-  (config) => {
+  async (config) => {
     // 动态设置 baseURL，确保每次请求都使用最新的配置
     // 这样可以避免在配置注入前就使用旧的 baseURL
     if (!config.baseURL) {
       config.baseURL = getApiUrl();
     }
 
-    // 添加 JWT token
-    const token = authService.getAccessToken();
-    if (token && !authService.isTokenExpired(token)) {
-      config.headers.Authorization = `Bearer ${token}`;
+    let accessToken = authService.getAccessToken();
+
+    // 可选鉴权接口不会为游客返回 401，因此 access token 过期时必须在请求前主动刷新。
+    if (
+      (!accessToken || authService.isTokenExpired(accessToken)) &&
+      authService.hasValidRefreshToken()
+    ) {
+      try {
+        accessToken = await refreshAccessTokenOnce();
+      } catch (error) {
+        clearExpiredSession();
+        return Promise.reject(error);
+      }
+    }
+
+    if (accessToken && !authService.isTokenExpired(accessToken)) {
+      config.headers.Authorization = `Bearer ${accessToken}`;
     }
 
     return config;
@@ -128,42 +161,15 @@ api.interceptors.response.use(
     if (error.response && error.response.status === 401) {
       // 如果是JWT认证失败，尝试刷新token
       if (authService.hasValidRefreshToken() && !originalRequest._retry) {
-        if (isRefreshing) {
-          // 如果正在刷新，等待刷新完成，并自动重试原请求
-          return new Promise((resolve, reject) => {
-            failedQueue.push({ resolve, reject });
-          })
-            .then((token) => {
-              // 刷新完成后，自动为原请求补充新token并重试
-              if (token) {
-                originalRequest.headers.Authorization = `Bearer ${token}`;
-              }
-              return api(originalRequest);
-            })
-            .catch((err) => Promise.reject(err));
-        }
-
         originalRequest._retry = true;
-        isRefreshing = true;
 
         try {
-          // 刷新token
-          const newToken = await refreshAccessToken();
-          processQueue(null, newToken);
-          // 刷新成功后，自动为原请求补充新token并重试
+          const newToken = await refreshAccessTokenOnce();
           originalRequest.headers.Authorization = `Bearer ${newToken}`;
           return api(originalRequest);
         } catch (refreshError) {
-          processQueue(refreshError);
-          // 刷新失败，清除所有token并跳转到登录页
-          authService.clearTokens();
-          if (localStorage.getItem('profile')) {
-            localStorage.removeItem('profile');
-          }
-          window.location.href = '/login';
+          clearExpiredSession();
           return Promise.reject(refreshError);
-        } finally {
-          isRefreshing = false;
         }
       } else {
         // 没有有效的refresh token或者是旧的session认证
@@ -176,25 +182,6 @@ api.interceptors.response.use(
     return Promise.reject(error);
   }
 );
-
-// Token刷新功能
-let isRefreshing = false;
-let failedQueue: Array<{
-  resolve: (_value: any) => void;
-  reject: (_error: any) => void;
-}> = [];
-
-const processQueue = (error: any, token: string | null = null) => {
-  failedQueue.forEach(({ resolve, reject }) => {
-    if (error) {
-      reject(error);
-    } else {
-      resolve(token);
-    }
-  });
-
-  failedQueue = [];
-};
 
 export const refreshAccessToken = async (): Promise<string> => {
   const refreshTokenValue = authService.getRefreshToken();


### PR DESCRIPTION
## Description

Fix authenticated optional-route requests becoming anonymous after the access token expires.

The API request interceptor previously omitted expired access tokens and only refreshed tokens after a `401` response. Optional-auth routes treat requests without a token as guests, so private article requests returned `403 Access denied` instead of triggering token refresh.

- Refresh an expired or missing access token before sending a request when a valid refresh token exists
- Share one refresh operation across concurrent requests
- Continue using the same shared refresh path for `401` retry handling
- Add regression tests for optional-auth requests and concurrent refreshes

## Testing

- [x] `cd web && bun run test` (21 tests passed)
- [x] `cd web && bun run lint`
- [x] `cd web && bun run build`

## Notes

The production build continues to report the repository's existing bundle-size and mixed dynamic/static import warnings.