### PR TITLE
Add Live Photo attachment support

### DIFF
--- a/server/attachments/uploadKeys.ts
+++ b/server/attachments/uploadKeys.ts
@@ -28,3 +28,6 @@ export const extractCompressedUuid = (key?: string) =>
 
 export const extractPosterUuid = (key?: string) =>
   key?.match(/\/posters\/([^/.]+)\.[^.]+$/)?.[1] ?? null;
+
+export const extractPairedVideoUuid = (key?: string) =>
+  key?.match(/\/paired-videos\/([^/.]+)\.[^.]+$/)?.[1] ?? null;

--- a/server/route/v2/attachment.ts
+++ b/server/route/v2/attachment.ts
@@ -3,6 +3,7 @@ import { Hono } from 'hono';
 import {
   extractCompressedUuid,
   extractOriginalUploadUuid,
+  extractPairedVideoUuid,
   extractPosterUuid,
   getUploadExtension,
 } from '../../attachments/uploadKeys';
@@ -26,6 +27,7 @@ import {
   MAX_FILES,
   getMediaKindFromContentType,
   inferAttachmentMediaKind,
+  isImageContentType,
   isVideoContentType,
   mergeUniqueRoteAttachmentDetails,
   validateContentType,
@@ -39,6 +41,33 @@ import { AttachmentPresignZod } from '../../utils/zod';
 // 附件相关路由
 const attachmentsRouter = new Hono<{ Variables: HonoVariables }>();
 
+type PresignFileInput = {
+  filename?: string;
+  contentType?: string;
+  size?: number;
+  mediaKind?: 'image' | 'video' | 'livePhoto';
+  pairedVideo?: {
+    filename?: string;
+    contentType?: string;
+    size?: number;
+  };
+};
+
+type FinalizeAttachmentInput = {
+  uuid: string;
+  originalKey: string;
+  compressedKey?: string;
+  posterKey?: string;
+  pairedVideoKey?: string;
+  pairedVideoSize?: number;
+  pairedVideoMimetype?: string;
+  pairedVideoFilename?: string;
+  size?: number;
+  mimetype?: string;
+  mediaKind?: 'image' | 'video' | 'livePhoto';
+  hash?: string;
+  noteId?: string;
+};
 // 删除单个附件
 attachmentsRouter.delete('/:id', authenticateJWT, async (c: HonoContext) => {
   const user = c.get('user') as User;
@@ -120,7 +149,7 @@ attachmentsRouter.post(
     }
     const body = await c.req.json();
     const { files } = body as {
-      files: Array<{ filename?: string; contentType?: string; size?: number }>;
+      files: PresignFileInput[];
     };
 
     // 验证输入长度和格式
@@ -131,7 +160,9 @@ attachmentsRouter.post(
       throw new Error(`Maximum ${MAX_FILES} files allowed`);
     }
 
-    const hasVideo = files.some((f) => isVideoContentType(f.contentType));
+    const hasVideo = files.some(
+      (f) => isVideoContentType(f.contentType) || f.mediaKind === 'livePhoto'
+    );
     if (hasVideo && !uploadPolicy.canUploadVideo) {
       return c.json(createResponse(null, 'capability_required:attachment.video.upload'), 403);
     }
@@ -139,6 +170,27 @@ attachmentsRouter.post(
     // 严格验证每个文件的内容类型和大小
     for (const f of files) {
       validateContentType(f.contentType);
+
+      if (f.mediaKind === 'livePhoto') {
+        if (!isImageContentType(f.contentType)) {
+          throw new Error('Live Photo original resource must be an image');
+        }
+        if (!f.pairedVideo) {
+          throw new Error('Live Photo paired video is required');
+        }
+        validateContentType(f.pairedVideo.contentType);
+        if (!isVideoContentType(f.pairedVideo.contentType)) {
+          throw new Error('Live Photo paired video resource must be a video');
+        }
+        validateFileSize(f.size, f.contentType, uploadPolicy.maxVideoUploadSizeMB);
+        validateFileSize(
+          f.pairedVideo.size,
+          f.pairedVideo.contentType,
+          uploadPolicy.maxVideoUploadSizeMB
+        );
+        continue;
+      }
+
       validateFileSize(f.size, f.contentType, uploadPolicy.maxVideoUploadSizeMB);
     }
 
@@ -147,7 +199,8 @@ attachmentsRouter.post(
         const uuid = randomUUID();
         const ext = getUploadExtension(f.filename, f.contentType);
         const originalKey = `users/${user.id}/uploads/${uuid}${ext}`;
-        const mediaKind = getMediaKindFromContentType(f.contentType);
+        const mediaKind =
+          f.mediaKind === 'livePhoto' ? 'livePhoto' : getMediaKindFromContentType(f.contentType);
         const original = await presignPutUrl(originalKey, f.contentType || undefined, 15 * 60);
 
         const result: Record<string, any> = {
@@ -160,7 +213,7 @@ attachmentsRouter.post(
           },
         };
 
-        if (mediaKind === 'image') {
+        if (mediaKind === 'image' || mediaKind === 'livePhoto') {
           const compressedKey = `users/${user.id}/compressed/${uuid}.webp`;
           const compressed = await presignPutUrl(compressedKey, 'image/webp', 15 * 60);
           result.compressed = {
@@ -168,6 +221,26 @@ attachmentsRouter.post(
             putUrl: compressed.putUrl,
             url: compressed.url,
             contentType: 'image/webp',
+          };
+        }
+
+        if (mediaKind === 'livePhoto') {
+          const pairedVideo = f.pairedVideo;
+          if (!pairedVideo) {
+            throw new Error('Live Photo paired video is required');
+          }
+          const pairedVideoExt = getUploadExtension(pairedVideo.filename, pairedVideo.contentType);
+          const pairedVideoKey = `users/${user.id}/paired-videos/${uuid}${pairedVideoExt}`;
+          const pairedVideoUpload = await presignPutUrl(
+            pairedVideoKey,
+            pairedVideo.contentType || undefined,
+            15 * 60
+          );
+          result.pairedVideo = {
+            key: pairedVideoKey,
+            putUrl: pairedVideoUpload.putUrl,
+            url: pairedVideoUpload.url,
+            contentType: pairedVideo.contentType,
           };
         }
 
@@ -203,16 +276,7 @@ attachmentsRouter.post(
     }
     const body = await c.req.json();
     const { attachments, noteId } = body as {
-      attachments: Array<{
-        uuid: string;
-        originalKey: string;
-        compressedKey?: string;
-        posterKey?: string;
-        size?: number;
-        mimetype?: string;
-        hash?: string;
-        noteId?: string;
-      }>;
+      attachments: FinalizeAttachmentInput[];
       noteId?: string;
     };
 
@@ -231,7 +295,8 @@ attachmentsRouter.post(
       (a) =>
         !a.originalKey?.startsWith(prefix) ||
         (a.compressedKey !== undefined && !a.compressedKey.startsWith(prefix)) ||
-        (a.posterKey !== undefined && !a.posterKey.startsWith(prefix))
+        (a.posterKey !== undefined && !a.posterKey.startsWith(prefix)) ||
+        (a.pairedVideoKey !== undefined && !a.pairedVideoKey.startsWith(prefix))
     );
     if (invalid) {
       throw new Error('Invalid object key');
@@ -243,16 +308,35 @@ attachmentsRouter.post(
         validateContentType(a.mimetype);
         validateFileSize(a.size, a.mimetype, uploadPolicy.maxVideoUploadSizeMB);
       }
+
+      if (a.mediaKind === 'livePhoto' || a.pairedVideoKey) {
+        if (!isImageContentType(a.mimetype)) {
+          throw new Error('Live Photo original resource must be an image');
+        }
+        validateContentType(a.pairedVideoMimetype);
+        if (!isVideoContentType(a.pairedVideoMimetype)) {
+          throw new Error('Live Photo paired video resource must be a video');
+        }
+        validateFileSize(
+          a.pairedVideoSize,
+          a.pairedVideoMimetype,
+          uploadPolicy.maxVideoUploadSizeMB
+        );
+      }
     }
 
     const hasVideo = attachments.some(
       (a) =>
         inferAttachmentMediaKind({
+          mediaKind: a.mediaKind,
           mimetype: a.mimetype,
           compressedKey: a.compressedKey,
           posterKey: a.posterKey,
+          pairedVideoKey: a.pairedVideoKey,
           key: a.originalKey,
-        }) === 'video'
+        }) === 'video' ||
+        a.mediaKind === 'livePhoto' ||
+        !!a.pairedVideoKey
     );
     if (hasVideo && !uploadPolicy.canUploadVideo) {
       return c.json(createResponse(null, 'capability_required:attachment.video.upload'), 403);
@@ -264,9 +348,11 @@ attachmentsRouter.post(
 
     for (const a of attachments) {
       const mediaKind = inferAttachmentMediaKind({
+        mediaKind: a.mediaKind,
         mimetype: a.mimetype,
         compressedKey: a.compressedKey,
         posterKey: a.posterKey,
+        pairedVideoKey: a.pairedVideoKey,
         key: a.originalKey,
       });
 
@@ -302,14 +388,17 @@ attachmentsRouter.post(
         continue;
       }
 
-      if (mediaKind === 'image' && normalizedAttachment.posterKey) {
+      if ((mediaKind === 'image' || mediaKind === 'livePhoto') && normalizedAttachment.posterKey) {
         validationErrors.push(
-          `Images cannot include posterKey: ${a.originalKey} (uuid: ${a.uuid})`
+          `Image-like attachments cannot include posterKey: ${a.originalKey} (uuid: ${a.uuid})`
         );
         normalizedAttachment.posterKey = undefined;
       }
 
-      if (mediaKind === 'image' && normalizedAttachment.compressedKey) {
+      if (
+        (mediaKind === 'image' || mediaKind === 'livePhoto') &&
+        normalizedAttachment.compressedKey
+      ) {
         const compressedExists = await checkObjectExists(normalizedAttachment.compressedKey);
         if (!compressedExists) {
           validationErrors.push(
@@ -331,6 +420,43 @@ attachmentsRouter.post(
             normalizedAttachment.compressedKey = undefined;
           }
         }
+      }
+
+      if (mediaKind === 'livePhoto') {
+        if (!normalizedAttachment.pairedVideoKey) {
+          validationErrors.push(
+            `Live Photo paired video missing: ${a.originalKey} (uuid: ${a.uuid})`
+          );
+          continue;
+        }
+
+        const pairedVideoExists = await checkObjectExists(normalizedAttachment.pairedVideoKey);
+        if (!pairedVideoExists) {
+          validationErrors.push(
+            `Live Photo paired video not found: ${normalizedAttachment.pairedVideoKey} (uuid: ${a.uuid})`
+          );
+          continue;
+        }
+
+        const pairedVideoUuid = extractPairedVideoUuid(normalizedAttachment.pairedVideoKey);
+        if (!pairedVideoUuid) {
+          validationErrors.push(
+            `Invalid paired video key format: originalKey=${a.originalKey}, pairedVideoKey=${normalizedAttachment.pairedVideoKey}`
+          );
+          continue;
+        }
+
+        if (originalUuid !== pairedVideoUuid) {
+          validationErrors.push(
+            `UUID mismatch: originalKey contains uuid '${originalUuid}', but pairedVideoKey contains uuid '${pairedVideoUuid}'`
+          );
+          continue;
+        }
+      } else if (normalizedAttachment.pairedVideoKey) {
+        validationErrors.push(
+          `Only Live Photo attachments can include pairedVideoKey: ${a.originalKey} (uuid: ${a.uuid})`
+        );
+        continue;
       }
 
       if (mediaKind === 'video' && normalizedAttachment.posterKey) {
@@ -395,12 +521,15 @@ attachmentsRouter.post(
           key: a.originalKey,
           mimetype: a.mimetype || null,
           mediaKind: inferAttachmentMediaKind({
+            mediaKind: a.mediaKind,
             mimetype: a.mimetype || null,
             compressedKey: a.compressedKey,
             posterKey: a.posterKey,
+            pairedVideoKey: a.pairedVideoKey,
           }),
           compressKey: a.compressedKey,
           posterKey: a.posterKey,
+          pairedVideoKey: a.pairedVideoKey,
         },
       }));
       validateRoteAttachmentDetails(
@@ -413,13 +542,19 @@ attachmentsRouter.post(
       const urlPrefix = storageConfig?.urlPrefix;
       const oUrl = `${urlPrefix}/${a.originalKey}`;
       const mediaKind = inferAttachmentMediaKind({
+        mediaKind: a.mediaKind,
         mimetype: a.mimetype || null,
         compressedKey: a.compressedKey,
         posterKey: a.posterKey,
+        pairedVideoKey: a.pairedVideoKey,
       });
       const cUrl =
-        mediaKind === 'image' && a.compressedKey ? `${urlPrefix}/${a.compressedKey}` : null;
+        (mediaKind === 'image' || mediaKind === 'livePhoto') && a.compressedKey
+          ? `${urlPrefix}/${a.compressedKey}`
+          : null;
       const pUrl = mediaKind === 'video' && a.posterKey ? `${urlPrefix}/${a.posterKey}` : null;
+      const pairedVideoUrl =
+        mediaKind === 'livePhoto' && a.pairedVideoKey ? `${urlPrefix}/${a.pairedVideoKey}` : null;
       const baseDetails: any = {
         size: a.size || 0,
         mimetype: a.mimetype || null,
@@ -429,6 +564,15 @@ attachmentsRouter.post(
       };
       if (a.compressedKey) baseDetails.compressKey = a.compressedKey;
       if (a.posterKey) baseDetails.posterKey = a.posterKey;
+      if (pairedVideoUrl && a.pairedVideoKey) {
+        baseDetails.pairedVideoKey = a.pairedVideoKey;
+        baseDetails.pairedVideoUrl = pairedVideoUrl;
+        baseDetails.pairedVideoMimetype = a.pairedVideoMimetype || null;
+        baseDetails.pairedVideoSize = a.pairedVideoSize || 0;
+        if (a.pairedVideoFilename) {
+          baseDetails.pairedVideoFilename = a.pairedVideoFilename;
+        }
+      }
       if (a.hash) baseDetails.hash = a.hash;
 
       return {

--- a/server/route/v2/openKeyRouter.ts
+++ b/server/route/v2/openKeyRouter.ts
@@ -8,6 +8,7 @@ import { Hono } from 'hono';
 import {
   extractCompressedUuid,
   extractOriginalUploadUuid,
+  extractPairedVideoUuid,
   extractPosterUuid,
   getUploadExtension,
 } from '../../attachments/uploadKeys';
@@ -57,6 +58,7 @@ import {
   MAX_FILES,
   getMediaKindFromContentType,
   inferAttachmentMediaKind,
+  isImageContentType,
   isVideoContentType,
   mergeUniqueRoteAttachmentDetails,
   validateContentType,
@@ -79,6 +81,33 @@ import {
 
 const router = new Hono<{ Variables: HonoVariables }>();
 
+type PresignFileInput = {
+  filename?: string;
+  contentType?: string;
+  size?: number;
+  mediaKind?: 'image' | 'video' | 'livePhoto';
+  pairedVideo?: {
+    filename?: string;
+    contentType?: string;
+    size?: number;
+  };
+};
+
+type FinalizeAttachmentInput = {
+  uuid: string;
+  originalKey: string;
+  compressedKey?: string;
+  posterKey?: string;
+  pairedVideoKey?: string;
+  pairedVideoSize?: number;
+  pairedVideoMimetype?: string;
+  pairedVideoFilename?: string;
+  size?: number;
+  mimetype?: string;
+  mediaKind?: 'image' | 'video' | 'livePhoto';
+  hash?: string;
+  noteId?: string;
+};
 function requireOpenKeyPerm(...perms: string[]) {
   return async (c: HonoContext, next: () => Promise<void>) => {
     const openKey = c.get('openKey')!;
@@ -980,7 +1009,7 @@ router.post(
     }
     const body = await c.req.json();
     const { files } = body as {
-      files: Array<{ filename?: string; contentType?: string; size?: number }>;
+      files: PresignFileInput[];
     };
 
     // Validate input using Zod
@@ -990,7 +1019,9 @@ router.post(
       throw new Error(`Maximum ${MAX_FILES} files allowed`);
     }
 
-    const hasVideo = files.some((f) => isVideoContentType(f.contentType));
+    const hasVideo = files.some(
+      (f) => isVideoContentType(f.contentType) || f.mediaKind === 'livePhoto'
+    );
     if (hasVideo && !openKey.permissions.includes('UPLOADVIDEO')) {
       return c.json(createResponse(null, 'openkey_permission_required:UPLOADVIDEO'), 403);
     }
@@ -1001,6 +1032,26 @@ router.post(
     // Strict validation
     for (const f of files) {
       validateContentType(f.contentType);
+      if (f.mediaKind === 'livePhoto') {
+        if (!isImageContentType(f.contentType)) {
+          throw new Error('Live Photo original resource must be an image');
+        }
+        if (!f.pairedVideo) {
+          throw new Error('Live Photo paired video is required');
+        }
+        validateContentType(f.pairedVideo.contentType);
+        if (!isVideoContentType(f.pairedVideo.contentType)) {
+          throw new Error('Live Photo paired video resource must be a video');
+        }
+        validateFileSize(f.size, f.contentType, uploadPolicy.maxVideoUploadSizeMB);
+        validateFileSize(
+          f.pairedVideo.size,
+          f.pairedVideo.contentType,
+          uploadPolicy.maxVideoUploadSizeMB
+        );
+        continue;
+      }
+
       validateFileSize(f.size, f.contentType, uploadPolicy.maxVideoUploadSizeMB);
     }
 
@@ -1009,7 +1060,8 @@ router.post(
         const uuid = randomUUID();
         const ext = getUploadExtension(f.filename, f.contentType);
         const originalKey = `users/${openKey.userid}/uploads/${uuid}${ext}`;
-        const mediaKind = getMediaKindFromContentType(f.contentType);
+        const mediaKind =
+          f.mediaKind === 'livePhoto' ? 'livePhoto' : getMediaKindFromContentType(f.contentType);
         const original = await presignPutUrl(originalKey, f.contentType || undefined, 15 * 60);
 
         const result: Record<string, any> = {
@@ -1022,7 +1074,7 @@ router.post(
           },
         };
 
-        if (mediaKind === 'image') {
+        if (mediaKind === 'image' || mediaKind === 'livePhoto') {
           const compressedKey = `users/${openKey.userid}/compressed/${uuid}.webp`;
           const compressed = await presignPutUrl(compressedKey, 'image/webp', 15 * 60);
           result.compressed = {
@@ -1030,6 +1082,26 @@ router.post(
             putUrl: compressed.putUrl,
             url: compressed.url,
             contentType: 'image/webp',
+          };
+        }
+
+        if (mediaKind === 'livePhoto') {
+          const pairedVideo = f.pairedVideo;
+          if (!pairedVideo) {
+            throw new Error('Live Photo paired video is required');
+          }
+          const pairedVideoExt = getUploadExtension(pairedVideo.filename, pairedVideo.contentType);
+          const pairedVideoKey = `users/${openKey.userid}/paired-videos/${uuid}${pairedVideoExt}`;
+          const pairedVideoUpload = await presignPutUrl(
+            pairedVideoKey,
+            pairedVideo.contentType || undefined,
+            15 * 60
+          );
+          result.pairedVideo = {
+            key: pairedVideoKey,
+            putUrl: pairedVideoUpload.putUrl,
+            url: pairedVideoUpload.url,
+            contentType: pairedVideo.contentType,
           };
         }
 
@@ -1066,16 +1138,7 @@ router.post(
     }
     const body = await c.req.json();
     const { attachments, noteId } = body as {
-      attachments: Array<{
-        uuid: string;
-        originalKey: string;
-        compressedKey?: string;
-        posterKey?: string;
-        size?: number;
-        mimetype?: string;
-        hash?: string;
-        noteId?: string;
-      }>;
+      attachments: FinalizeAttachmentInput[];
       noteId?: string;
     };
 
@@ -1093,7 +1156,8 @@ router.post(
       (a) =>
         !a.originalKey?.startsWith(prefix) ||
         (a.compressedKey !== undefined && !a.compressedKey.startsWith(prefix)) ||
-        (a.posterKey !== undefined && !a.posterKey.startsWith(prefix))
+        (a.posterKey !== undefined && !a.posterKey.startsWith(prefix)) ||
+        (a.pairedVideoKey !== undefined && !a.pairedVideoKey.startsWith(prefix))
     );
     if (invalid) {
       throw new Error('Invalid object key');
@@ -1104,16 +1168,35 @@ router.post(
         validateContentType(a.mimetype);
         validateFileSize(a.size, a.mimetype, uploadPolicy.maxVideoUploadSizeMB);
       }
+
+      if (a.mediaKind === 'livePhoto' || a.pairedVideoKey) {
+        if (!isImageContentType(a.mimetype)) {
+          throw new Error('Live Photo original resource must be an image');
+        }
+        validateContentType(a.pairedVideoMimetype);
+        if (!isVideoContentType(a.pairedVideoMimetype)) {
+          throw new Error('Live Photo paired video resource must be a video');
+        }
+        validateFileSize(
+          a.pairedVideoSize,
+          a.pairedVideoMimetype,
+          uploadPolicy.maxVideoUploadSizeMB
+        );
+      }
     }
 
     const hasVideo = attachments.some(
       (a) =>
         inferAttachmentMediaKind({
+          mediaKind: a.mediaKind,
           mimetype: a.mimetype,
           compressedKey: a.compressedKey,
           posterKey: a.posterKey,
+          pairedVideoKey: a.pairedVideoKey,
           key: a.originalKey,
-        }) === 'video'
+        }) === 'video' ||
+        a.mediaKind === 'livePhoto' ||
+        !!a.pairedVideoKey
     );
     if (hasVideo && !openKey.permissions.includes('UPLOADVIDEO')) {
       return c.json(createResponse(null, 'openkey_permission_required:UPLOADVIDEO'), 403);
@@ -1127,9 +1210,11 @@ router.post(
 
     for (const a of attachments) {
       const mediaKind = inferAttachmentMediaKind({
+        mediaKind: a.mediaKind,
         mimetype: a.mimetype,
         compressedKey: a.compressedKey,
         posterKey: a.posterKey,
+        pairedVideoKey: a.pairedVideoKey,
         key: a.originalKey,
       });
 
@@ -1163,14 +1248,17 @@ router.post(
         continue;
       }
 
-      if (mediaKind === 'image' && normalizedAttachment.posterKey) {
+      if ((mediaKind === 'image' || mediaKind === 'livePhoto') && normalizedAttachment.posterKey) {
         validationErrors.push(
-          `Images cannot include posterKey: ${a.originalKey} (uuid: ${a.uuid})`
+          `Image-like attachments cannot include posterKey: ${a.originalKey} (uuid: ${a.uuid})`
         );
         normalizedAttachment.posterKey = undefined;
       }
 
-      if (mediaKind === 'image' && normalizedAttachment.compressedKey) {
+      if (
+        (mediaKind === 'image' || mediaKind === 'livePhoto') &&
+        normalizedAttachment.compressedKey
+      ) {
         const compressedExists = await checkObjectExists(normalizedAttachment.compressedKey);
         if (!compressedExists) {
           validationErrors.push(
@@ -1192,6 +1280,43 @@ router.post(
             normalizedAttachment.compressedKey = undefined;
           }
         }
+      }
+
+      if (mediaKind === 'livePhoto') {
+        if (!normalizedAttachment.pairedVideoKey) {
+          validationErrors.push(
+            `Live Photo paired video missing: ${a.originalKey} (uuid: ${a.uuid})`
+          );
+          continue;
+        }
+
+        const pairedVideoExists = await checkObjectExists(normalizedAttachment.pairedVideoKey);
+        if (!pairedVideoExists) {
+          validationErrors.push(
+            `Live Photo paired video not found: ${normalizedAttachment.pairedVideoKey} (uuid: ${a.uuid})`
+          );
+          continue;
+        }
+
+        const pairedVideoUuid = extractPairedVideoUuid(normalizedAttachment.pairedVideoKey);
+        if (!pairedVideoUuid) {
+          validationErrors.push(
+            `Invalid paired video key format: originalKey=${a.originalKey}, pairedVideoKey=${normalizedAttachment.pairedVideoKey}`
+          );
+          continue;
+        }
+
+        if (originalUuid !== pairedVideoUuid) {
+          validationErrors.push(
+            `UUID mismatch: originalKey contains uuid '${originalUuid}', but pairedVideoKey contains uuid '${pairedVideoUuid}'`
+          );
+          continue;
+        }
+      } else if (normalizedAttachment.pairedVideoKey) {
+        validationErrors.push(
+          `Only Live Photo attachments can include pairedVideoKey: ${a.originalKey} (uuid: ${a.uuid})`
+        );
+        continue;
       }
 
       if (mediaKind === 'video' && normalizedAttachment.posterKey) {
@@ -1252,12 +1377,15 @@ router.post(
           key: a.originalKey,
           mimetype: a.mimetype || null,
           mediaKind: inferAttachmentMediaKind({
+            mediaKind: a.mediaKind,
             mimetype: a.mimetype || null,
             compressedKey: a.compressedKey,
             posterKey: a.posterKey,
+            pairedVideoKey: a.pairedVideoKey,
           }),
           compressKey: a.compressedKey,
           posterKey: a.posterKey,
+          pairedVideoKey: a.pairedVideoKey,
         },
       }));
       validateRoteAttachmentDetails(
@@ -1270,13 +1398,19 @@ router.post(
       const urlPrefix = storageConfig?.urlPrefix;
       const oUrl = `${urlPrefix}/${a.originalKey}`;
       const mediaKind = inferAttachmentMediaKind({
+        mediaKind: a.mediaKind,
         mimetype: a.mimetype || null,
         compressedKey: a.compressedKey,
         posterKey: a.posterKey,
+        pairedVideoKey: a.pairedVideoKey,
       });
       const cUrl =
-        mediaKind === 'image' && a.compressedKey ? `${urlPrefix}/${a.compressedKey}` : null;
+        (mediaKind === 'image' || mediaKind === 'livePhoto') && a.compressedKey
+          ? `${urlPrefix}/${a.compressedKey}`
+          : null;
       const pUrl = mediaKind === 'video' && a.posterKey ? `${urlPrefix}/${a.posterKey}` : null;
+      const pairedVideoUrl =
+        mediaKind === 'livePhoto' && a.pairedVideoKey ? `${urlPrefix}/${a.pairedVideoKey}` : null;
       const baseDetails: any = {
         size: a.size || 0,
         mimetype: a.mimetype || null,
@@ -1286,6 +1420,15 @@ router.post(
       };
       if (a.compressedKey) baseDetails.compressKey = a.compressedKey;
       if (a.posterKey) baseDetails.posterKey = a.posterKey;
+      if (pairedVideoUrl && a.pairedVideoKey) {
+        baseDetails.pairedVideoKey = a.pairedVideoKey;
+        baseDetails.pairedVideoUrl = pairedVideoUrl;
+        baseDetails.pairedVideoMimetype = a.pairedVideoMimetype || null;
+        baseDetails.pairedVideoSize = a.pairedVideoSize || 0;
+        if (a.pairedVideoFilename) {
+          baseDetails.pairedVideoFilename = a.pairedVideoFilename;
+        }
+      }
       if (a.hash) baseDetails.hash = a.hash;
 
       return {

--- a/server/tests/fileValidation.test.ts
+++ b/server/tests/fileValidation.test.ts
@@ -75,6 +75,54 @@ describe('fileValidation', () => {
     );
   });
 
+  it('treats Live Photos as image-like attachments', () => {
+    expect(
+      inferAttachmentMediaKind({
+        pairedVideoKey: 'users/test/paired-videos/live.mov',
+      })
+    ).toBe('livePhoto');
+
+    expect(() =>
+      validateRoteAttachmentDetails([
+        {
+          details: {
+            mediaKind: 'image',
+            mimetype: 'image/png',
+          },
+        },
+        {
+          details: {
+            mediaKind: 'livePhoto',
+            mimetype: 'image/heic',
+            key: 'users/test/uploads/live.heic',
+            compressKey: 'users/test/compressed/live.webp',
+            pairedVideoKey: 'users/test/paired-videos/live.mov',
+          },
+        },
+      ])
+    ).not.toThrow();
+  });
+
+  it('rejects mixing Live Photos with standalone videos', () => {
+    expect(() =>
+      validateRoteAttachmentDetails([
+        {
+          details: {
+            mediaKind: 'livePhoto',
+            mimetype: 'image/heic',
+            pairedVideoKey: 'users/test/paired-videos/live.mov',
+          },
+        },
+        {
+          details: {
+            mediaKind: 'video',
+            mimetype: 'video/mp4',
+          },
+        },
+      ])
+    ).toThrow('Images and videos cannot be uploaded together in the same Rote');
+  });
+
   it('uses configured video upload size limit', () => {
     const maxVideoSizeMB = DEFAULT_MAX_VIDEO_UPLOAD_SIZE_MB + 50;
     const allowedSize = getMaxVideoUploadSizeBytes(maxVideoSizeMB);

--- a/server/types/main.ts
+++ b/server/types/main.ts
@@ -8,9 +8,15 @@ export interface UploadResult {
     mtime: Date | null | undefined;
     hash: string | null | undefined;
     // 对象存储中的 Key，便于删除和追踪
+    mediaKind?: 'image' | 'video' | 'livePhoto' | null;
     key?: string;
     compressKey?: string;
     posterKey?: string;
+    pairedVideoKey?: string;
+    pairedVideoUrl?: string;
+    pairedVideoMimetype?: string | null;
+    pairedVideoSize?: number;
+    pairedVideoFilename?: string;
   };
 }
 

--- a/server/utils/dbMethods/attachment.ts
+++ b/server/utils/dbMethods/attachment.ts
@@ -7,6 +7,33 @@ import { r2deletehandler } from '../r2';
 import { createRoteChange } from './change';
 import { DatabaseError } from './common';
 
+function collectAttachmentObjectKeys(details: any): string[] {
+  if (!details || typeof details !== 'object') {
+    return [];
+  }
+
+  const candidates = [
+    details.key,
+    details.compressKey,
+    details.posterKey,
+    details.pairedVideoKey,
+    details.livePhotoVideoKey,
+    details.livePhoto?.pairedVideoKey,
+  ];
+
+  return Array.from(
+    new Set(candidates.filter((key): key is string => typeof key === 'string' && key.length > 0))
+  );
+}
+
+function deleteAttachmentObjects(details: any) {
+  for (const key of collectAttachmentObjectKeys(details)) {
+    r2deletehandler(key).catch((err) => {
+      console.error(`Failed to delete attachment object from R2: ${key}`, err);
+    });
+  }
+}
+
 // 附件相关方法
 export async function createAttachments(
   userid: string,
@@ -296,20 +323,7 @@ export async function deleteRoteAttachmentsByRoteId(roteid: string, userid: stri
     }
 
     attachmentsList.forEach(({ details }) => {
-      // @ts-expect-error - details 可能包含动态属性
-      const key = details?.key;
-      // @ts-expect-error - details 可能包含动态属性
-      const compressKey = details?.compressKey;
-      if (key) {
-        r2deletehandler(key).catch((err) => {
-          console.error(`Failed to delete attachment from R2: ${key}`, err);
-        });
-      }
-      if (compressKey) {
-        r2deletehandler(compressKey).catch((err) => {
-          console.error(`Failed to delete compressed attachment from R2: ${compressKey}`, err);
-        });
-      }
+      deleteAttachmentObjects(details);
     });
 
     // 记录变更历史（如果 rote 存在）
@@ -479,20 +493,7 @@ export async function deleteAttachments(
 
     // 优先使用 DB 中的 details 删除，以涵盖压缩文件；兼容传入 key 的旧行为
     dbAttachments.forEach(({ details }) => {
-      // @ts-expect-error - details 可能包含动态属性
-      const key = details?.key;
-      // @ts-expect-error - details 可能包含动态属性
-      const compressKey = details?.compressKey;
-      if (key) {
-        r2deletehandler(key).catch((err) => {
-          console.error(`Failed to delete attachment from R2: ${key}`, err);
-        });
-      }
-      if (compressKey) {
-        r2deletehandler(compressKey).catch((err) => {
-          console.error(`Failed to delete compressed attachment from R2: ${compressKey}`, err);
-        });
-      }
+      deleteAttachmentObjects(details);
     });
 
     // 兼容性：如果请求体传入了 key，但 DB 没有 details（历史数据），也尝试删除
@@ -558,22 +559,7 @@ export async function deleteAttachment(id: string, userid: string): Promise<any>
       }
     }
 
-    if (record?.details) {
-      // @ts-expect-error - details 可能包含动态属性
-      const key = record.details?.key;
-      // @ts-expect-error - details 可能包含动态属性
-      const compressKey = record.details?.compressKey;
-      if (key) {
-        r2deletehandler(key).catch((err) => {
-          console.error(`Failed to delete attachment from R2: ${key}`, err);
-        });
-      }
-      if (compressKey) {
-        r2deletehandler(compressKey).catch((err) => {
-          console.error(`Failed to delete compressed attachment from R2: ${compressKey}`, err);
-        });
-      }
-    }
+    deleteAttachmentObjects(record?.details);
 
     return { count: result.length };
   } catch (error) {

--- a/server/utils/fileValidation.ts
+++ b/server/utils/fileValidation.ts
@@ -34,7 +34,7 @@ export const DEFAULT_MAX_VIDEO_UPLOAD_SIZE_MB = 300;
 export const MAX_FILES = 9;
 export const MAX_BATCH_SIZE = 100;
 
-export type MediaKind = 'image' | 'video';
+export type MediaKind = 'image' | 'video' | 'livePhoto';
 
 type AttachmentLike = {
   details?: {
@@ -43,6 +43,8 @@ type AttachmentLike = {
     contentType?: string | null;
     compressKey?: string | null;
     posterKey?: string | null;
+    pairedVideoKey?: string | null;
+    livePhotoVideoKey?: string | null;
     key?: string | null;
   } | null;
 };
@@ -54,6 +56,8 @@ type UploadLike = {
   compressedKey?: string | null;
   compressKey?: string | null;
   posterKey?: string | null;
+  pairedVideoKey?: string | null;
+  livePhotoVideoKey?: string | null;
   key?: string | null;
 };
 
@@ -100,8 +104,16 @@ export function inferAttachmentMediaKind(input?: UploadLike | null): MediaKind |
     return null;
   }
 
-  if (input.mediaKind === 'image' || input.mediaKind === 'video') {
+  if (
+    input.mediaKind === 'image' ||
+    input.mediaKind === 'video' ||
+    input.mediaKind === 'livePhoto'
+  ) {
     return input.mediaKind;
+  }
+
+  if (input.pairedVideoKey || input.livePhotoVideoKey) {
+    return 'livePhoto';
   }
 
   const mediaKind = getMediaKindFromContentType(input.mimetype || input.contentType);
@@ -217,7 +229,7 @@ export function mergeUniqueRoteAttachmentDetails<T extends AttachmentLike>(
 export function validateRoteMediaKinds(mediaKinds: MediaKind[]): void {
   if (mediaKinds.length === 0) return;
 
-  const imageCount = mediaKinds.filter((kind) => kind === 'image').length;
+  const imageCount = mediaKinds.filter((kind) => kind === 'image' || kind === 'livePhoto').length;
   const videoCount = mediaKinds.filter((kind) => kind === 'video').length;
 
   if (imageCount > 0 && videoCount > 0) {

--- a/server/utils/zod.ts
+++ b/server/utils/zod.ts
@@ -138,6 +138,14 @@ export const AttachmentPresignZod = z.object({
         filename: z.string().max(255, 'Filename cannot exceed 255 characters').optional(),
         contentType: z.string().min(1, 'Content type cannot be empty'),
         size: z.number().int().positive('File size must be greater than 0'),
+        mediaKind: z.enum(['image', 'video', 'livePhoto']).optional(),
+        pairedVideo: z
+          .object({
+            filename: z.string().max(255, 'Filename cannot exceed 255 characters').optional(),
+            contentType: z.string().min(1, 'Content type cannot be empty'),
+            size: z.number().int().positive('File size must be greater than 0'),
+          })
+          .optional(),
       })
     )
     .min(1, 'At least one file is required')

--- a/web/src/components/editor/AttachmentItem.tsx
+++ b/web/src/components/editor/AttachmentItem.tsx
@@ -2,7 +2,7 @@ import type { Attachment } from '@/types/main';
 import { VideoAttachmentPreview } from '@/components/rote/VideoAttachmentPreview';
 import { getAttachmentMediaKind } from '@/utils/directUpload';
 import { generateVideoPoster } from '@/utils/generateVideoPoster';
-import { X } from 'lucide-react';
+import { CirclePlay, X } from 'lucide-react';
 import { PhotoView } from 'react-photo-view';
 import { useEffect, useMemo, useState } from 'react';
 
@@ -22,6 +22,7 @@ function AttachmentItem({
   onDelete,
 }: AttachmentItemProps) {
   const mediaKind = getAttachmentMediaKind(attachment);
+  const isLivePhoto = mediaKind === 'livePhoto';
   const [localPosterSrc, setLocalPosterSrc] = useState<string | null>(null);
   const objectUrl = useMemo(
     () => (attachment instanceof File ? URL.createObjectURL(attachment) : null),
@@ -102,13 +103,21 @@ function AttachmentItem({
         </>
       ) : (
         <PhotoView src={previewSrc}>
-          <img
-            className={`h-full w-full object-cover ${isUploading ? 'opacity-80' : ''}`}
-            height={80}
-            width={80}
-            src={thumbSrc}
-            alt="uploaded"
-          />
+          <div className="relative h-full w-full">
+            <img
+              className={`h-full w-full object-cover ${isUploading ? 'opacity-80' : ''}`}
+              height={80}
+              width={80}
+              src={thumbSrc}
+              alt="uploaded"
+            />
+            {isLivePhoto && (
+              <span className="absolute bottom-1.5 left-1.5 flex items-center gap-1 rounded bg-black/60 px-1.5 py-0.5 text-[10px] font-semibold tracking-normal text-white">
+                <CirclePlay className="size-3" />
+                LIVE
+              </span>
+            )}
+          </div>
         </PhotoView>
       )}
 

--- a/web/src/components/editor/RoteEditor.tsx
+++ b/web/src/components/editor/RoteEditor.tsx
@@ -77,7 +77,9 @@ function RoteEditor({ roteAtom, callback }: { roteAtom: RoteAtomType; callback?:
     [rote.attachments]
   );
   const hasVideoAttachment = attachmentMediaKinds.includes('video');
-  const imageAttachmentCount = attachmentMediaKinds.filter((kind) => kind === 'image').length;
+  const imageAttachmentCount = attachmentMediaKinds.filter(
+    (kind) => kind === 'image' || kind === 'livePhoto'
+  ).length;
   const canAddMoreAttachments = !hasVideoAttachment && imageAttachmentCount < 9;
   const uploadAccept = hasVideoAttachment
     ? VIDEO_ACCEPT

--- a/web/src/components/rote/AttachmentsGrid.tsx
+++ b/web/src/components/rote/AttachmentsGrid.tsx
@@ -1,5 +1,6 @@
 import type { Attachment } from '@/types/main';
 import { getAttachmentMediaKind } from '@/utils/directUpload';
+import { CirclePlay } from 'lucide-react';
 import { PhotoProvider, PhotoView } from 'react-photo-view';
 import { VideoAttachmentPreview } from './VideoAttachmentPreview';
 import 'react-photo-view/dist/react-photo-view.css';
@@ -34,24 +35,40 @@ export default function AttachmentsGrid({ attachments, withTimeStamp }: Attachme
           ))
         ) : (
           <PhotoProvider>
-            {sortedAttachments.map((file, index) => (
-              <PhotoView key={`files_${index}`} src={file.url}>
-                <img
-                  className={`${
-                    attachments.length % 3 === 0
-                      ? 'aspect-square w-[calc(1/3*100%-4px)]'
-                      : attachments.length % 2 === 0
-                        ? 'aspect-square w-[calc(1/2*100%-3px)]'
-                        : attachments.length === 1
-                          ? 'w-full max-w-[500px] rounded-2xl border-[0.5px]'
-                          : 'aspect-square w-[calc(1/3*100%-3px)]'
-                  } bg-foreground/3 grow object-cover`}
-                  src={`${file.compressUrl || file.url}`}
-                  crossOrigin={withTimeStamp ? 'anonymous' : undefined}
-                  alt=""
-                />
-              </PhotoView>
-            ))}
+            {sortedAttachments.map((file, index) => {
+              const isLivePhoto = getAttachmentMediaKind(file) === 'livePhoto';
+              const imageClassName =
+                attachments.length % 3 === 0
+                  ? 'aspect-square w-[calc(1/3*100%-4px)]'
+                  : attachments.length % 2 === 0
+                    ? 'aspect-square w-[calc(1/2*100%-3px)]'
+                    : attachments.length === 1
+                      ? 'w-full max-w-[500px] rounded-2xl border-[0.5px]'
+                      : 'aspect-square w-[calc(1/3*100%-3px)]';
+              const renderedImageClassName =
+                attachments.length === 1
+                  ? 'bg-foreground/3 block w-full object-cover'
+                  : 'bg-foreground/3 block h-full w-full object-cover';
+
+              return (
+                <PhotoView key={`files_${index}`} src={file.url}>
+                  <div className={`${imageClassName} relative grow overflow-hidden`}>
+                    <img
+                      className={renderedImageClassName}
+                      src={`${file.compressUrl || file.url}`}
+                      crossOrigin={withTimeStamp ? 'anonymous' : undefined}
+                      alt=""
+                    />
+                    {isLivePhoto && (
+                      <span className="absolute bottom-2 left-2 flex items-center gap-1 rounded bg-black/60 px-1.5 py-0.5 text-[10px] font-semibold tracking-normal text-white">
+                        <CirclePlay className="size-3" />
+                        LIVE
+                      </span>
+                    )}
+                  </div>
+                </PhotoView>
+              );
+            })}
           </PhotoProvider>
         )}
       </div>

--- a/web/src/components/rote/NoteExportCard.tsx
+++ b/web/src/components/rote/NoteExportCard.tsx
@@ -32,7 +32,10 @@ export default function NoteExportCard({
   }, [onReady]);
 
   const imageAttachments = attachments?.filter(
-    (a) => a.details?.mediaKind === 'image' || (!a.details?.mediaKind && a.url)
+    (a) =>
+      a.details?.mediaKind === 'image' ||
+      a.details?.mediaKind === 'livePhoto' ||
+      (!a.details?.mediaKind && a.url)
   );
 
   return (

--- a/web/src/types/main.ts
+++ b/web/src/types/main.ts
@@ -71,12 +71,17 @@ export type Attachment = {
     originalname?: string;
     encoding?: string;
     mimetype?: string | null;
-    mediaKind?: 'image' | 'video';
+    mediaKind?: 'image' | 'video' | 'livePhoto';
     size?: number;
     bucket?: string;
     key?: string;
     compressKey?: string;
     posterKey?: string;
+    pairedVideoKey?: string;
+    pairedVideoUrl?: string;
+    pairedVideoMimetype?: string | null;
+    pairedVideoSize?: number;
+    pairedVideoFilename?: string;
     acl?: string;
     contentType?: string;
     contentDisposition?: string | null;

--- a/web/src/utils/directUpload.ts
+++ b/web/src/utils/directUpload.ts
@@ -2,14 +2,21 @@ import type { Attachment } from '@/types/main';
 import axios, { type AxiosProgressEvent } from 'axios';
 import { post } from './api';
 
-export type PresignFile = { filename?: string; contentType?: string; size?: number };
-export type MediaKind = 'image' | 'video';
+export type MediaKind = 'image' | 'video' | 'livePhoto';
+export type PresignFile = {
+  filename?: string;
+  contentType?: string;
+  size?: number;
+  mediaKind?: MediaKind;
+  pairedVideo?: { filename?: string; contentType?: string; size?: number };
+};
 
 export type PresignItem = {
   uuid: string;
   original: { key: string; putUrl: string; url: string; contentType?: string };
   compressed?: { key: string; putUrl: string; url: string; contentType: 'image/webp' };
   poster?: { key: string; putUrl: string; url: string; contentType: 'image/jpeg' };
+  pairedVideo?: { key: string; putUrl: string; url: string; contentType?: string };
 };
 
 export interface PresignResponse {
@@ -129,8 +136,13 @@ export type FinalizeAttachment = {
   originalKey: string;
   compressedKey?: string;
   posterKey?: string;
+  pairedVideoKey?: string;
+  pairedVideoSize?: number;
+  pairedVideoMimetype?: string;
+  pairedVideoFilename?: string;
   size?: number;
   mimetype?: string;
+  mediaKind?: MediaKind;
   hash?: string;
 };
 
@@ -143,11 +155,19 @@ export async function finalize(attachments: FinalizeAttachment[], noteId?: strin
 export function getAttachmentMediaKind(attachment: File | Attachment): MediaKind | null {
   const mimetype = attachment instanceof File ? attachment.type : attachment.details?.mimetype;
   const mediaKind = attachment instanceof File ? undefined : attachment.details?.mediaKind;
+  const pairedVideoKey =
+    attachment instanceof File ? undefined : attachment.details?.pairedVideoKey;
 
-  if (mediaKind === 'image' || mediaKind === 'video') {
+  if (mediaKind === 'image' || mediaKind === 'video' || mediaKind === 'livePhoto') {
     return mediaKind;
   }
+  if (pairedVideoKey) return 'livePhoto';
   if (mimetype?.startsWith('image/')) return 'image';
   if (mimetype?.startsWith('video/')) return 'video';
   return null;
+}
+
+export function isImageLikeAttachment(attachment: File | Attachment) {
+  const mediaKind = getAttachmentMediaKind(attachment);
+  return mediaKind === 'image' || mediaKind === 'livePhoto';
 }


### PR DESCRIPTION
## Summary
- add Live Photo media kind support to attachment presign/finalize flows, including paired video keys and validation
- clean up paired video objects when deleting attachments
- show Live Photo attachments as image-like media on web with a LIVE badge

## Validation
- server: bun test tests/fileValidation.test.ts
- server: bun run build
- server: bun run lint
- web: bun run build
- web: bun run lint