### PR TITLE
Validate AI retrieval time ranges

### DIFF
--- a/server/route/v2/ai.ts
+++ b/server/route/v2/ai.ts
@@ -421,8 +421,9 @@ aiRouter.post('/agent/stream', authenticateJWT, bodyTypeCheck, async (c: HonoCon
         emit: (event) => writeAgentSseEvent(stream, event),
       });
     } catch (error: any) {
+      console.error('AI agent stream failed:', error);
       await writeSseEvent(stream, 'error', {
-        message: error?.message || 'AI agent stream failed',
+        message: 'AI agent stream failed',
       });
     }
   });
@@ -462,8 +463,9 @@ aiRouter.post('/chat/stream', authenticateJWT, bodyTypeCheck, async (c: HonoCont
         await writeSseEvent(stream, 'done', {});
       }
     } catch (error: any) {
+      console.error('AI stream failed:', error);
       await writeSseEvent(stream, 'error', {
-        message: error?.message || 'AI stream failed',
+        message: 'AI stream failed',
       });
     }
   });

--- a/server/tests/aiRetrievalPlanner.test.ts
+++ b/server/tests/aiRetrievalPlanner.test.ts
@@ -110,8 +110,44 @@ describe('canonicalizeSearchRotesArgs', () => {
       from: '2026-01-01T00:00:00+08:00',
       to: '2026-01-03T23:59:59+08:00',
     });
+    expect(
+      canonicalizeTimeRange({
+        from: '2026-01-01T08:00:00+08:00',
+        to: '2026-01-03T18:30:00+08:00',
+      })
+    ).toMatchObject({
+      from: '2026-01-01T08:00:00+08:00',
+      to: '2026-01-03T18:30:00+08:00',
+    });
     expect(canonicalizeTimeRange({ timeExpression: '今天' })?.label).toBe('今天');
     expect(canonicalizeTimeRange({ timeExpression: '最近7天' })?.label).toBe('最近7天');
+  });
+
+  it('normalizes structured relative from/to ranges before SQL use', () => {
+    const range = canonicalizeTimeRange({ from: '60 days ago', to: '30 days ago' });
+
+    expect(range?.from).toMatch(/^\d{4}-\d{2}-\d{2}T00:00:00\+08:00$/);
+    expect(range?.to).toMatch(/^\d{4}-\d{2}-\d{2}T23:59:59\+08:00$/);
+    expect(range?.from).not.toContain('days ago');
+    expect(range?.to).not.toContain('days ago');
+    expect(Date.parse(range?.from || '')).toBeLessThan(Date.parse(range?.to || ''));
+  });
+
+  it('ignores invalid time ranges instead of passing them through', () => {
+    const warnings: string[] = [];
+
+    expect(canonicalizeTimeRange({ from: 'sixty days ago', to: '30 days ago' }, warnings)).toBe(
+      null
+    );
+    expect(warnings).toContain('invalid_time_range_ignored');
+
+    const scoped = canonicalizeSearchRotesArgs({
+      ownerId: 'u1',
+      availableTags: AVAILABLE_TAGS,
+      args: { from: '2026-02-30', to: '2026-03-01' },
+    });
+    expect(scoped.scope.timeRange).toBeNull();
+    expect(scoped.warnings).toContain('invalid_time_range_ignored');
   });
 
   it('clamps limit and validates sourceTypes', () => {

--- a/server/tests/aiRetrievalPlanner.test.ts
+++ b/server/tests/aiRetrievalPlanner.test.ts
@@ -133,6 +133,43 @@ describe('canonicalizeSearchRotesArgs', () => {
     expect(Date.parse(range?.from || '')).toBeLessThan(Date.parse(range?.to || ''));
   });
 
+  it('prefers structured timeRange DSL over free-text fields', () => {
+    expect(
+      canonicalizeTimeRange({
+        timeRange: { type: 'absolute', fromDate: '2026-05-08', toDate: '2026-05-09' },
+        from: 'bad input',
+        to: 'also bad',
+      })
+    ).toMatchObject({
+      from: '2026-05-08T00:00:00+08:00',
+      to: '2026-05-09T23:59:59+08:00',
+    });
+
+    const rolling = canonicalizeTimeRange({
+      timeRange: { type: 'rolling', amount: 7, unit: 'day' },
+    });
+    expect(rolling?.from).toMatch(/^\d{4}-\d{2}-\d{2}T00:00:00\+08:00$/);
+    expect(rolling?.to).toMatch(/^\d{4}-\d{2}-\d{2}T23:59:59\+08:00$/);
+    expect(rolling?.label).toBe('last 7 days');
+
+    const relativeBetween = canonicalizeTimeRange({
+      timeRange: {
+        type: 'relative_between',
+        fromRelative: { amount: 60, unit: 'day', direction: 'ago' },
+        toRelative: { amount: 30, unit: 'day', direction: 'ago' },
+      },
+    });
+    expect(relativeBetween?.from).toMatch(/T00:00:00\+08:00$/);
+    expect(relativeBetween?.to).toMatch(/T23:59:59\+08:00$/);
+    expect(Date.parse(relativeBetween?.from || '')).toBeLessThan(
+      Date.parse(relativeBetween?.to || '')
+    );
+
+    expect(canonicalizeTimeRange({ timeRange: { type: 'preset', preset: 'today' } })?.label).toBe(
+      '今天'
+    );
+  });
+
   it('ignores invalid time ranges instead of passing them through', () => {
     const warnings: string[] = [];
 
@@ -148,6 +185,14 @@ describe('canonicalizeSearchRotesArgs', () => {
     });
     expect(scoped.scope.timeRange).toBeNull();
     expect(scoped.warnings).toContain('invalid_time_range_ignored');
+
+    const dslScoped = canonicalizeSearchRotesArgs({
+      ownerId: 'u1',
+      availableTags: AVAILABLE_TAGS,
+      args: { timeRange: { type: 'rolling', amount: 0, unit: 'day' } },
+    });
+    expect(dslScoped.scope.timeRange).toBeNull();
+    expect(dslScoped.warnings).toContain('invalid_time_range_ignored');
   });
 
   it('clamps limit and validates sourceTypes', () => {

--- a/server/tests/aiRetrievalPlanner.test.ts
+++ b/server/tests/aiRetrievalPlanner.test.ts
@@ -170,6 +170,33 @@ describe('canonicalizeSearchRotesArgs', () => {
     );
   });
 
+  it('honors structured timeRange type when extra fields are present', () => {
+    expect(
+      canonicalizeTimeRange({
+        timeRange: {
+          type: 'absolute',
+          fromDate: '2026-05-08',
+          toDate: '2026-05-09',
+          unit: 'day',
+        },
+      })
+    ).toMatchObject({
+      from: '2026-05-08T00:00:00+08:00',
+      to: '2026-05-09T23:59:59+08:00',
+    });
+
+    expect(
+      canonicalizeTimeRange({
+        timeRange: {
+          type: 'absolute',
+          preset: 'today',
+          fromDate: '2026-05-08',
+          toDate: '2026-05-09',
+        },
+      })?.label
+    ).toBe('2026-05-08 到 2026-05-09');
+  });
+
   it('ignores invalid time ranges instead of passing them through', () => {
     const warnings: string[] = [];
 

--- a/server/utils/ai/agent/tools.ts
+++ b/server/utils/ai/agent/tools.ts
@@ -113,6 +113,10 @@ function parseSearchNotesInput(args: unknown, fallbackQuery: string): SearchRote
       ? uniqueStrings(raw.excludeTags)
       : uniqueStrings(tags.exclude),
     semanticScope: uniqueStrings(raw.semanticScope),
+    timeRange:
+      raw.timeRange && typeof raw.timeRange === 'object' && !Array.isArray(raw.timeRange)
+        ? raw.timeRange
+        : undefined,
     timeExpression: typeof raw.timeExpression === 'string' ? raw.timeExpression.trim() : undefined,
     from: typeof raw.from === 'string' ? raw.from.trim() : undefined,
     to: typeof raw.to === 'string' ? raw.to.trim() : undefined,
@@ -441,6 +445,56 @@ export function getNativeRoteTools(): RoteAgentTool[] {
                 items: { type: 'string' },
                 description:
                   'Soft topic keywords for semantic retrieval. Use for themes and patterns that are not verified tags.',
+              },
+              timeRange: {
+                type: 'object',
+                description:
+                  'Preferred structured time range. Use this instead of free-text from/to for dates.',
+                properties: {
+                  type: {
+                    type: 'string',
+                    enum: ['absolute', 'rolling', 'relative_between', 'preset'],
+                  },
+                  preset: {
+                    type: 'string',
+                    enum: ['today', 'yesterday', 'this_month', 'last_month'],
+                  },
+                  fromDate: {
+                    type: 'string',
+                    description:
+                      'For absolute ranges only. ISO date/datetime such as 2026-05-08 or 2026-05-08T00:00:00+08:00.',
+                  },
+                  toDate: {
+                    type: 'string',
+                    description:
+                      'For absolute ranges only. ISO date/datetime such as 2026-05-09 or 2026-05-09T23:59:59+08:00.',
+                  },
+                  amount: { type: 'number', description: 'For rolling ranges, e.g. 7.' },
+                  unit: {
+                    type: 'string',
+                    enum: ['day', 'week', 'month', 'year'],
+                    description: 'For rolling ranges.',
+                  },
+                  fromRelative: {
+                    type: 'object',
+                    description: 'For relative_between ranges, e.g. 60 days ago.',
+                    properties: {
+                      amount: { type: 'number' },
+                      unit: { type: 'string', enum: ['day', 'week', 'month', 'year'] },
+                      direction: { type: 'string', enum: ['ago'] },
+                    },
+                  },
+                  toRelative: {
+                    type: 'object',
+                    description: 'For relative_between ranges, e.g. 30 days ago.',
+                    properties: {
+                      amount: { type: 'number' },
+                      unit: { type: 'string', enum: ['day', 'week', 'month', 'year'] },
+                      direction: { type: 'string', enum: ['ago'] },
+                    },
+                  },
+                  label: { type: 'string' },
+                },
               },
               timeExpression: {
                 type: 'string',

--- a/server/utils/ai/agent/tools.ts
+++ b/server/utils/ai/agent/tools.ts
@@ -442,9 +442,21 @@ export function getNativeRoteTools(): RoteAgentTool[] {
                 description:
                   'Soft topic keywords for semantic retrieval. Use for themes and patterns that are not verified tags.',
               },
-              timeExpression: { type: 'string' },
-              from: { type: 'string' },
-              to: { type: 'string' },
+              timeExpression: {
+                type: 'string',
+                description:
+                  'Relative range expression such as today, yesterday, last 7 days, or 最近7天.',
+              },
+              from: {
+                type: 'string',
+                description:
+                  'Absolute ISO date/datetime only, such as 2026-05-08 or 2026-05-08T00:00:00+08:00. Use timeExpression for relative ranges.',
+              },
+              to: {
+                type: 'string',
+                description:
+                  'Absolute ISO date/datetime only, such as 2026-05-09 or 2026-05-09T23:59:59+08:00. Use timeExpression for relative ranges.',
+              },
               lifecycleScope: {
                 type: 'string',
                 enum: Array.from(VALID_LIFECYCLE_SCOPES),

--- a/server/utils/ai/retrievalPlan.ts
+++ b/server/utils/ai/retrievalPlan.ts
@@ -21,6 +21,27 @@ export interface NormalizedTimeRange {
   label: string;
 }
 
+export type StructuredTimeRangeType = 'absolute' | 'rolling' | 'relative_between' | 'preset';
+export type StructuredTimeRangePreset = 'today' | 'yesterday' | 'this_month' | 'last_month';
+
+export interface StructuredRelativeTimePoint {
+  amount?: number;
+  unit?: AiTimeUnit;
+  direction?: 'ago';
+}
+
+export interface StructuredTimeRange {
+  type?: StructuredTimeRangeType;
+  preset?: StructuredTimeRangePreset;
+  fromDate?: string;
+  toDate?: string;
+  amount?: number;
+  unit?: AiTimeUnit;
+  fromRelative?: StructuredRelativeTimePoint;
+  toRelative?: StructuredRelativeTimePoint;
+  label?: string;
+}
+
 export interface RetrievalScope {
   ownerId: string;
   query: string;
@@ -42,6 +63,7 @@ export interface SearchRotesArgs {
   excludeTags?: string[];
   semanticScope?: string[];
   sourceTypes?: AiSourceType[];
+  timeRange?: StructuredTimeRange;
   timeExpression?: string;
   from?: string;
   to?: string;
@@ -119,6 +141,19 @@ const VALID_LIFECYCLE_SCOPES = new Set<LifecycleScope>([
   'unspecified',
 ]);
 const VALID_TASK_STATUS_SCOPES = new Set<TaskStatusScope>(['open', 'closed', 'all', 'unspecified']);
+const VALID_STRUCTURED_TIME_TYPES = new Set<StructuredTimeRangeType>([
+  'absolute',
+  'rolling',
+  'relative_between',
+  'preset',
+]);
+const VALID_STRUCTURED_TIME_PRESETS = new Set<StructuredTimeRangePreset>([
+  'today',
+  'yesterday',
+  'this_month',
+  'last_month',
+]);
+const VALID_STRUCTURED_TIME_UNITS = new Set<AiTimeUnit>(['day', 'week', 'month', 'year']);
 const DEFAULT_LIMIT = 15;
 const MAX_LIMIT = 50;
 const MAX_STEPS = 6;
@@ -415,10 +450,138 @@ export function normalizeTimeRangeInput(value: unknown): NormalizedTimeRange | n
   };
 }
 
+function normalizeStructuredTimeUnit(value: unknown): AiTimeUnit | null {
+  if (typeof value !== 'string') return null;
+  const unit = value.trim().toLowerCase();
+  if (unit === 'days') return 'day';
+  if (unit === 'weeks') return 'week';
+  if (unit === 'months') return 'month';
+  if (unit === 'years') return 'year';
+  return VALID_STRUCTURED_TIME_UNITS.has(unit as AiTimeUnit) ? (unit as AiTimeUnit) : null;
+}
+
+function normalizeStructuredAmount(value: unknown): number | null {
+  const amount = Number(value);
+  if (!Number.isFinite(amount)) return null;
+  const normalized = Math.floor(amount);
+  return normalized >= 1 && normalized <= 10000 ? normalized : null;
+}
+
+function structuredLabel(raw: Record<string, unknown>, fallback: string): string {
+  return typeof raw.label === 'string' && raw.label.trim() ? raw.label.trim() : fallback;
+}
+
+function formatRelativePointLabel(point: Record<string, unknown>): string {
+  const amount = normalizeStructuredAmount(point.amount) || 0;
+  const unit = normalizeStructuredTimeUnit(point.unit) || 'day';
+  return `${amount} ${unit}${amount === 1 ? '' : 's'} ago`;
+}
+
+function normalizeStructuredRelativePoint(value: unknown, end = false): string | null {
+  const point = asRecord(value);
+  const amount = normalizeStructuredAmount(point.amount);
+  const unit = normalizeStructuredTimeUnit(point.unit);
+  const direction = typeof point.direction === 'string' ? point.direction.trim() : 'ago';
+  if (!amount || !unit || direction !== 'ago') return null;
+
+  const date = addRelativeOffset(getShanghaiToday(), amount, unit);
+  return end ? endOfDay(date) : startOfDay(date);
+}
+
+function canonicalizePresetTimeRange(
+  preset: StructuredTimeRangePreset,
+  raw: Record<string, unknown>
+): NormalizedTimeRange {
+  const today = getShanghaiToday();
+  if (preset === 'today') {
+    return { from: startOfDay(today), to: endOfDay(today), label: structuredLabel(raw, '今天') };
+  }
+  if (preset === 'yesterday') {
+    const yesterday = addDays(today, -1);
+    return {
+      from: startOfDay(yesterday),
+      to: endOfDay(yesterday),
+      label: structuredLabel(raw, '昨天'),
+    };
+  }
+  if (preset === 'this_month') {
+    const start = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 1));
+    return {
+      from: startOfDay(start),
+      to: endOfDay(today),
+      label: structuredLabel(raw, '本月'),
+    };
+  }
+  const range = monthRange(today.getUTCFullYear(), today.getUTCMonth() - 1, '上个月');
+  return { ...range, label: structuredLabel(raw, range.label) };
+}
+
+function canonicalizeStructuredTimeRange(value: unknown): NormalizedTimeRange | null {
+  const raw = asRecord(value);
+  if (!Object.keys(raw).length) return null;
+
+  const type = VALID_STRUCTURED_TIME_TYPES.has(raw.type as StructuredTimeRangeType)
+    ? (raw.type as StructuredTimeRangeType)
+    : undefined;
+  const preset = VALID_STRUCTURED_TIME_PRESETS.has(raw.preset as StructuredTimeRangePreset)
+    ? (raw.preset as StructuredTimeRangePreset)
+    : undefined;
+
+  if (type === 'preset' || preset) {
+    if (!preset) return null;
+    return canonicalizePresetTimeRange(preset, raw);
+  }
+
+  if (type === 'rolling' || raw.amount !== undefined || raw.unit !== undefined) {
+    const amount = normalizeStructuredAmount(raw.amount);
+    const unit = normalizeStructuredTimeUnit(raw.unit);
+    if (!amount || !unit) return null;
+    const today = getShanghaiToday();
+    const start = addRelativeOffset(today, amount, unit);
+    return {
+      from: startOfDay(start),
+      to: endOfDay(today),
+      label: structuredLabel(raw, `last ${amount} ${unit}${amount === 1 ? '' : 's'}`),
+    };
+  }
+
+  if (type === 'relative_between' || raw.fromRelative || raw.toRelative) {
+    const from = normalizeStructuredRelativePoint(raw.fromRelative);
+    const to = normalizeStructuredRelativePoint(raw.toRelative, true);
+    if (!from || !to || !isOrderedTimeRange(from, to)) return null;
+    return {
+      from,
+      to,
+      label: structuredLabel(
+        raw,
+        `${formatRelativePointLabel(asRecord(raw.fromRelative))} 到 ${formatRelativePointLabel(
+          asRecord(raw.toRelative)
+        )}`
+      ),
+    };
+  }
+
+  if (type === 'absolute' || raw.fromDate !== undefined || raw.toDate !== undefined) {
+    return normalizeTimeRangeInput({
+      from: raw.fromDate,
+      to: raw.toDate,
+      label: raw.label,
+    });
+  }
+
+  return null;
+}
+
 export function canonicalizeTimeRange(
   args: SearchRotesArgs,
   warnings?: string[]
 ): NormalizedTimeRange | null {
+  if (args.timeRange !== undefined) {
+    const structured = canonicalizeStructuredTimeRange(args.timeRange);
+    if (structured) return structured;
+    warnings?.push('invalid_time_range_ignored');
+  }
+
   const from = typeof args.from === 'string' ? args.from.trim() : '';
   const to = typeof args.to === 'string' ? args.to.trim() : '';
   if (from && to) {
@@ -559,6 +722,56 @@ function plannerTools(): ChatToolDefinition[] {
             excludeTags: { type: 'array', items: { type: 'string' } },
             semanticScope: { type: 'array', items: { type: 'string' } },
             sourceTypes: { type: 'array', items: { type: 'string', enum: ['rote', 'article'] } },
+            timeRange: {
+              type: 'object',
+              description:
+                'Preferred structured time range. Use this instead of free-text from/to for dates.',
+              properties: {
+                type: {
+                  type: 'string',
+                  enum: ['absolute', 'rolling', 'relative_between', 'preset'],
+                },
+                preset: {
+                  type: 'string',
+                  enum: ['today', 'yesterday', 'this_month', 'last_month'],
+                },
+                fromDate: {
+                  type: 'string',
+                  description:
+                    'For absolute ranges only. ISO date/datetime such as 2026-05-08 or 2026-05-08T00:00:00+08:00.',
+                },
+                toDate: {
+                  type: 'string',
+                  description:
+                    'For absolute ranges only. ISO date/datetime such as 2026-05-09 or 2026-05-09T23:59:59+08:00.',
+                },
+                amount: { type: 'number', description: 'For rolling ranges, e.g. 7.' },
+                unit: {
+                  type: 'string',
+                  enum: ['day', 'week', 'month', 'year'],
+                  description: 'For rolling ranges.',
+                },
+                fromRelative: {
+                  type: 'object',
+                  description: 'For relative_between ranges, e.g. 60 days ago.',
+                  properties: {
+                    amount: { type: 'number' },
+                    unit: { type: 'string', enum: ['day', 'week', 'month', 'year'] },
+                    direction: { type: 'string', enum: ['ago'] },
+                  },
+                },
+                toRelative: {
+                  type: 'object',
+                  description: 'For relative_between ranges, e.g. 30 days ago.',
+                  properties: {
+                    amount: { type: 'number' },
+                    unit: { type: 'string', enum: ['day', 'week', 'month', 'year'] },
+                    direction: { type: 'string', enum: ['ago'] },
+                  },
+                },
+                label: { type: 'string' },
+              },
+            },
             timeExpression: {
               type: 'string',
               description:

--- a/server/utils/ai/retrievalPlan.ts
+++ b/server/utils/ai/retrievalPlan.ts
@@ -123,6 +123,12 @@ const DEFAULT_LIMIT = 15;
 const MAX_LIMIT = 50;
 const MAX_STEPS = 6;
 const MAX_TOOL_CALLS = 10;
+const DATE_ONLY_RE = /^(\d{4})[-/.](\d{1,2})[-/.](\d{1,2})$/;
+const ISO_DATE_TIME_WITH_ZONE_RE =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2})(\.\d{1,3})?)?(Z|[+-]\d{2}:\d{2})$/;
+const RELATIVE_POINT_RE =
+  /^(\d+|[一二两三四五六七八九十]+)\s*(天|日|周|星期|个月|月|年|days?|weeks?|months?|years?)\s*ago$/i;
+const RELATIVE_POINT_ZH_RE = /^(\d+|[一二两三四五六七八九十]+)\s*(天|日|周|星期|个月|月|年)前$/;
 
 function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value)
@@ -254,6 +260,36 @@ function monthRange(year: number, monthIndex: number, label: string): Normalized
   return { from: startOfDay(start), to: endOfDay(end), label };
 }
 
+function isValidDateParts(year: number, month: number, day: number): boolean {
+  if (!Number.isInteger(year) || year < 1000 || year > 9999) return false;
+  if (!Number.isInteger(month) || month < 1 || month > 12) return false;
+  const maxDay = new Date(Date.UTC(year, month, 0)).getUTCDate();
+  return Number.isInteger(day) && day >= 1 && day <= maxDay;
+}
+
+function isValidTimeParts(hour: number, minute: number, second: number): boolean {
+  return (
+    Number.isInteger(hour) &&
+    hour >= 0 &&
+    hour <= 23 &&
+    Number.isInteger(minute) &&
+    minute >= 0 &&
+    minute <= 59 &&
+    Number.isInteger(second) &&
+    second >= 0 &&
+    second <= 59
+  );
+}
+
+function isValidTimezoneOffset(value: string): boolean {
+  if (value === 'Z') return true;
+  const match = value.match(/^([+-])(\d{2}):(\d{2})$/);
+  if (!match) return false;
+  const hours = Number(match[2]);
+  const minutes = Number(match[3]);
+  return hours >= 0 && hours <= 23 && minutes >= 0 && minutes <= 59;
+}
+
 function chineseNumberToInt(value: string): number | null {
   const numeric = Number(value);
   if (Number.isFinite(numeric)) return Math.max(1, Math.floor(numeric));
@@ -280,21 +316,115 @@ function chineseNumberToInt(value: string): number | null {
   return null;
 }
 
-function normalizeDateInput(value: string, end = false): string {
-  const normalized = value.trim().replace(/[/.]/g, '-');
-  if (normalized.includes('T')) return normalized;
-  return `${normalized}${end ? 'T23:59:59+08:00' : 'T00:00:00+08:00'}`;
+function unitTextToUnit(value: string): AiTimeUnit {
+  const unitText = value.toLowerCase();
+  return unitText === '天' || unitText === '日' || unitText.startsWith('day')
+    ? 'day'
+    : unitText === '周' || unitText === '星期' || unitText.startsWith('week')
+      ? 'week'
+      : unitText === '年' || unitText.startsWith('year')
+        ? 'year'
+        : 'month';
 }
 
-export function canonicalizeTimeRange(args: SearchRotesArgs): NormalizedTimeRange | null {
+function addRelativeOffset(date: Date, amount: number, unit: AiTimeUnit): Date {
+  if (unit === 'month') return addMonths(date, -amount);
+  if (unit === 'year') return addMonths(date, -amount * 12);
+  return addDays(date, -(unit === 'day' ? amount : amount * 7));
+}
+
+function parseRelativePointDate(value: string): Date | null {
+  const match = value.trim().match(RELATIVE_POINT_RE) || value.trim().match(RELATIVE_POINT_ZH_RE);
+  if (!match) return null;
+
+  const amount = chineseNumberToInt(match[1]);
+  if (!amount || amount > 10000) return null;
+  return addRelativeOffset(getShanghaiToday(), amount, unitTextToUnit(match[2]));
+}
+
+function normalizeDateOnlyInput(value: string, end = false): string | null {
+  const match = value.trim().match(DATE_ONLY_RE);
+  if (!match) return null;
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  if (!isValidDateParts(year, month, day)) return null;
+
+  return `${year}-${pad(month)}-${pad(day)}${end ? 'T23:59:59+08:00' : 'T00:00:00+08:00'}`;
+}
+
+function normalizeIsoDateTimeInput(value: string): string | null {
+  const normalized = value.trim();
+  const match = normalized.match(ISO_DATE_TIME_WITH_ZONE_RE);
+  if (!match) return null;
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const hour = Number(match[4]);
+  const minute = Number(match[5]);
+  const second = match[6] ? Number(match[6]) : 0;
+  const zone = match[8];
+
+  if (!isValidDateParts(year, month, day)) return null;
+  if (!isValidTimeParts(hour, minute, second)) return null;
+  if (!isValidTimezoneOffset(zone)) return null;
+  if (!Number.isFinite(Date.parse(normalized))) return null;
+
+  return normalized;
+}
+
+function normalizeDateInput(value: string, end = false): string | null {
+  const normalized = value.trim();
+  if (!normalized) return null;
+  if (normalized.includes('T')) return normalizeIsoDateTimeInput(normalized);
+
+  const dateOnly = normalizeDateOnlyInput(normalized, end);
+  if (dateOnly) return dateOnly;
+
+  const relativePoint = parseRelativePointDate(normalized);
+  if (relativePoint) return end ? endOfDay(relativePoint) : startOfDay(relativePoint);
+
+  return null;
+}
+
+function isOrderedTimeRange(from: string, to: string): boolean {
+  const fromTime = Date.parse(from);
+  const toTime = Date.parse(to);
+  return Number.isFinite(fromTime) && Number.isFinite(toTime) && fromTime <= toTime;
+}
+
+export function normalizeTimeRangeInput(value: unknown): NormalizedTimeRange | null {
+  const raw = asRecord(value);
+  const from = typeof raw.from === 'string' ? raw.from.trim() : '';
+  const to = typeof raw.to === 'string' ? raw.to.trim() : '';
+  if (!from || !to) return null;
+
+  const normalizedFrom = normalizeDateInput(from);
+  const normalizedTo = normalizeDateInput(to, true);
+  if (!normalizedFrom || !normalizedTo || !isOrderedTimeRange(normalizedFrom, normalizedTo)) {
+    return null;
+  }
+
+  return {
+    from: normalizedFrom,
+    to: normalizedTo,
+    label:
+      typeof raw.label === 'string' && raw.label.trim() ? raw.label.trim() : `${from} 到 ${to}`,
+  };
+}
+
+export function canonicalizeTimeRange(
+  args: SearchRotesArgs,
+  warnings?: string[]
+): NormalizedTimeRange | null {
   const from = typeof args.from === 'string' ? args.from.trim() : '';
   const to = typeof args.to === 'string' ? args.to.trim() : '';
   if (from && to) {
-    return {
-      from: normalizeDateInput(from),
-      to: normalizeDateInput(to, true),
-      label: `${from} 到 ${to}`,
-    };
+    const normalized = normalizeTimeRangeInput({ from, to, label: `${from} 到 ${to}` });
+    if (!normalized) warnings?.push('invalid_time_range_ignored');
+    return normalized;
   }
 
   const expression = typeof args.timeExpression === 'string' ? args.timeExpression.trim() : '';
@@ -317,27 +447,12 @@ export function canonicalizeTimeRange(args: SearchRotesArgs): NormalizedTimeRang
   }
 
   const rollingMatch = expression.match(
-    /(?:最近|近|过去|前)\s*(\d+|[一二两三四五六七八九十]+)\s*(天|日|周|星期|个月|月|年|days?|weeks?|months?|years?)/i
+    /(?:最近|近|过去|前|last|past|previous|recent)\s*(\d+|[一二两三四五六七八九十]+)\s*(天|日|周|星期|个月|月|年|days?|weeks?|months?|years?)/i
   );
   if (rollingMatch) {
     const amount = chineseNumberToInt(rollingMatch[1]);
-    const unitText = rollingMatch[2].toLowerCase();
-    const unit: AiTimeUnit =
-      unitText === '天' || unitText === '日' || unitText.startsWith('day')
-        ? 'day'
-        : unitText === '周' || unitText === '星期' || unitText.startsWith('week')
-          ? 'week'
-          : unitText === '年' || unitText.startsWith('year')
-            ? 'year'
-            : 'month';
     if (amount) {
-      const start =
-        unit === 'month'
-          ? addMonths(today, -amount)
-          : addDays(
-              today,
-              -(unit === 'day' ? amount : unit === 'week' ? amount * 7 : amount * 365)
-            );
+      const start = addRelativeOffset(today, amount, unitTextToUnit(rollingMatch[2]));
       return { from: startOfDay(start), to: endOfDay(today), label: rollingMatch[0] };
     }
   }
@@ -346,11 +461,13 @@ export function canonicalizeTimeRange(args: SearchRotesArgs): NormalizedTimeRang
     /(\d{4}[-/.]\d{1,2}[-/.]\d{1,2})\s*(?:到|至|~|-|—)\s*(\d{4}[-/.]\d{1,2}[-/.]\d{1,2})/
   );
   if (explicitRange) {
-    return {
-      from: normalizeDateInput(explicitRange[1]),
-      to: normalizeDateInput(explicitRange[2], true),
+    const normalized = normalizeTimeRangeInput({
+      from: explicitRange[1],
+      to: explicitRange[2],
       label: explicitRange[0],
-    };
+    });
+    if (!normalized) warnings?.push('invalid_time_range_ignored');
+    return normalized;
   }
 
   return null;
@@ -393,7 +510,7 @@ export function canonicalizeSearchRotesArgs(params: {
     excludeTags: Array.from(new Set(excludeTags)),
     semanticScope: Array.from(semanticScope).slice(0, 30),
     sourceTypes: normalizeSourceTypes(params.args.sourceTypes, warnings),
-    timeRange: canonicalizeTimeRange(params.args),
+    timeRange: canonicalizeTimeRange(params.args, warnings),
     lifecycleScope: normalizeLifecycleScope(params.args.lifecycleScope),
     taskStatusScope: normalizeTaskStatusScope(params.args.taskStatusScope),
     limit: clampLimit(params.args.limit),
@@ -442,9 +559,21 @@ function plannerTools(): ChatToolDefinition[] {
             excludeTags: { type: 'array', items: { type: 'string' } },
             semanticScope: { type: 'array', items: { type: 'string' } },
             sourceTypes: { type: 'array', items: { type: 'string', enum: ['rote', 'article'] } },
-            timeExpression: { type: 'string' },
-            from: { type: 'string' },
-            to: { type: 'string' },
+            timeExpression: {
+              type: 'string',
+              description:
+                'Relative range expression such as today, yesterday, last 7 days, or 最近7天.',
+            },
+            from: {
+              type: 'string',
+              description:
+                'Absolute ISO date/datetime only, such as 2026-05-08 or 2026-05-08T00:00:00+08:00. Use timeExpression for relative ranges.',
+            },
+            to: {
+              type: 'string',
+              description:
+                'Absolute ISO date/datetime only, such as 2026-05-09 or 2026-05-09T23:59:59+08:00. Use timeExpression for relative ranges.',
+            },
             lifecycleScope: {
               type: 'string',
               enum: ['active', 'archived', 'all', 'unspecified'],

--- a/server/utils/ai/retrievalPlan.ts
+++ b/server/utils/ai/retrievalPlan.ts
@@ -527,12 +527,12 @@ function canonicalizeStructuredTimeRange(value: unknown): NormalizedTimeRange | 
     ? (raw.preset as StructuredTimeRangePreset)
     : undefined;
 
-  if (type === 'preset' || preset) {
+  const parsePreset = () => {
     if (!preset) return null;
     return canonicalizePresetTimeRange(preset, raw);
-  }
+  };
 
-  if (type === 'rolling' || raw.amount !== undefined || raw.unit !== undefined) {
+  const parseRolling = () => {
     const amount = normalizeStructuredAmount(raw.amount);
     const unit = normalizeStructuredTimeUnit(raw.unit);
     if (!amount || !unit) return null;
@@ -543,9 +543,9 @@ function canonicalizeStructuredTimeRange(value: unknown): NormalizedTimeRange | 
       to: endOfDay(today),
       label: structuredLabel(raw, `last ${amount} ${unit}${amount === 1 ? '' : 's'}`),
     };
-  }
+  };
 
-  if (type === 'relative_between' || raw.fromRelative || raw.toRelative) {
+  const parseRelativeBetween = () => {
     const from = normalizeStructuredRelativePoint(raw.fromRelative);
     const to = normalizeStructuredRelativePoint(raw.toRelative, true);
     if (!from || !to || !isOrderedTimeRange(from, to)) return null;
@@ -559,15 +559,26 @@ function canonicalizeStructuredTimeRange(value: unknown): NormalizedTimeRange | 
         )}`
       ),
     };
-  }
+  };
 
-  if (type === 'absolute' || raw.fromDate !== undefined || raw.toDate !== undefined) {
-    return normalizeTimeRangeInput({
+  const parseAbsolute = () =>
+    normalizeTimeRangeInput({
       from: raw.fromDate,
       to: raw.toDate,
       label: raw.label,
     });
+
+  if (type) {
+    if (type === 'absolute') return parseAbsolute();
+    if (type === 'rolling') return parseRolling();
+    if (type === 'relative_between') return parseRelativeBetween();
+    return parsePreset();
   }
+
+  if (preset) return parsePreset();
+  if (raw.fromRelative || raw.toRelative) return parseRelativeBetween();
+  if (raw.amount !== undefined || raw.unit !== undefined) return parseRolling();
+  if (raw.fromDate !== undefined || raw.toDate !== undefined) return parseAbsolute();
 
   return null;
 }

--- a/server/utils/dbMethods/ai.ts
+++ b/server/utils/dbMethods/ai.ts
@@ -21,6 +21,7 @@ import { DEFAULT_AI_CONFIG, mergeAiConfig } from '../ai/providers';
 import {
   createRetrievalPlan,
   lifecycleScopeToArchived,
+  normalizeTimeRangeInput,
   toPlannerAgentDto,
   type NormalizedTimeRange,
   type PlannerAgentDto,
@@ -137,6 +138,16 @@ function normalizeEmbeddingDimensions(value: number): number {
 function normalizeLimit(limit?: number): number {
   if (!limit || Number.isNaN(limit)) return 10;
   return Math.min(Math.max(Math.floor(limit), 1), MAX_VECTOR_SEARCH_LIMIT);
+}
+
+function normalizeSearchTimeRange(timeRange?: NormalizedTimeRange | null): {
+  timeRange: NormalizedTimeRange | null;
+  warnings: string[];
+} {
+  if (!timeRange) return { timeRange: null, warnings: [] };
+  const normalized = normalizeTimeRangeInput(timeRange);
+  if (normalized) return { timeRange: normalized, warnings: [] };
+  return { timeRange: null, warnings: ['invalid_time_range_ignored'] };
 }
 
 function buildTextArraySql(values: string[]) {
@@ -766,6 +777,7 @@ export async function semanticSearch(params: {
       (params.sourceTypes || ['rote', 'article']).filter((type) => VALID_SOURCE_TYPES.has(type))
     )
   );
+  const { timeRange } = normalizeSearchTimeRange(params.timeRange);
   const vectorLiteral = vectorToLiteral(queryEmbedding);
   const sourceTypeSql =
     sourceTypes.length === 1
@@ -813,12 +825,12 @@ export async function semanticSearch(params: {
     typeof params.archived === 'boolean'
       ? sql`AND de."sourceType" = 'rote' AND r."archived" = ${params.archived}`
       : sql``;
-  const timeRangeSql = params.timeRange
+  const timeRangeSql = timeRange
     ? sql`
       AND (
-        (de."sourceType" = 'rote' AND r."createdAt" >= ${params.timeRange.from}::timestamptz AND r."createdAt" <= ${params.timeRange.to}::timestamptz)
+        (de."sourceType" = 'rote' AND r."createdAt" >= ${timeRange.from}::timestamptz AND r."createdAt" <= ${timeRange.to}::timestamptz)
         OR
-        (de."sourceType" = 'article' AND a."createdAt" >= ${params.timeRange.from}::timestamptz AND a."createdAt" <= ${params.timeRange.to}::timestamptz)
+        (de."sourceType" = 'article' AND a."createdAt" >= ${timeRange.from}::timestamptz AND a."createdAt" <= ${timeRange.to}::timestamptz)
       )
     `
     : sql``;
@@ -1022,6 +1034,7 @@ export async function textSearchMemory(params: {
 }): Promise<SemanticSearchResult[]> {
   if (!params.ownerId) return [];
   const limit = normalizeLimit(params.limit);
+  const { timeRange } = normalizeSearchTimeRange(params.timeRange);
   const sourceTypes = new Set(
     (params.sourceTypes || ['rote', 'article']).filter((type) => VALID_SOURCE_TYPES.has(type))
   );
@@ -1080,7 +1093,7 @@ export async function textSearchMemory(params: {
           ${excludeTagsSql}
           ${stateSql}
           ${archivedSql}
-          ${buildTextSearchTimeSql('r', params.timeRange)}
+          ${buildTextSearchTimeSql('r', timeRange)}
           ${excludeSql}
         ORDER BY r."updatedAt" DESC
         LIMIT ${limit}
@@ -1107,7 +1120,7 @@ export async function textSearchMemory(params: {
         FROM "articles" a
         WHERE a."authorId" = ${params.ownerId}
           ${buildArticleTextTermSql(activeTerms)}
-          ${buildTextSearchTimeSql('a', params.timeRange)}
+          ${buildTextSearchTimeSql('a', timeRange)}
           ${excludeSql}
         ORDER BY a."updatedAt" DESC
         LIMIT ${limit}
@@ -1142,13 +1155,15 @@ export async function searchMemoryWithFallback(params: {
   exclude?: { sourceType: AiSourceType; sourceId: string };
   excludeIds?: string[];
 }): Promise<{ sources: SemanticSearchResult[]; warnings: string[] }> {
+  const { timeRange, warnings } = normalizeSearchTimeRange(params.timeRange);
+  const safeParams = { ...params, timeRange };
   try {
-    return { sources: await semanticSearch(params), warnings: [] };
+    return { sources: await semanticSearch(safeParams), warnings };
   } catch (error: any) {
     if (params.scope === 'public') throw error;
     return {
-      sources: await textSearchMemory(params),
-      warnings: [`semantic_search_fallback_text:${error?.message || 'unknown_error'}`],
+      sources: await textSearchMemory(safeParams),
+      warnings: [...warnings, 'semantic_search_fallback_text'],
     };
   }
 }

--- a/server/utils/handlers.ts
+++ b/server/utils/handlers.ts
@@ -1,5 +1,19 @@
 import { HonoContext } from '../types/hono';
 
+function containsSensitiveServerDetails(message: string): boolean {
+  const normalized = message.toLowerCase();
+  return (
+    normalized.includes('postgres') ||
+    normalized.includes('timestamptz') ||
+    normalized.includes('timestamp with time zone') ||
+    normalized.includes('invalid input syntax for type') ||
+    normalized.includes('sql') ||
+    /\b(select|insert|update|delete|with|from|where|join|returning)\b/.test(normalized) ||
+    /\b(userid|user_id|user id|ownerid|owner_id)\b/i.test(message) ||
+    /\$\d+/.test(message)
+  );
+}
+
 export const errorHandler = async (err: Error, c: HonoContext) => {
   console.error('API Error:', err.message);
 
@@ -156,7 +170,7 @@ export const errorHandler = async (err: Error, c: HonoContext) => {
     return c.json(
       {
         code: 1,
-        message: err.message,
+        message: containsSensitiveServerDetails(err.message) ? 'Invalid request' : err.message,
         data: null,
       },
       400
@@ -218,10 +232,13 @@ export const errorHandler = async (err: Error, c: HonoContext) => {
   }
 
   // Default server error
+  const defaultMessage = err.message || 'Internal server error';
   return c.json(
     {
       code: 1,
-      message: err.message || 'Internal server error',
+      message: containsSensitiveServerDetails(defaultMessage)
+        ? 'Internal server error'
+        : defaultMessage,
       data: null,
     },
     500


### PR DESCRIPTION
## Summary
- Strictly normalize AI retrieval time ranges before SQL uses them.
- Add a preferred structured `timeRange` DSL for model tool calls: `absolute`, `rolling`, `relative_between`, and `preset`.
- Keep legacy `from`/`to`/`timeExpression` compatibility, but make structured `timeRange` take priority.
- Convert exact structured relative points like `60 days ago` to absolute Asia/Shanghai day bounds, and ignore invalid ranges with `invalid_time_range_ignored`.
- Revalidate time ranges at semantic/text search boundaries and stop returning raw fallback errors or SSE SQL details to clients.

## Root Cause
The retrieval planner trusted model-provided `from`/`to` strings and appended day bounds to any non-ISO input, which could turn `60 days ago` into `60 days agoT00:00:00+08:00` before casting it as `timestamptz` in Postgres.

## Fix Approach
Model output remains untrusted. The backend now prefers a bounded, typed time-range intent object, converts it deterministically to `NormalizedTimeRange`, and validates again before SQL. If parsing fails, the time filter is ignored rather than executed.

## Validation
- `bun run lint`
- `bun run build`
- `POSTGRESQL_URL=postgres://rote:rote_password_123@localhost:5433/rote bun test tests/aiRetrievalPlanner.test.ts`