### PR TITLE
[codex] support OAuth client id negotiation

### DIFF
--- a/server/oauth/clientMetadata.ts
+++ b/server/oauth/clientMetadata.ts
@@ -1,0 +1,219 @@
+import { findOAuthClient, upsertOAuthClient } from '../utils/dbMethods';
+import { assertValidRedirectUri, isPrivateUseRedirectUri } from './utils';
+import { normalizeClientScopes } from './flow';
+import messages from './messages.json';
+
+const CLIENT_METADATA_MAX_BYTES = 64 * 1024;
+const CLIENT_METADATA_FETCH_TIMEOUT_MS = 5000;
+
+type OAuthClientMetadata = {
+  client_id: string;
+  client_name: string;
+  redirect_uris: string[];
+  client_uri?: string;
+  logo_uri?: string;
+  grant_types?: string[];
+  response_types?: string[];
+  scope?: string;
+  token_endpoint_auth_method?: string;
+};
+
+function oauthClientMetadataError(message: string): never {
+  throw new Error(messages.codes.clientMetadataInvalidPrefix + message);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function assertStringArray(value: unknown, field: string): string[] {
+  if (
+    !Array.isArray(value) ||
+    value.length === 0 ||
+    !value.every((item) => typeof item === 'string')
+  ) {
+    oauthClientMetadataError(field);
+  }
+  return value;
+}
+
+function assertOptionalString(value: unknown, field: string): string | null {
+  if (value === undefined || value === null) return null;
+  if (typeof value !== 'string') oauthClientMetadataError(field);
+  return value;
+}
+
+function assertClientMetadataDocumentUrl(clientId: string): URL {
+  let parsed: URL;
+  try {
+    parsed = new URL(clientId);
+  } catch {
+    oauthClientMetadataError('client_id_url');
+  }
+
+  if (parsed.protocol !== 'https:') oauthClientMetadataError('client_id_scheme');
+  if (parsed.username || parsed.password) oauthClientMetadataError('client_id_userinfo');
+  if (parsed.hash) oauthClientMetadataError('client_id_fragment');
+  if (!parsed.pathname || parsed.pathname === '/') oauthClientMetadataError('client_id_path');
+
+  const rawPath = clientId.replace(/^[a-z][a-z0-9+.-]*:\/\/[^/?#]*/i, '').split(/[?#]/)[0];
+  const hasDotSegment = rawPath.split('/').some((segment) => {
+    let decoded = segment;
+    try {
+      decoded = decodeURIComponent(segment);
+    } catch {
+      return true;
+    }
+    return decoded === '.' || decoded === '..';
+  });
+  if (hasDotSegment) {
+    oauthClientMetadataError('client_id_path_segments');
+  }
+
+  return parsed;
+}
+
+function isNativePublicClientId(clientId: string): boolean {
+  if (clientId.length > 255) return false;
+  if (clientId.includes('://')) return false;
+  const segments = clientId.split('.');
+  if (segments.length < 3) return false;
+  return segments.every((segment) => /^[A-Za-z][A-Za-z0-9-]{0,62}$/.test(segment));
+}
+
+function nativeClientName(clientId: string): string {
+  const segments = clientId.split('.');
+  return segments[segments.length - 1] || clientId;
+}
+
+function validateClientMetadata(clientId: string, raw: unknown): OAuthClientMetadata {
+  if (!isRecord(raw)) oauthClientMetadataError('document');
+  if (raw.client_id !== clientId) oauthClientMetadataError('client_id_mismatch');
+  if (typeof raw.client_name !== 'string' || raw.client_name.trim().length === 0) {
+    oauthClientMetadataError('client_name');
+  }
+
+  const redirectUris = assertStringArray(raw.redirect_uris, 'redirect_uris');
+  redirectUris.forEach((uri) => assertValidRedirectUri(uri));
+
+  if (
+    raw.grant_types !== undefined &&
+    !assertStringArray(raw.grant_types, 'grant_types').includes('authorization_code')
+  ) {
+    oauthClientMetadataError('grant_types');
+  }
+  if (
+    raw.response_types !== undefined &&
+    !assertStringArray(raw.response_types, 'response_types').includes('code')
+  ) {
+    oauthClientMetadataError('response_types');
+  }
+  if (raw.token_endpoint_auth_method !== undefined && raw.token_endpoint_auth_method !== 'none') {
+    oauthClientMetadataError('token_endpoint_auth_method');
+  }
+  if (raw.scope !== undefined && typeof raw.scope !== 'string') {
+    oauthClientMetadataError('scope');
+  }
+
+  return {
+    client_id: clientId,
+    client_name: raw.client_name.trim(),
+    redirect_uris: redirectUris,
+    client_uri: assertOptionalString(raw.client_uri, 'client_uri') || undefined,
+    logo_uri: assertOptionalString(raw.logo_uri, 'logo_uri') || undefined,
+    grant_types: Array.isArray(raw.grant_types) ? (raw.grant_types as string[]) : undefined,
+    response_types: Array.isArray(raw.response_types)
+      ? (raw.response_types as string[])
+      : undefined,
+    scope: typeof raw.scope === 'string' ? raw.scope : undefined,
+    token_endpoint_auth_method:
+      typeof raw.token_endpoint_auth_method === 'string'
+        ? raw.token_endpoint_auth_method
+        : undefined,
+  };
+}
+
+async function readClientMetadataJson(response: Response): Promise<unknown> {
+  if (!response.ok) oauthClientMetadataError('fetch_status');
+  const contentLength = response.headers.get('content-length');
+  if (contentLength && Number(contentLength) > CLIENT_METADATA_MAX_BYTES) {
+    oauthClientMetadataError('document_too_large');
+  }
+
+  const bytes = await response.arrayBuffer();
+  if (bytes.byteLength > CLIENT_METADATA_MAX_BYTES) {
+    oauthClientMetadataError('document_too_large');
+  }
+
+  try {
+    return JSON.parse(new TextDecoder().decode(bytes));
+  } catch {
+    oauthClientMetadataError('json');
+  }
+}
+
+export function isClientMetadataDocumentClientId(clientId: string): boolean {
+  try {
+    assertClientMetadataDocumentUrl(clientId);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function fetchOAuthClientMetadataDocument(clientId: string) {
+  assertClientMetadataDocumentUrl(clientId);
+  const response = await fetch(clientId, {
+    headers: { accept: 'application/json' },
+    signal: AbortSignal.timeout(CLIENT_METADATA_FETCH_TIMEOUT_MS),
+  });
+  return validateClientMetadata(clientId, await readClientMetadataJson(response));
+}
+
+export async function resolveOAuthClient(clientId: string) {
+  const existing = await findOAuthClient(clientId);
+  if (existing) return existing;
+  if (!isClientMetadataDocumentClientId(clientId)) return null;
+
+  const metadata = await fetchOAuthClientMetadataDocument(clientId);
+  return await upsertOAuthClient({
+    clientId: metadata.client_id,
+    clientName: metadata.client_name,
+    redirectUris: metadata.redirect_uris,
+    scopes: normalizeClientScopes(metadata.scope),
+    clientUri: metadata.client_uri || null,
+    logoUri: metadata.logo_uri || null,
+  });
+}
+
+export async function resolveClientInitiatedOAuthClient(
+  clientId: string,
+  options: { redirectUri?: string } = {}
+) {
+  const existing = await resolveOAuthClient(clientId);
+  if (existing) return existing;
+
+  if (
+    !options.redirectUri ||
+    !isNativePublicClientId(clientId) ||
+    !isPrivateUseRedirectUri(options.redirectUri)
+  ) {
+    return null;
+  }
+
+  assertValidRedirectUri(options.redirectUri);
+  return await upsertOAuthClient({
+    clientId,
+    clientName: nativeClientName(clientId),
+    redirectUris: [options.redirectUri],
+    scopes: normalizeClientScopes(undefined),
+    clientUri: null,
+    logoUri: null,
+  });
+}
+
+export const clientMetadataTestExports = {
+  validateClientMetadata,
+  assertClientMetadataDocumentUrl,
+  isNativePublicClientId,
+};

--- a/server/oauth/messages.json
+++ b/server/oauth/messages.json
@@ -40,6 +40,7 @@
   "codes": {
     "decisionRequired": "oauth_decision_required",
     "jwtNotConfigured": "jwt_not_configured",
+    "clientMetadataInvalidPrefix": "client_metadata_invalid:",
     "requestIdRequired": "request_id_required",
     "redirectUriFragmentForbidden": "redirect_uri_fragment_forbidden",
     "redirectUriInvalid": "redirect_uri_invalid",

--- a/server/oauth/utils.ts
+++ b/server/oauth/utils.ts
@@ -79,7 +79,38 @@ export function assertValidRedirectUri(value: string): void {
     return;
   }
 
+  if (isPrivateUseRedirectUri(value)) {
+    return;
+  }
+
   throw new Error(messages.codes.redirectUriSchemeForbidden);
+}
+
+export function isPrivateUseRedirectUri(value: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return false;
+  }
+
+  if (parsed.hash) return false;
+  const scheme = parsed.protocol.slice(0, -1).toLowerCase();
+  const blockedSchemes = new Set([
+    'about',
+    'blob',
+    'data',
+    'file',
+    'ftp',
+    'http',
+    'https',
+    'javascript',
+    'mailto',
+  ]);
+  if (blockedSchemes.has(scheme)) return false;
+  if (!/^[a-z][a-z0-9+.-]{2,63}$/.test(scheme)) return false;
+
+  return Boolean(parsed.hostname || parsed.pathname);
 }
 
 export async function parseFormBody(c: HonoContext): Promise<Record<string, string>> {

--- a/server/route/oauthMetadata.ts
+++ b/server/route/oauthMetadata.ts
@@ -35,6 +35,7 @@ oauthMetadataRouter.get('/oauth-authorization-server', (c: HonoContext) =>
     grant_types_supported: ['authorization_code', 'refresh_token'],
     code_challenge_methods_supported: ['S256'],
     token_endpoint_auth_methods_supported: ['none'],
+    client_id_metadata_document_supported: true,
     scopes_supported: OAUTH_MCP_SCOPES,
     resource_documentation: getMcpResource(c),
   })

--- a/server/route/v2/mcpOAuth.ts
+++ b/server/route/v2/mcpOAuth.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'crypto';
 import { Hono } from 'hono';
 import mainJson from '../../json/main.json';
+import { resolveClientInitiatedOAuthClient } from '../../oauth/clientMetadata';
 import messages from '../../oauth/messages.json';
 import {
   consumeOAuthAuthorizationCode,
@@ -108,7 +109,7 @@ oauthRouter.get('/authorize', (c: HonoContext) =>
     if (codeChallengeMethod !== 'S256')
       oauthError(messages.errors.invalidRequest, messages.onlyPkceS256);
 
-    const client = await findOAuthClient(clientId);
+    const client = await resolveClientInitiatedOAuthClient(clientId, { redirectUri });
     if (!client) oauthError(messages.errors.invalidClient, messages.clientNotFound);
     if (!client.redirectUris.includes(redirectUri))
       oauthError(messages.errors.invalidRequest, messages.redirectUriMismatch);

--- a/server/tests/oauth-mcp.test.ts
+++ b/server/tests/oauth-mcp.test.ts
@@ -9,10 +9,12 @@ import {
 } from './oauthMcp/common.test';
 import { authorizeAndExchange } from './oauthMcp/flow.test';
 import {
+  testClientInitiatedNativeClientFlow,
   testAuthorizeValidation,
   testDenyFlow,
   testMetadata,
 } from './oauthMcp/metadataAuthorization.test';
+import { testClientMetadataDocumentSupport } from './oauthMcp/clientMetadata.test';
 import { testInsufficientScope, testMcpTools, testProtocol } from './oauthMcp/protocolTools.test';
 import {
   testPkceReuseAndAudience,
@@ -25,6 +27,8 @@ async function main() {
   await ensureInitialized();
   const appAccessToken = await loginOrRegister();
   await testMetadata();
+  await testClientMetadataDocumentSupport();
+  await testClientInitiatedNativeClientFlow(appAccessToken);
   const client = await registerClient();
   const codeChallenge = await sha256Base64Url(randomToken(48));
   await testAuthorizeValidation(client.client_id, codeChallenge);

--- a/server/tests/oauthMcp/clientMetadata.test.ts
+++ b/server/tests/oauthMcp/clientMetadata.test.ts
@@ -1,0 +1,63 @@
+import {
+  clientMetadataTestExports,
+  fetchOAuthClientMetadataDocument,
+} from '../../oauth/clientMetadata';
+import { assertValidRedirectUri } from '../../oauth/utils';
+import { assert } from './common.test';
+
+const { assertClientMetadataDocumentUrl, isNativePublicClientId } = clientMetadataTestExports;
+
+export async function testClientMetadataDocumentSupport() {
+  const clientId = 'https://client.example.com/oauth/client-metadata.json';
+  assertClientMetadataDocumentUrl(clientId);
+  assert(isNativePublicClientId('org.rcex.KeepTalkingApp'), 'native client id should be accepted');
+  assertValidRedirectUri('ktoauth://oauth/callback');
+
+  for (const invalid of [
+    'http://client.example.com/oauth/client-metadata.json',
+    'https://client.example.com',
+    'https://user:pass@client.example.com/oauth/client-metadata.json',
+    'https://client.example.com/oauth/client-metadata.json#fragment',
+    'https://client.example.com/oauth/../client-metadata.json',
+  ]) {
+    let rejected = false;
+    try {
+      assertClientMetadataDocumentUrl(invalid);
+    } catch {
+      rejected = true;
+    }
+    assert(rejected, 'invalid client metadata URL should be rejected: ' + invalid);
+  }
+
+  const originalFetch = globalThis.fetch;
+  (globalThis as any).fetch = async (url: string) => {
+    assert(url === clientId, 'metadata fetch URL mismatch');
+    return new Response(
+      JSON.stringify({
+        client_id: clientId,
+        client_name: 'Client Metadata Test',
+        redirect_uris: ['http://127.0.0.1:8765/callback'],
+        grant_types: ['authorization_code'],
+        response_types: ['code'],
+        token_endpoint_auth_method: 'none',
+        scope: 'notes:read notes:write',
+      }),
+      {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }
+    );
+  };
+
+  try {
+    const metadata = await fetchOAuthClientMetadataDocument(clientId);
+    assert(metadata.client_id === clientId, 'metadata client_id mismatch');
+    assert(metadata.client_name === 'Client Metadata Test', 'metadata client_name mismatch');
+    assert(
+      metadata.redirect_uris.includes('http://127.0.0.1:8765/callback'),
+      'metadata redirect missing'
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}

--- a/server/tests/oauthMcp/metadataAuthorization.test.ts
+++ b/server/tests/oauthMcp/metadataAuthorization.test.ts
@@ -5,7 +5,9 @@ import {
   assert,
   assertStatus,
   publicRequest,
+  randomToken,
   request,
+  sha256Base64Url,
 } from './common.test';
 import { extractRequestId, startAuthorization } from './flow.test';
 
@@ -20,6 +22,10 @@ export async function testMetadata() {
     'missing auth endpoint'
   );
   assert(authServer.data.token_endpoint?.endsWith('/v2/api/oauth/token'), 'missing token endpoint');
+  assert(
+    authServer.data.client_id_metadata_document_supported === true,
+    'missing client_id metadata support marker'
+  );
 }
 
 export async function testAuthorizeValidation(clientId: string, codeChallenge: string) {
@@ -89,4 +95,62 @@ export async function testDenyFlow(
   const redirectUrl = new URL(deny.data.data.redirectUrl);
   assert(redirectUrl.searchParams.get('error') === 'access_denied', 'deny redirect error mismatch');
   assert(redirectUrl.searchParams.get('state') === 'deny-state', 'deny redirect state mismatch');
+}
+
+export async function testClientInitiatedNativeClientFlow(appAccessToken: string) {
+  const clientId = 'org.rcex.KeepTalkingTest';
+  const redirectUri = 'ktoauthtest://oauth/callback';
+  const verifier = randomToken(48);
+  const codeChallenge = await sha256Base64Url(verifier);
+  const state = randomToken(12);
+  const params = new URLSearchParams({
+    response_type: 'code',
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    scope: 'notes:read notes:write profile:read',
+    resource: MCP_RESOURCE,
+    code_challenge: codeChallenge,
+    code_challenge_method: 'S256',
+    state,
+  });
+  const authorize = await request('GET', '/oauth/authorize?' + params, { redirect: 'manual' });
+  assertStatus(authorize.status, 302, 'client-initiated native authorization redirect');
+  const requestId = extractRequestId(authorize.headers.get('location') || '');
+
+  const session = await request('GET', '/oauth/authorize/session?requestId=' + requestId, {
+    headers: { Authorization: 'Bearer ' + appAccessToken },
+  });
+  assertStatus(session.status, 200, 'client-initiated native authorization session');
+  assert(session.data.data?.client?.clientId === clientId, 'native client id mismatch');
+  assert(session.data.data?.redirectUri === redirectUri, 'native redirect_uri mismatch');
+
+  const approve = await request('POST', '/oauth/authorize/approve', {
+    headers: { Authorization: 'Bearer ' + appAccessToken },
+    body: { requestId, decision: 'approve' },
+  });
+  assertStatus(approve.status, 200, 'client-initiated native authorization approval');
+  const redirect = new URL(approve.data.data.redirectUrl);
+  assert(redirect.protocol === 'ktoauthtest:', 'native redirect scheme mismatch');
+  assert(redirect.searchParams.get('state') === state, 'native redirect state mismatch');
+  const code = redirect.searchParams.get('code');
+  assert(code, 'native authorization code missing');
+
+  const token = await request('POST', '/oauth/token', {
+    form: new URLSearchParams({
+      grant_type: 'authorization_code',
+      client_id: clientId,
+      redirect_uri: redirectUri,
+      code,
+      code_verifier: verifier,
+      resource: MCP_RESOURCE,
+    }),
+  });
+  assertStatus(token.status, 200, 'client-initiated native token exchange');
+  assert(token.data.access_token, 'native access token missing');
+  assert(token.data.refresh_token, 'native refresh token missing');
+
+  const revoke = await request('POST', '/oauth/revoke', {
+    form: new URLSearchParams({ token: token.data.refresh_token }),
+  });
+  assertStatus(revoke.status, 200, 'native refresh token revoke');
 }

--- a/server/utils/dbMethods/oauthMcpClients.ts
+++ b/server/utils/dbMethods/oauthMcpClients.ts
@@ -31,6 +31,45 @@ export async function createOAuthClient(data: {
   }
 }
 
+export async function upsertOAuthClient(data: {
+  clientId: string;
+  clientName: string;
+  redirectUris: string[];
+  scopes: string[];
+  clientUri?: string | null;
+  logoUri?: string | null;
+}) {
+  try {
+    const [client] = await db
+      .insert(oauthClients)
+      .values({
+        clientId: data.clientId,
+        clientName: data.clientName,
+        clientUri: data.clientUri || null,
+        logoUri: data.logoUri || null,
+        redirectUris: data.redirectUris,
+        scopes: data.scopes,
+        createdAt: sql`now()`,
+        updatedAt: sql`now()`,
+      })
+      .onConflictDoUpdate({
+        target: oauthClients.clientId,
+        set: {
+          clientName: data.clientName,
+          clientUri: data.clientUri || null,
+          logoUri: data.logoUri || null,
+          redirectUris: data.redirectUris,
+          scopes: data.scopes,
+          updatedAt: sql`now()`,
+        },
+      })
+      .returning();
+    return client;
+  } catch (error) {
+    throw new DatabaseError('oauth_client_upsert_failed', error);
+  }
+}
+
 export async function findOAuthClient(clientId: string) {
   try {
     const [client] = await db


### PR DESCRIPTION
## Summary
- Add client-initiated OAuth client resolution for HTTP MCP authorization.
- Support OAuth Client ID Metadata Document clients and native public reverse-DNS client IDs with private-use redirect URIs.
- Advertise `client_id_metadata_document_supported` in authorization server metadata and add coverage to OAuth/MCP tests.
- Preserve `/oauth/authorize?requestId=...` through login so unauthenticated HTTP MCP authorization returns to the consent page instead of `/home`.

## Why
Some MCP/OAuth clients begin authorization with a stable `client_id` before dynamic registration. Previously those requests failed with `invalid_client`, including native clients using custom redirect schemes.

Unauthenticated users could also lose the original authorization target during login and land on the app home page, which prevented the OAuth consent step from appearing.

## Validation
- `cd server && bun run lint`
- `cd server && bun run build`
- `cd server && POSTGRESQL_URL=postgresql://rote:rote_password_123@localhost:5433/rote TEST_BASE_URL=http://127.0.0.1:3004 bun run tests/oauth-mcp.test.ts`
- `cd web && bun run lint`
- `cd web && bun run build`
- Browser smoke: unauthenticated `/oauth/authorize?requestId=...` redirected to `/login?redirect=...`; after login it returned to `/oauth/authorize?requestId=...` and displayed `拒绝` / `允许`.
