### PR TITLE
Limit Rote deploy jobs by changed paths

### DIFF
--- a/.github/workflows/develop-deploy.yml
+++ b/.github/workflows/develop-deploy.yml
@@ -9,7 +9,48 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed app paths
+        id: filter
+        shell: bash
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          CURRENT_SHA: ${{ github.sha }}
+        run: |
+          if [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ] || ! git cat-file -e "$BEFORE_SHA^{commit}" 2>/dev/null; then
+            BASE_SHA="$(git rev-list --max-parents=0 "$CURRENT_SHA")"
+          else
+            BASE_SHA="$BEFORE_SHA"
+          fi
+
+          git diff --name-only "$BASE_SHA" "$CURRENT_SHA" > changed-files.txt
+
+          if grep -Eq '^(server/|\.github/workflows/develop-deploy\.yml$)' changed-files.txt; then
+            echo "backend=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "backend=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if grep -Eq '^(web/|\.github/workflows/develop-deploy\.yml$)' changed-files.txt; then
+            echo "frontend=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "frontend=false" >> "$GITHUB_OUTPUT"
+          fi
+
   build-backend:
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.backend == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -40,6 +81,8 @@ jobs:
             ${{ secrets.DOCKERHUB_USERNAME }}/rote-backend:develop-${{ github.sha }}
 
   build-frontend:
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.frontend == 'true' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -11,7 +11,49 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  detect-changes:
+    if: ${{ github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed app paths
+        id: filter
+        shell: bash
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          CURRENT_SHA: ${{ github.sha }}
+        run: |
+          if [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ] || ! git cat-file -e "$BEFORE_SHA^{commit}" 2>/dev/null; then
+            BASE_SHA="$(git rev-list --max-parents=0 "$CURRENT_SHA")"
+          else
+            BASE_SHA="$BEFORE_SHA"
+          fi
+
+          git diff --name-only "$BASE_SHA" "$CURRENT_SHA" > changed-files.txt
+
+          if grep -Eq '^(server/|\.github/workflows/release-deploy\.yml$)' changed-files.txt; then
+            echo "backend=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "backend=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if grep -Eq '^(web/|\.github/workflows/release-deploy\.yml$)' changed-files.txt; then
+            echo "frontend=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "frontend=false" >> "$GITHUB_OUTPUT"
+          fi
+
   build-backend:
+    needs: detect-changes
+    if: ${{ always() && (github.event_name == 'release' || needs.detect-changes.outputs.backend == 'true') }}
     runs-on: ubuntu-latest
 
     steps:
@@ -42,6 +84,8 @@ jobs:
             ${{ secrets.DOCKERHUB_USERNAME }}/rote-backend:${{ github.event.release.tag_name || github.ref_name || 'main' }}
 
   build-frontend:
+    needs: detect-changes
+    if: ${{ always() && (github.event_name == 'release' || needs.detect-changes.outputs.frontend == 'true') }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary\n- Limit develop deploy backend/frontend jobs to their changed app paths\n- Limit main push release deploy jobs by changed app paths\n- Keep release published events building both images\n\n## Verification\n- Ruby YAML parse passed for both deploy workflows\n- Dokploy Rote watchPaths set to web/** and server/**