### PR TITLE
Add web AI client time context

### DIFF
--- a/server/utils/ai/agent/clientRuntime.ts
+++ b/server/utils/ai/agent/clientRuntime.ts
@@ -4,6 +4,7 @@ import type { ChatToolCall } from '../client';
 import { getNativeRoteTools } from './tools';
 import {
   DEFAULT_AGENT_POLICY,
+  type RoteAgentClientContext,
   type RoteAgentClientState,
   type RoteAgentContext,
   type RoteAgentRequest,
@@ -12,6 +13,42 @@ import {
 
 function sourceKey(source: SemanticSearchResult): string {
   return `${source.sourceType}:${source.sourceId}`;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function sanitizeString(value: unknown, maxLength: number): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed.slice(0, maxLength) : undefined;
+}
+
+function sanitizeUtcOffsetMinutes(value: unknown): number | undefined {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return undefined;
+  const minutes = Math.trunc(numeric);
+  return minutes >= -14 * 60 && minutes <= 14 * 60 ? minutes : undefined;
+}
+
+function sanitizeClientContext(value: unknown): RoteAgentClientContext | null {
+  const raw = asRecord(value);
+  if (!Object.keys(raw).length) return null;
+
+  const context: RoteAgentClientContext = {
+    nowIso: sanitizeString(raw.nowIso, 64),
+    localDate: sanitizeString(raw.localDate, 32),
+    localDateTime: sanitizeString(raw.localDateTime, 64),
+    timeZone: sanitizeString(raw.timeZone, 80),
+    utcOffsetMinutes: sanitizeUtcOffsetMinutes(raw.utcOffsetMinutes),
+    locale: sanitizeString(raw.locale, 32),
+    calendar: sanitizeString(raw.calendar, 32),
+  };
+
+  return Object.values(context).some((item) => item !== undefined) ? context : null;
 }
 
 class ClientSourceCollector {
@@ -85,6 +122,7 @@ function sanitizeRequest(value: unknown): RoteAgentRequest {
     pendingPlan: request.pendingPlan,
     clarificationAnswer:
       typeof request.clarificationAnswer === 'string' ? request.clarificationAnswer : undefined,
+    clientContext: sanitizeClientContext(request.clientContext),
   };
 }
 
@@ -100,6 +138,7 @@ function sanitizeState(value: unknown): RoteAgentClientState {
           .slice(0, 500)
       : [],
     selectedContext: state.selectedContext || null,
+    clientContext: sanitizeClientContext(state.clientContext),
     stateVersion: Number.isFinite(state.stateVersion) ? Number(state.stateVersion) : 1,
   };
 }
@@ -121,6 +160,9 @@ export async function executeClientRoteTool(params: {
 
   const request = sanitizeRequest(params.request);
   const state = sanitizeState(params.state);
+  if (!state.clientContext && request.clientContext) {
+    state.clientContext = request.clientContext;
+  }
   const collector = new ClientSourceCollector(params.sourceKeys);
   const call: ChatToolCall = {
     id: `client_${Date.now()}_${Math.random().toString(16).slice(2)}`,

--- a/server/utils/ai/agent/toolDefinitions.ts
+++ b/server/utils/ai/agent/toolDefinitions.ts
@@ -1,0 +1,200 @@
+import type { ChatToolDefinition } from '../client';
+import type { LifecycleScope, TaskStatusScope } from '../retrievalPlan';
+import { NATIVE_ROTE_SKILLS } from './skills';
+
+export function createSkillViewToolDefinition(): ChatToolDefinition {
+  return {
+    type: 'function',
+    function: {
+      name: 'rote_skill_view',
+      description: 'Load the workflow and safety notes for a built-in Rote AI skill.',
+      parameters: {
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string',
+            enum: NATIVE_ROTE_SKILLS.map((skill) => skill.name),
+          },
+        },
+        required: ['name'],
+      },
+    },
+  };
+}
+
+export function createSearchNotesToolDefinition(params: {
+  lifecycleScopes: LifecycleScope[];
+  taskStatusScopes: TaskStatusScope[];
+}): ChatToolDefinition {
+  return {
+    type: 'function',
+    function: {
+      name: 'rote_search_notes',
+      description:
+        'Search the current user Rote notes and articles with Rote-aware filters. Use this before answering questions that depend on memory.',
+      parameters: {
+        type: 'object',
+        properties: {
+          query: {
+            type: 'string',
+            description:
+              'Semantic evidence query. For broad analysis, write a broad useful query; leave empty only for pure hard-filter browsing.',
+          },
+          tags: {
+            type: 'array',
+            items: { type: 'string' },
+          },
+          excludeTags: {
+            type: 'array',
+            items: { type: 'string' },
+          },
+          semanticScope: {
+            type: 'array',
+            items: { type: 'string' },
+            description:
+              'Soft topic keywords for semantic retrieval. Use for themes and patterns that are not verified tags.',
+          },
+          timeRange: {
+            type: 'object',
+            description:
+              'Preferred structured time range. Use this instead of free-text from/to for dates.',
+            properties: {
+              type: {
+                type: 'string',
+                enum: ['absolute', 'rolling', 'relative_between', 'preset'],
+              },
+              preset: {
+                type: 'string',
+                enum: ['today', 'yesterday', 'this_month', 'last_month'],
+              },
+              fromDate: {
+                type: 'string',
+                description:
+                  'For absolute ranges only. ISO date/datetime such as 2026-05-08 or 2026-05-08T00:00:00+08:00.',
+              },
+              toDate: {
+                type: 'string',
+                description:
+                  'For absolute ranges only. ISO date/datetime such as 2026-05-09 or 2026-05-09T23:59:59+08:00.',
+              },
+              amount: { type: 'number', description: 'For rolling ranges, e.g. 7.' },
+              unit: {
+                type: 'string',
+                enum: ['day', 'week', 'month', 'year'],
+                description: 'For rolling ranges.',
+              },
+              fromRelative: {
+                type: 'object',
+                description: 'For relative_between ranges, e.g. 60 days ago.',
+                properties: {
+                  amount: { type: 'number' },
+                  unit: { type: 'string', enum: ['day', 'week', 'month', 'year'] },
+                  direction: { type: 'string', enum: ['ago'] },
+                },
+              },
+              toRelative: {
+                type: 'object',
+                description: 'For relative_between ranges, e.g. 30 days ago.',
+                properties: {
+                  amount: { type: 'number' },
+                  unit: { type: 'string', enum: ['day', 'week', 'month', 'year'] },
+                  direction: { type: 'string', enum: ['ago'] },
+                },
+              },
+              label: { type: 'string' },
+            },
+          },
+          timeExpression: {
+            type: 'string',
+            description:
+              'Relative range expression such as today, yesterday, last 7 days, or 最近7天.',
+          },
+          from: {
+            type: 'string',
+            description:
+              'Absolute ISO date/datetime only, such as 2026-05-08 or 2026-05-08T00:00:00+08:00. Use timeExpression for relative ranges.',
+          },
+          to: {
+            type: 'string',
+            description:
+              'Absolute ISO date/datetime only, such as 2026-05-09 or 2026-05-09T23:59:59+08:00. Use timeExpression for relative ranges.',
+          },
+          lifecycleScope: {
+            type: 'string',
+            enum: params.lifecycleScopes,
+            description:
+              'Note lifecycle scope only: active for unarchived notes, archived for archived notes, all for both, unspecified if not asked.',
+          },
+          taskStatusScope: {
+            type: 'string',
+            enum: params.taskStatusScopes,
+            description:
+              'Task/open-loop semantic scope only. This is independent from lifecycleScope and does not map to archived.',
+          },
+          sourceTypes: {
+            type: 'array',
+            items: { type: 'string', enum: ['rote', 'article'] },
+          },
+          limit: {
+            type: 'number',
+            description:
+              'Final source count to return. Choose a larger value for broad pattern analysis and a smaller value for focused lookup.',
+          },
+          cursor: {
+            type: 'string',
+            description: 'Opaque cursor returned by a previous rote_search_notes call.',
+          },
+        },
+        required: ['query'],
+      },
+    },
+  };
+}
+
+export const GET_NOTE_TOOL_DEFINITION: ChatToolDefinition = {
+  type: 'function',
+  function: {
+    name: 'rote_get_note',
+    description: 'Read more context for one Rote source owned by the current user.',
+    parameters: {
+      type: 'object',
+      properties: {
+        sourceType: { type: 'string', enum: ['rote', 'article'] },
+        sourceId: { type: 'string' },
+        reason: { type: 'string' },
+      },
+      required: ['sourceType', 'sourceId'],
+    },
+  },
+};
+
+export const FIND_RELATED_NOTES_TOOL_DEFINITION: ChatToolDefinition = {
+  type: 'function',
+  function: {
+    name: 'rote_find_related_notes',
+    description: 'Find related Rote notes for a source owned by the current user.',
+    parameters: {
+      type: 'object',
+      properties: {
+        sourceType: { type: 'string', enum: ['rote', 'article'] },
+        sourceId: { type: 'string' },
+        limit: { type: 'number' },
+      },
+      required: ['sourceType', 'sourceId'],
+    },
+  },
+};
+
+export const GET_TAGS_TOOL_DEFINITION: ChatToolDefinition = {
+  type: 'function',
+  function: {
+    name: 'rote_get_tags',
+    description: 'List the current user tags and counts.',
+    parameters: {
+      type: 'object',
+      properties: {
+        limit: { type: 'number' },
+      },
+    },
+  },
+};

--- a/server/utils/ai/agent/tools.ts
+++ b/server/utils/ai/agent/tools.ts
@@ -20,6 +20,13 @@ import {
   type TaskStatusScope,
 } from '../retrievalPlan';
 import { getNativeRoteSkill, NATIVE_ROTE_SKILLS } from './skills';
+import {
+  FIND_RELATED_NOTES_TOOL_DEFINITION,
+  GET_NOTE_TOOL_DEFINITION,
+  GET_TAGS_TOOL_DEFINITION,
+  createSearchNotesToolDefinition,
+  createSkillViewToolDefinition,
+} from './toolDefinitions';
 import type {
   RoteAgentContext,
   RoteAgentSourceRegistration,
@@ -159,6 +166,7 @@ async function executeAgentSearch(
       ...(ctx.request.excludeIds || []),
       ...(ctx.state.seenSourceIds || []),
     ]),
+    timeContext: ctx.state.clientContext,
   });
   const probe = await searchRotesProbe(scope);
   const toolResult = {
@@ -398,203 +406,26 @@ async function executeSkillView(args: unknown): Promise<RoteAgentToolResult> {
 export function getNativeRoteTools(): RoteAgentTool[] {
   return [
     {
-      definition: {
-        type: 'function',
-        function: {
-          name: 'rote_skill_view',
-          description: 'Load the workflow and safety notes for a built-in Rote AI skill.',
-          parameters: {
-            type: 'object',
-            properties: {
-              name: {
-                type: 'string',
-                enum: NATIVE_ROTE_SKILLS.map((skill) => skill.name),
-              },
-            },
-            required: ['name'],
-          },
-        },
-      },
+      definition: createSkillViewToolDefinition(),
       execute: executeSkillView,
     },
     {
-      definition: {
-        type: 'function',
-        function: {
-          name: 'rote_search_notes',
-          description:
-            'Search the current user Rote notes and articles with Rote-aware filters. Use this before answering questions that depend on memory.',
-          parameters: {
-            type: 'object',
-            properties: {
-              query: {
-                type: 'string',
-                description:
-                  'Semantic evidence query. For broad analysis, write a broad useful query; leave empty only for pure hard-filter browsing.',
-              },
-              tags: {
-                type: 'array',
-                items: { type: 'string' },
-              },
-              excludeTags: {
-                type: 'array',
-                items: { type: 'string' },
-              },
-              semanticScope: {
-                type: 'array',
-                items: { type: 'string' },
-                description:
-                  'Soft topic keywords for semantic retrieval. Use for themes and patterns that are not verified tags.',
-              },
-              timeRange: {
-                type: 'object',
-                description:
-                  'Preferred structured time range. Use this instead of free-text from/to for dates.',
-                properties: {
-                  type: {
-                    type: 'string',
-                    enum: ['absolute', 'rolling', 'relative_between', 'preset'],
-                  },
-                  preset: {
-                    type: 'string',
-                    enum: ['today', 'yesterday', 'this_month', 'last_month'],
-                  },
-                  fromDate: {
-                    type: 'string',
-                    description:
-                      'For absolute ranges only. ISO date/datetime such as 2026-05-08 or 2026-05-08T00:00:00+08:00.',
-                  },
-                  toDate: {
-                    type: 'string',
-                    description:
-                      'For absolute ranges only. ISO date/datetime such as 2026-05-09 or 2026-05-09T23:59:59+08:00.',
-                  },
-                  amount: { type: 'number', description: 'For rolling ranges, e.g. 7.' },
-                  unit: {
-                    type: 'string',
-                    enum: ['day', 'week', 'month', 'year'],
-                    description: 'For rolling ranges.',
-                  },
-                  fromRelative: {
-                    type: 'object',
-                    description: 'For relative_between ranges, e.g. 60 days ago.',
-                    properties: {
-                      amount: { type: 'number' },
-                      unit: { type: 'string', enum: ['day', 'week', 'month', 'year'] },
-                      direction: { type: 'string', enum: ['ago'] },
-                    },
-                  },
-                  toRelative: {
-                    type: 'object',
-                    description: 'For relative_between ranges, e.g. 30 days ago.',
-                    properties: {
-                      amount: { type: 'number' },
-                      unit: { type: 'string', enum: ['day', 'week', 'month', 'year'] },
-                      direction: { type: 'string', enum: ['ago'] },
-                    },
-                  },
-                  label: { type: 'string' },
-                },
-              },
-              timeExpression: {
-                type: 'string',
-                description:
-                  'Relative range expression such as today, yesterday, last 7 days, or 最近7天.',
-              },
-              from: {
-                type: 'string',
-                description:
-                  'Absolute ISO date/datetime only, such as 2026-05-08 or 2026-05-08T00:00:00+08:00. Use timeExpression for relative ranges.',
-              },
-              to: {
-                type: 'string',
-                description:
-                  'Absolute ISO date/datetime only, such as 2026-05-09 or 2026-05-09T23:59:59+08:00. Use timeExpression for relative ranges.',
-              },
-              lifecycleScope: {
-                type: 'string',
-                enum: Array.from(VALID_LIFECYCLE_SCOPES),
-                description:
-                  'Note lifecycle scope only: active for unarchived notes, archived for archived notes, all for both, unspecified if not asked.',
-              },
-              taskStatusScope: {
-                type: 'string',
-                enum: Array.from(VALID_TASK_STATUS_SCOPES),
-                description:
-                  'Task/open-loop semantic scope only. This is independent from lifecycleScope and does not map to archived.',
-              },
-              sourceTypes: {
-                type: 'array',
-                items: { type: 'string', enum: ['rote', 'article'] },
-              },
-              limit: {
-                type: 'number',
-                description:
-                  'Final source count to return. Choose a larger value for broad pattern analysis and a smaller value for focused lookup.',
-              },
-              cursor: {
-                type: 'string',
-                description: 'Opaque cursor returned by a previous rote_search_notes call.',
-              },
-            },
-            required: ['query'],
-          },
-        },
-      },
+      definition: createSearchNotesToolDefinition({
+        lifecycleScopes: Array.from(VALID_LIFECYCLE_SCOPES),
+        taskStatusScopes: Array.from(VALID_TASK_STATUS_SCOPES),
+      }),
       execute: executeSearchNotes,
     },
     {
-      definition: {
-        type: 'function',
-        function: {
-          name: 'rote_get_note',
-          description: 'Read more context for one Rote source owned by the current user.',
-          parameters: {
-            type: 'object',
-            properties: {
-              sourceType: { type: 'string', enum: ['rote', 'article'] },
-              sourceId: { type: 'string' },
-              reason: { type: 'string' },
-            },
-            required: ['sourceType', 'sourceId'],
-          },
-        },
-      },
+      definition: GET_NOTE_TOOL_DEFINITION,
       execute: executeGetNote,
     },
     {
-      definition: {
-        type: 'function',
-        function: {
-          name: 'rote_find_related_notes',
-          description: 'Find related Rote notes for a source owned by the current user.',
-          parameters: {
-            type: 'object',
-            properties: {
-              sourceType: { type: 'string', enum: ['rote', 'article'] },
-              sourceId: { type: 'string' },
-              limit: { type: 'number' },
-            },
-            required: ['sourceType', 'sourceId'],
-          },
-        },
-      },
+      definition: FIND_RELATED_NOTES_TOOL_DEFINITION,
       execute: executeFindRelatedNotes,
     },
     {
-      definition: {
-        type: 'function',
-        function: {
-          name: 'rote_get_tags',
-          description: 'List the current user tags and counts.',
-          parameters: {
-            type: 'object',
-            properties: {
-              limit: { type: 'number' },
-            },
-          },
-        },
-      },
+      definition: GET_TAGS_TOOL_DEFINITION,
       execute: executeGetTags,
     },
   ];

--- a/web/src/utils/aiApi.ts
+++ b/web/src/utils/aiApi.ts
@@ -172,6 +172,7 @@ export interface AiAgentClientState {
     selectedSourceIds?: string[];
     selectedTags?: string[];
   } | null;
+  clientContext?: AiClientRequestContext | null;
   stateVersion?: number;
 }
 
@@ -243,9 +244,86 @@ export type AiChatPayload = {
   excludeIds?: string[];
   history?: { role: 'user' | 'assistant'; content: string }[];
   state?: AiAgentClientState | null;
+  clientContext?: AiClientRequestContext | null;
   debug?: boolean;
   enableThinking?: boolean;
 };
+
+export interface AiClientRequestContext {
+  nowIso: string;
+  localDate: string;
+  localDateTime: string;
+  timeZone?: string;
+  utcOffsetMinutes: number;
+  locale?: string;
+  calendar?: string;
+}
+
+function padDatePart(value: number): string {
+  return String(value).padStart(2, '0');
+}
+
+function formatUtcOffset(minutes: number): string {
+  const sign = minutes >= 0 ? '+' : '-';
+  const absolute = Math.abs(minutes);
+  return `${sign}${padDatePart(Math.floor(absolute / 60))}:${padDatePart(absolute % 60)}`;
+}
+
+export function createAiClientRequestContext(now = new Date()): AiClientRequestContext {
+  const resolvedOptions = Intl.DateTimeFormat().resolvedOptions();
+  const utcOffsetMinutes = -now.getTimezoneOffset();
+  const localDate = [
+    now.getFullYear(),
+    padDatePart(now.getMonth() + 1),
+    padDatePart(now.getDate()),
+  ].join('-');
+  const localTime = [
+    padDatePart(now.getHours()),
+    padDatePart(now.getMinutes()),
+    padDatePart(now.getSeconds()),
+  ].join(':');
+
+  return {
+    nowIso: now.toISOString(),
+    localDate,
+    localDateTime: `${localDate}T${localTime}${formatUtcOffset(utcOffsetMinutes)}`,
+    timeZone: resolvedOptions.timeZone,
+    utcOffsetMinutes,
+    locale: typeof navigator !== 'undefined' ? navigator.language : resolvedOptions.locale,
+    calendar: resolvedOptions.calendar,
+  };
+}
+
+export function buildAiClientTimeContextMessage(context: AiClientRequestContext): string {
+  return [
+    'Use the current request time context for relative date phrases.',
+    `Client now (UTC): ${context.nowIso}`,
+    `Client local date: ${context.localDate}`,
+    `Client local date/time: ${context.localDateTime}`,
+    context.timeZone ? `Client time zone: ${context.timeZone}` : null,
+    `Client UTC offset minutes: ${context.utcOffsetMinutes}`,
+    context.locale ? `Client locale: ${context.locale}` : null,
+    context.calendar ? `Client calendar: ${context.calendar}` : null,
+    'Resolve relative date phrases such as today, yesterday, this month, last month, 最近, 本月, and 上月 using this context.',
+    'For Rote search tools, prefer structured timeRange preset/rolling/relative_between or pass the original phrase as timeExpression. Use from/to only for explicit absolute dates.',
+  ]
+    .filter((line): line is string => Boolean(line))
+    .join('\n');
+}
+
+export function withAiClientRequestContext(payload: AiChatPayload): AiChatPayload {
+  const clientContext = payload.clientContext || createAiClientRequestContext();
+  return {
+    ...payload,
+    clientContext,
+    state: payload.state
+      ? {
+          ...payload.state,
+          clientContext: payload.state.clientContext || clientContext,
+        }
+      : payload.state,
+  };
+}
 
 export const getClientAgentBootstrap = () =>
   get('/ai/client-agent/bootstrap').then((res) => res.data as ClientAgentBootstrap);
@@ -256,14 +334,26 @@ export const executeClientAgentTool = (payload: {
   request: AiChatPayload;
   state?: AiAgentClientState | null;
   sourceKeys?: string[];
-}) =>
-  post('/ai/client-agent/tools/execute', payload).then((res) => res.data as ClientAgentToolResult);
+}) => {
+  const request = withAiClientRequestContext(payload.request);
+  return post('/ai/client-agent/tools/execute', {
+    ...payload,
+    request,
+    state: payload.state
+      ? {
+          ...payload.state,
+          clientContext: payload.state.clientContext || request.clientContext,
+        }
+      : payload.state,
+  }).then((res) => res.data as ClientAgentToolResult);
+};
 
 async function createAiStreamRequest(
   endpoint: '/ai/chat/stream' | '/ai/agent/stream',
   payload: AiChatPayload,
   signal?: AbortSignal
 ) {
+  const requestPayload = withAiClientRequestContext(payload);
   let token = authService.getAccessToken();
   const request = () =>
     fetch(`${getApiUrl()}${endpoint}`, {
@@ -272,7 +362,7 @@ async function createAiStreamRequest(
         'Content-Type': 'application/json',
         ...(token ? { Authorization: `Bearer ${token}` } : {}),
       },
-      body: JSON.stringify(payload),
+      body: JSON.stringify(requestPayload),
       signal,
     });
 

--- a/web/src/utils/localAiAgent.test.ts
+++ b/web/src/utils/localAiAgent.test.ts
@@ -5,6 +5,15 @@ const mocks = vi.hoisted(() => ({
   complete: vi.fn(),
   bootstrap: vi.fn(),
   executeTool: vi.fn(),
+  clientContext: {
+    nowIso: '2026-07-07T14:14:35.000Z',
+    localDate: '2026-07-07',
+    localDateTime: '2026-07-07T22:14:35+08:00',
+    timeZone: 'Asia/Shanghai',
+    utcOffsetMinutes: 480,
+    locale: 'zh-CN',
+    calendar: 'gregory',
+  },
 }));
 
 vi.mock('@/utils/localAi', () => ({
@@ -14,6 +23,23 @@ vi.mock('@/utils/localAi', () => ({
 vi.mock('@/utils/aiApi', () => ({
   getClientAgentBootstrap: mocks.bootstrap,
   executeClientAgentTool: mocks.executeTool,
+  withAiClientRequestContext: (payload: {
+    clientContext?: unknown;
+    state?: { clientContext?: unknown } | null;
+  }) => {
+    const clientContext = payload.clientContext || mocks.clientContext;
+    return {
+      ...payload,
+      clientContext,
+      state: payload.state
+        ? {
+            ...payload.state,
+            clientContext: payload.state.clientContext || clientContext,
+          }
+        : payload.state,
+    };
+  },
+  buildAiClientTimeContextMessage: () => 'Client time context for tests',
 }));
 
 const config = {
@@ -105,7 +131,11 @@ describe('local AI agent', () => {
       expect.objectContaining({ enableThinking: true })
     );
     expect(mocks.executeTool).toHaveBeenCalledWith(
-      expect.objectContaining({ toolName: 'rote_get_tags', arguments: {} })
+      expect.objectContaining({
+        toolName: 'rote_get_tags',
+        arguments: {},
+        request: expect.objectContaining({ clientContext: mocks.clientContext }),
+      })
     );
     expect(onDelta).toHaveBeenCalledWith('final answer');
   });

--- a/web/src/utils/localAiAgent.ts
+++ b/web/src/utils/localAiAgent.ts
@@ -1,7 +1,9 @@
 import type { PersonalAiProviderConfig } from '@/state/localAi';
 import {
+  buildAiClientTimeContextMessage,
   executeClientAgentTool,
   getClientAgentBootstrap,
+  withAiClientRequestContext,
   type AiAgentClientState,
   type AiChatPayload,
   type AiChatStreamHandlers,
@@ -40,18 +42,23 @@ export async function localAiAgentStream(params: {
   enableThinking: boolean;
   signal?: AbortSignal;
 }) {
+  const payload = withAiClientRequestContext(params.payload);
+  const clientContext = payload.clientContext;
   const bootstrap = params.toolsAvailable ? await getClientAgentBootstrap() : null;
   const messages: LocalChatMessage[] = [
     {
       role: 'system',
       content: bootstrap?.systemPrompt || PERSONAL_ASSISTANT_PROMPT,
     },
-    ...(params.payload.history || []).slice(-8),
-    { role: 'user', content: params.payload.message },
+    ...(clientContext
+      ? [{ role: 'system' as const, content: buildAiClientTimeContextMessage(clientContext) }]
+      : []),
+    ...(payload.history || []).slice(-8),
+    { role: 'user', content: payload.message },
   ];
   const sourceMap = new Map<string, AiSemanticResult>();
   let sourceKeys: string[] = [];
-  let state: AiAgentClientState = params.payload.state || { stateVersion: 1, seenSourceIds: [] };
+  let state: AiAgentClientState = payload.state || { stateVersion: 1, seenSourceIds: [] };
   let toolCallCount = 0;
   let hasAnswer = false;
   const availableToolNames = new Set(bootstrap?.tools.map((tool) => tool.function.name) || []);
@@ -142,7 +149,7 @@ export async function localAiAgentStream(params: {
       const result = await executeClientAgentTool({
         toolName: call.function.name,
         arguments: args,
-        request: params.payload,
+        request: payload,
         state,
         sourceKeys,
       });


### PR DESCRIPTION
## Summary
- Include browser local time context in Web AI chat and agent stream payloads
- Add the same request time context to Web personal AI prompts
- Preserve clientContext through client-agent tool execution for local AI tool mode

## Verification
- web: bun run lint
- web: bun run build
- server: bun run lint
- server: bun run build