### PR TITLE
[codex] Fix Live Photo web preview source

### DIFF
--- a/web/src/components/editor/AttachmentItem.tsx
+++ b/web/src/components/editor/AttachmentItem.tsx
@@ -1,6 +1,10 @@
 import type { Attachment } from '@/types/main';
 import { VideoAttachmentPreview } from '@/components/rote/VideoAttachmentPreview';
-import { getAttachmentMediaKind } from '@/utils/directUpload';
+import {
+  getAttachmentImagePreviewSrc,
+  getAttachmentImageThumbnailSrc,
+  getAttachmentMediaKind,
+} from '@/utils/directUpload';
 import { generateVideoPoster } from '@/utils/generateVideoPoster';
 import { CirclePlay, X } from 'lucide-react';
 import { PhotoView } from 'react-photo-view';
@@ -58,8 +62,14 @@ function AttachmentItem({
     mediaKind === 'video'
       ? localPosterSrc || (!(attachment instanceof File) ? attachment.posterUrl || '' : '')
       : objectUrl ||
-        (!(attachment instanceof File) ? attachment.compressUrl || attachment.url : '');
-  const previewSrc = objectUrl || (!(attachment instanceof File) ? attachment.url : '');
+        (!(attachment instanceof File) ? getAttachmentImageThumbnailSrc(attachment) : '');
+  const previewSrc =
+    objectUrl ||
+    (!(attachment instanceof File)
+      ? mediaKind === 'video'
+        ? attachment.url
+        : getAttachmentImagePreviewSrc(attachment)
+      : '');
   const progressValue =
     typeof uploadProgress === 'number' ? Math.max(0, Math.min(100, uploadProgress)) : 0;
 

--- a/web/src/components/rote/AttachmentsGrid.tsx
+++ b/web/src/components/rote/AttachmentsGrid.tsx
@@ -1,5 +1,9 @@
 import type { Attachment } from '@/types/main';
-import { getAttachmentMediaKind } from '@/utils/directUpload';
+import {
+  getAttachmentImagePreviewSrc,
+  getAttachmentImageThumbnailSrc,
+  getAttachmentMediaKind,
+} from '@/utils/directUpload';
 import { CirclePlay } from 'lucide-react';
 import { PhotoProvider, PhotoView } from 'react-photo-view';
 import { VideoAttachmentPreview } from './VideoAttachmentPreview';
@@ -37,6 +41,8 @@ export default function AttachmentsGrid({ attachments, withTimeStamp }: Attachme
           <PhotoProvider>
             {sortedAttachments.map((file, index) => {
               const isLivePhoto = getAttachmentMediaKind(file) === 'livePhoto';
+              const previewSrc = getAttachmentImagePreviewSrc(file);
+              const thumbSrc = getAttachmentImageThumbnailSrc(file);
               const imageClassName =
                 attachments.length % 3 === 0
                   ? 'aspect-square w-[calc(1/3*100%-4px)]'
@@ -51,11 +57,11 @@ export default function AttachmentsGrid({ attachments, withTimeStamp }: Attachme
                   : 'bg-foreground/3 block h-full w-full object-cover';
 
               return (
-                <PhotoView key={`files_${index}`} src={file.url}>
+                <PhotoView key={`files_${index}`} src={previewSrc}>
                   <div className={`${imageClassName} relative grow overflow-hidden`}>
                     <img
                       className={renderedImageClassName}
-                      src={`${file.compressUrl || file.url}`}
+                      src={thumbSrc}
                       crossOrigin={withTimeStamp ? 'anonymous' : undefined}
                       alt=""
                     />

--- a/web/src/utils/directUpload.test.ts
+++ b/web/src/utils/directUpload.test.ts
@@ -1,0 +1,94 @@
+import type { Attachment } from '@/types/main';
+import {
+  getAttachmentImagePreviewSrc,
+  getAttachmentImageThumbnailSrc,
+  isHeicLikeAttachment,
+} from '@/utils/directUpload';
+import { describe, expect, it } from 'vitest';
+
+function makeAttachment(overrides: Partial<Attachment>): Attachment {
+  const base: Attachment = {
+    id: 'attachment-1',
+    url: 'https://cdn.example.com/users/u/uploads/file.jpg',
+    compressUrl: 'https://cdn.example.com/users/u/compressed/file.webp',
+    posterUrl: null,
+    userid: 'user-1',
+    roteid: 'rote-1',
+    sortIndex: 0,
+    storage: 'R2',
+    details: {
+      mimetype: 'image/jpeg',
+      mediaKind: 'image',
+      key: 'users/u/uploads/file.jpg',
+    },
+    createdAt: '2026-06-11T00:00:00.000Z',
+    updatedAt: '2026-06-11T00:00:00.000Z',
+  };
+
+  return {
+    ...base,
+    ...overrides,
+    details: {
+      mimetype: 'image/jpeg',
+      mediaKind: 'image',
+      key: 'users/u/uploads/file.jpg',
+      ...base.details,
+      ...overrides.details,
+    },
+  };
+}
+
+describe('attachment image display sources', () => {
+  it('uses the compressed still when previewing a Live Photo', () => {
+    const attachment = makeAttachment({
+      url: 'https://cdn.example.com/users/u/uploads/live.HEIC',
+      compressUrl: 'https://cdn.example.com/users/u/compressed/live.webp',
+      details: {
+        mimetype: 'image/heic',
+        mediaKind: 'livePhoto',
+        key: 'users/u/uploads/live.HEIC',
+        pairedVideoKey: 'users/u/paired-videos/live.mov',
+      },
+    });
+
+    expect(getAttachmentImagePreviewSrc(attachment)).toBe(
+      'https://cdn.example.com/users/u/compressed/live.webp'
+    );
+  });
+
+  it('uses the compressed still for standalone HEIC images', () => {
+    const attachment = makeAttachment({
+      url: 'https://cdn.example.com/users/u/uploads/photo.HEIC',
+      compressUrl: 'https://cdn.example.com/users/u/compressed/photo.webp',
+      details: {
+        mimetype: 'image/heic',
+        mediaKind: 'image',
+        key: 'users/u/uploads/photo.HEIC',
+      },
+    });
+
+    expect(isHeicLikeAttachment(attachment)).toBe(true);
+    expect(getAttachmentImagePreviewSrc(attachment)).toBe(
+      'https://cdn.example.com/users/u/compressed/photo.webp'
+    );
+  });
+
+  it('keeps the original source for browser-renderable images', () => {
+    const attachment = makeAttachment({
+      url: 'https://cdn.example.com/users/u/uploads/photo.jpg',
+      compressUrl: 'https://cdn.example.com/users/u/compressed/photo.webp',
+      details: {
+        mimetype: 'image/jpeg',
+        mediaKind: 'image',
+        key: 'users/u/uploads/photo.jpg',
+      },
+    });
+
+    expect(getAttachmentImagePreviewSrc(attachment)).toBe(
+      'https://cdn.example.com/users/u/uploads/photo.jpg'
+    );
+    expect(getAttachmentImageThumbnailSrc(attachment)).toBe(
+      'https://cdn.example.com/users/u/compressed/photo.webp'
+    );
+  });
+});

--- a/web/src/utils/directUpload.ts
+++ b/web/src/utils/directUpload.ts
@@ -167,6 +167,42 @@ export function getAttachmentMediaKind(attachment: File | Attachment): MediaKind
   return null;
 }
 
+export function isHeicLikeAttachment(attachment: File | Attachment) {
+  const mimetype =
+    (attachment instanceof File ? attachment.type : attachment.details?.mimetype)?.toLowerCase() ||
+    '';
+  if (mimetype === 'image/heic' || mimetype === 'image/heif') {
+    return true;
+  }
+
+  const candidateNames =
+    attachment instanceof File
+      ? [attachment.name]
+      : [
+          attachment.details?.originalname,
+          attachment.details?.key,
+          attachment.url,
+          attachment.compressUrl,
+        ];
+
+  return candidateNames.some((name) => /\.(heic|heif)(\?|#|$)/i.test(name || ''));
+}
+
+export function getAttachmentImageThumbnailSrc(attachment: Attachment) {
+  return attachment.compressUrl || attachment.url || '';
+}
+
+export function getAttachmentImagePreviewSrc(attachment: Attachment) {
+  const mediaKind = getAttachmentMediaKind(attachment);
+  const shouldUseWebSafeStill = mediaKind === 'livePhoto' || isHeicLikeAttachment(attachment);
+
+  if (shouldUseWebSafeStill) {
+    return attachment.compressUrl || attachment.url || '';
+  }
+
+  return attachment.url || attachment.compressUrl || '';
+}
+
 export function isImageLikeAttachment(attachment: File | Attachment) {
   const mediaKind = getAttachmentMediaKind(attachment);
   return mediaKind === 'image' || mediaKind === 'livePhoto';


### PR DESCRIPTION
## Summary
- Use web-safe still image sources for Live Photo and HEIC/HEIF attachment previews.
- Keep original browser-renderable images opening from their original URL, while Live Photo/HEIC lightbox previews use the generated WebP compressed asset.
- Add unit coverage for Live Photo, HEIC, and JPEG source selection.

## Root Cause
Web attachment lightboxes used attachment.url directly. For iOS Live Photo uploads, that URL is the original HEIC resource, which object storage serves correctly as image/heic but browsers do not reliably render as an img/lightbox source.

## Validation
- npm test -- directUpload.test.ts
- npm run build
- npm run lint