### PR TITLE
[codex] preserve OAuth authorization redirect after login

### DIFF
--- a/server/route/v2/oauth.ts
+++ b/server/route/v2/oauth.ts
@@ -42,6 +42,21 @@ function validateRedirectUrl(redirectUrl: string | null | undefined, defaultUrl:
   return redirectUrl;
 }
 
+function getLoginRedirectUrl(frontendBaseUrl: string, stateData: any | null): URL {
+  return new URL(validateRedirectUrl(stateData?.redirectUrl, '/login'), frontendBaseUrl);
+}
+
+async function extractOptionalStateData(state: string | undefined): Promise<any | null> {
+  if (!state) return null;
+
+  try {
+    return await extractStateData(state);
+  } catch {
+    // Provider cancel callbacks may omit or expire state; route back to the default login page.
+    return null;
+  }
+}
+
 // 获取前端基础 URL
 async function getFrontendBaseUrl(c: HonoContext): Promise<string> {
   const siteConfig = await getConfig<SiteConfig>('site');
@@ -82,7 +97,7 @@ async function handleOAuthError(
       return c.redirect(bindUrl.toString());
     } else {
       // 登录模式错误，重定向到登录页面
-      const loginUrl = new URL('/login', frontendBaseUrl);
+      const loginUrl = getLoginRedirectUrl(frontendBaseUrl, stateData);
       loginUrl.searchParams.set('oauth', 'error');
       loginUrl.searchParams.set('provider', provider);
       loginUrl.searchParams.set('message', userFriendlyMessage);
@@ -98,10 +113,11 @@ async function handleOAuthError(
 async function handleOAuthCancelled(
   c: HonoContext,
   provider: string,
-  _errorCode: string
+  _errorCode: string,
+  stateData: any | null
 ): Promise<Response> {
   const frontendBaseUrl = await getFrontendBaseUrl(c);
-  const loginUrl = new URL('/login', frontendBaseUrl);
+  const loginUrl = getLoginRedirectUrl(frontendBaseUrl, stateData);
   loginUrl.searchParams.set('oauth', 'cancelled');
   loginUrl.searchParams.set('provider', provider);
   return c.redirect(loginUrl.toString());
@@ -277,7 +293,12 @@ async function handleOAuthCallback(c: HonoContext, providerName: string): Promis
     // 处理用户取消授权
     const cancelErrors = ['access_denied', 'user_cancelled_authorize'];
     if (error && cancelErrors.includes(error)) {
-      return await handleOAuthCancelled(c, providerName, error);
+      return await handleOAuthCancelled(
+        c,
+        providerName,
+        error,
+        await extractOptionalStateData(state)
+      );
     }
 
     if (error) {

--- a/web/src/pages/login/index.tsx
+++ b/web/src/pages/login/index.tsx
@@ -7,7 +7,7 @@ import { useAPIGet } from '@/utils/fetcher';
 import {
   getLoginPathWithRedirect,
   getSafeLoginRedirect,
-  isSafeLoginRedirect,
+  isOAuthAuthorizeRedirect,
 } from '@/utils/loginRedirect';
 import { registerWithPasskey } from '@/utils/passkey';
 import { useEffect, useState } from 'react';
@@ -52,7 +52,7 @@ function Login() {
   const [showPasskeyPrompt, setShowPasskeyPrompt] = useState(false);
   const isIosLoginFlow = searchParams.get('type') === 'ioslogin';
   const redirectTarget = searchParams.get('redirect');
-  const hasPostLoginRedirect = isSafeLoginRedirect(redirectTarget);
+  const hasOAuthAuthorizeRedirect = isOAuthAuthorizeRedirect(redirectTarget);
   const postLoginRedirect = getSafeLoginRedirect(searchParams);
 
   // 如果注册被禁用，确保 activeTab 是 'login'
@@ -226,7 +226,7 @@ function Login() {
         if (accessToken && refreshToken) {
           authService.setTokens(accessToken, refreshToken);
 
-          if (isIosLoginFlow || hasPostLoginRedirect) {
+          if (isIosLoginFlow || hasOAuthAuthorizeRedirect) {
             mutateProfile();
             completeAuthenticatedFlow({ accessToken, refreshToken });
           } else if (passkeyEnabled) {

--- a/web/src/pages/login/index.tsx
+++ b/web/src/pages/login/index.tsx
@@ -4,7 +4,11 @@ import { usePasskey } from '@/hooks/usePasskey';
 import { get, getApiUrl, post } from '@/utils/api';
 import { authService } from '@/utils/auth';
 import { useAPIGet } from '@/utils/fetcher';
-import { getLoginPathWithRedirect, getSafeLoginRedirect } from '@/utils/loginRedirect';
+import {
+  getLoginPathWithRedirect,
+  getSafeLoginRedirect,
+  isSafeLoginRedirect,
+} from '@/utils/loginRedirect';
 import { registerWithPasskey } from '@/utils/passkey';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -48,6 +52,7 @@ function Login() {
   const [showPasskeyPrompt, setShowPasskeyPrompt] = useState(false);
   const isIosLoginFlow = searchParams.get('type') === 'ioslogin';
   const redirectTarget = searchParams.get('redirect');
+  const hasPostLoginRedirect = isSafeLoginRedirect(redirectTarget);
   const postLoginRedirect = getSafeLoginRedirect(searchParams);
 
   // 如果注册被禁用，确保 activeTab 是 'login'
@@ -221,7 +226,7 @@ function Login() {
         if (accessToken && refreshToken) {
           authService.setTokens(accessToken, refreshToken);
 
-          if (isIosLoginFlow) {
+          if (isIosLoginFlow || hasPostLoginRedirect) {
             mutateProfile();
             completeAuthenticatedFlow({ accessToken, refreshToken });
           } else if (passkeyEnabled) {

--- a/web/src/pages/login/index.tsx
+++ b/web/src/pages/login/index.tsx
@@ -4,6 +4,7 @@ import { usePasskey } from '@/hooks/usePasskey';
 import { get, getApiUrl, post } from '@/utils/api';
 import { authService } from '@/utils/auth';
 import { useAPIGet } from '@/utils/fetcher';
+import { getLoginPathWithRedirect, getSafeLoginRedirect } from '@/utils/loginRedirect';
 import { registerWithPasskey } from '@/utils/passkey';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -47,10 +48,7 @@ function Login() {
   const [showPasskeyPrompt, setShowPasskeyPrompt] = useState(false);
   const isIosLoginFlow = searchParams.get('type') === 'ioslogin';
   const redirectTarget = searchParams.get('redirect');
-  const postLoginRedirect =
-    redirectTarget && redirectTarget.startsWith('/') && !redirectTarget.startsWith('//')
-      ? redirectTarget
-      : '/home';
+  const postLoginRedirect = getSafeLoginRedirect(searchParams);
 
   // 如果注册被禁用，确保 activeTab 是 'login'
   useEffect(() => {
@@ -110,7 +108,7 @@ function Login() {
     refreshToken?: string | null;
   }) {
     if (!isIosLoginFlow) {
-      navigate(postLoginRedirect);
+      navigate(postLoginRedirect, { replace: true });
       return;
     }
 
@@ -321,7 +319,7 @@ function Login() {
       // OAuth 登录失败
       toast.error(decodeURIComponent(errorMessage));
       // 清除 URL 参数
-      navigate('/login', { replace: true });
+      navigate(getLoginPathWithRedirect(postLoginRedirect), { replace: true });
     } else if (oauthStatus === 'cancelled') {
       // 用户取消授权
       const provider = searchParams.get('provider');
@@ -332,7 +330,7 @@ function Login() {
         toast.info(t('messages.oauthCancelled'));
       }
       // 清除 URL 参数
-      navigate('/login', { replace: true });
+      navigate(getLoginPathWithRedirect(postLoginRedirect), { replace: true });
     }
   }, [searchParams, navigate, mutateProfile, t, isIosLoginFlow, postLoginRedirect]);
 

--- a/web/src/pages/oauth/authorize.tsx
+++ b/web/src/pages/oauth/authorize.tsx
@@ -1,6 +1,7 @@
 import LoadingPlaceholder from '@/components/others/LoadingPlaceholder';
 import { Button } from '@/components/ui/button';
 import { authService } from '@/utils/auth';
+import { getCurrentRedirectPath, getLoginPathWithRedirect } from '@/utils/loginRedirect';
 import {
   getOAuthAuthorizeSession,
   submitOAuthAuthorizeDecision,
@@ -11,10 +12,6 @@ import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { toast } from 'sonner';
-
-function getLoginRedirectPath() {
-  return `${window.location.pathname}${window.location.search}`;
-}
 
 function getScopeLabelKey(scope: string) {
   return scope.replaceAll(':', '_');
@@ -103,7 +100,7 @@ export default function OAuthAuthorizePage() {
     }
 
     if (!authService.hasValidAccessToken() && !authService.hasValidRefreshToken()) {
-      navigate(`/login?redirect=${encodeURIComponent(getLoginRedirectPath())}`, { replace: true });
+      navigate(getLoginPathWithRedirect(getCurrentRedirectPath()), { replace: true });
       return;
     }
 
@@ -115,9 +112,7 @@ export default function OAuthAuthorizePage() {
       })
       .catch((err: any) => {
         if (err?.response?.status === 401) {
-          navigate(`/login?redirect=${encodeURIComponent(getLoginRedirectPath())}`, {
-            replace: true,
-          });
+          navigate(getLoginPathWithRedirect(getCurrentRedirectPath()), { replace: true });
           return;
         }
         setError(err?.response?.data?.message || err?.message || t('errors.loadFailed'));

--- a/web/src/route/main.tsx
+++ b/web/src/route/main.tsx
@@ -2,6 +2,7 @@ import LoadingPlaceholder from '@/components/others/LoadingPlaceholder';
 import ScrollPositionManager from '@/components/ScrollPositionManager';
 import LayoutDashboard from '@/layout/dashboard';
 import { useAuthState } from '@/state/profile';
+import { getSafeLoginRedirect } from '@/utils/loginRedirect';
 import { createBrowserRouter, Navigate, Outlet, RouterProvider } from 'react-router-dom';
 import { ProtectedRoute } from './protectedRoute';
 
@@ -38,13 +39,6 @@ function RootLayout() {
       <Outlet />
     </>
   );
-}
-
-function getSafeLoginRedirect(search: string) {
-  const redirectTarget = new URLSearchParams(search).get('redirect');
-  return redirectTarget && redirectTarget.startsWith('/') && !redirectTarget.startsWith('//')
-    ? redirectTarget
-    : '/home';
 }
 
 function LoginRouteEntry() {

--- a/web/src/route/protectedRoute.tsx
+++ b/web/src/route/protectedRoute.tsx
@@ -1,12 +1,14 @@
 import LoadingPlaceholder from '@/components/others/LoadingPlaceholder';
 import { useAuthState } from '@/state/profile';
+import { getLoginPathWithRedirect } from '@/utils/loginRedirect';
 import MobileDetect from 'mobile-detect';
 import { useEffect, useState } from 'react';
-import { Navigate } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router-dom';
 import { toast } from 'sonner';
 
 export const ProtectedRoute = ({ children }: any) => {
   const { tokenValid, isAuthPending } = useAuthState();
+  const location = useLocation();
   const [iosSafariToastDone, setIosSafariToastDone] = useState(
     localStorage.getItem('iosSafariToastDone') === 'true'
   );
@@ -44,5 +46,9 @@ export const ProtectedRoute = ({ children }: any) => {
     return <LoadingPlaceholder className="h-dvh w-full" size={6} />;
   }
 
-  return tokenValid ? children : <Navigate to="/login" />;
+  return tokenValid ? (
+    children
+  ) : (
+    <Navigate replace to={getLoginPathWithRedirect(`${location.pathname}${location.search}`)} />
+  );
 };

--- a/web/src/utils/loginRedirect.ts
+++ b/web/src/utils/loginRedirect.ts
@@ -17,6 +17,20 @@ export function getCurrentRedirectPath() {
   return `${window.location.pathname}${window.location.search}${window.location.hash}`;
 }
 
+export function isOAuthAuthorizeRedirect(value: string | null | undefined): value is string {
+  if (!isSafeLoginRedirect(value)) return false;
+
+  try {
+    const redirectUrl = new URL(value, window.location.origin);
+    return (
+      redirectUrl.pathname === '/oauth/authorize' &&
+      Boolean(redirectUrl.searchParams.get('requestId'))
+    );
+  } catch {
+    return false;
+  }
+}
+
 export function getLoginPathWithRedirect(redirectPath: string = getCurrentRedirectPath()) {
   return isSafeLoginRedirect(redirectPath)
     ? `/login?redirect=${encodeURIComponent(redirectPath)}`

--- a/web/src/utils/loginRedirect.ts
+++ b/web/src/utils/loginRedirect.ts
@@ -1,0 +1,24 @@
+const DEFAULT_LOGIN_REDIRECT = '/home';
+
+export function isSafeLoginRedirect(value: string | null | undefined): value is string {
+  return Boolean(value && value.startsWith('/') && !value.startsWith('//'));
+}
+
+export function getSafeLoginRedirect(
+  search: string | URLSearchParams,
+  fallback = DEFAULT_LOGIN_REDIRECT
+) {
+  const params = typeof search === 'string' ? new URLSearchParams(search) : search;
+  const redirectTarget = params.get('redirect');
+  return isSafeLoginRedirect(redirectTarget) ? redirectTarget : fallback;
+}
+
+export function getCurrentRedirectPath() {
+  return `${window.location.pathname}${window.location.search}${window.location.hash}`;
+}
+
+export function getLoginPathWithRedirect(redirectPath: string = getCurrentRedirectPath()) {
+  return isSafeLoginRedirect(redirectPath)
+    ? `/login?redirect=${encodeURIComponent(redirectPath)}`
+    : '/login';
+}


### PR DESCRIPTION
## Summary
- Centralize safe login redirect parsing and login URL generation.
- Return unauthenticated HTTP MCP authorization users to `/oauth/authorize?requestId=...` after password/passkey/OAuth login instead of `/home`.
- Return users to the authorization page after registration when the login page has an OAuth authorization redirect target, and avoid interrupting that flow with the optional passkey setup prompt.
- Keep the normal optional passkey setup prompt for ordinary registration redirects such as `/home` or `/profile`.
- Preserve redirect context when protected routes send users to login and when third-party OAuth login fails or is cancelled.

## Why
When an HTTP MCP OAuth authorization starts while the user is logged out, the frontend sends them to `/login?redirect=...`. Some login and registration paths could still lose that target, fall back to the app home page, or pause on optional setup UI, preventing the consent screen from appearing.

OAuth provider error and cancel callbacks also need to restore the login URL stored in the signed state token so the nested authorization redirect survives unsuccessful third-party login attempts.

## Validation
- `cd server && bun run lint`
- `cd server && bun run build`
- `cd web && bun run lint`
- `cd web && bun run build`
- Browser smoke on local backend/frontend: unauthenticated `/oauth/authorize?requestId=...` redirected to `/login?redirect=...`; after login it returned to `/oauth/authorize?requestId=...` and displayed `拒绝` / `允许`.
- Browser smoke on local backend/frontend: unauthenticated authorization flow opened the registration tab; after registration it returned directly to `/oauth/authorize?requestId=...` and displayed `拒绝` / `允许` without showing the optional passkey setup prompt.
