### PR TITLE
[codex] Fix tool calling probe for thinking models

### DIFF
--- a/server/tests/aiClient.test.ts
+++ b/server/tests/aiClient.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from 'bun:test';
 import {
   createChatCompletionWithToolsStreaming,
+  probeChatProviderToolCalling,
   type ChatToolDefinition,
 } from '../utils/ai/client';
 import type { AiProviderConfig } from '../types/config';
@@ -93,5 +94,38 @@ describe('ai client streaming', () => {
         arguments: '{"query":"work"}',
       },
     });
+  });
+
+  it('uses auto tool choice for tool calling probes', async () => {
+    let requestBody: any;
+    globalThis.fetch = (async (_url, init) => {
+      requestBody = JSON.parse(init?.body as string);
+      return new Response(
+        JSON.stringify({
+          choices: [
+            {
+              message: {
+                tool_calls: [
+                  {
+                    id: 'call_probe',
+                    type: 'function',
+                    function: {
+                      name: 'rote_tool_calling_probe',
+                      arguments: '{"token":"rote-tool-probe"}',
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      );
+    }) as typeof fetch;
+
+    const result = await probeChatProviderToolCalling(config);
+
+    expect(result.supported).toBe(true);
+    expect(requestBody.tool_choice).toBe('auto');
   });
 });

--- a/server/utils/ai/client.ts
+++ b/server/utils/ai/client.ts
@@ -191,10 +191,7 @@ export async function probeChatProviderToolCalling(
       ],
       {
         temperature: 0,
-        toolChoice: {
-          type: 'function',
-          function: { name: toolName },
-        },
+        toolChoice: 'auto',
       }
     );
 

--- a/web/src/utils/personalAiProvider.test.ts
+++ b/web/src/utils/personalAiProvider.test.ts
@@ -51,6 +51,11 @@ describe(`personal AI provider test`, () => {
 
     expect(result.data.success).toBe(true);
     expect(result.data.toolCalling?.supported).toBe(true);
+    expect(JSON.parse(fetchMock.mock.calls[1][1]?.body as string)).toEqual(
+      expect.objectContaining({
+        tool_choice: 'auto',
+      })
+    );
     expect(fetchMock).toHaveBeenCalledWith(
       'https://api.example.com/v1/chat/completions',
       expect.objectContaining({

--- a/web/src/utils/personalAiProvider.ts
+++ b/web/src/utils/personalAiProvider.ts
@@ -139,10 +139,7 @@ async function probeBrowserAiToolCalling(
           },
         },
       ],
-      tool_choice: {
-        type: 'function',
-        function: { name: toolName },
-      },
+      tool_choice: 'auto',
     });
 
     const body = await response.json();


### PR DESCRIPTION
## Summary

- Change frontend personal AI tool-calling probe to use `tool_choice: "auto"` instead of forcing a specific function tool.
- Apply the same change to the backend provider probe used by site model testing.
- Add tests that assert probe requests send `tool_choice: "auto"`.

## Why

Some thinking/reasoning model providers reject `tool_choice: "required"` or function-object tool choices while thinking mode is enabled. The probe was surfacing that provider 400 as a missing tool-calling result.

## Validation

- `cd web && bun run test src/utils/personalAiProvider.test.ts`
- `cd server && bun test tests/aiClient.test.ts`
- `cd web && bun run lint`
- `cd web && bun run build`
- `cd server && bun run lint`
- `cd server && bun run build`