### PR TITLE
fix: enforce recent memory retrieval scope

### DIFF
--- a/server/route/v2/ai.ts
+++ b/server/route/v2/ai.ts
@@ -26,7 +26,7 @@ import {
   getPgvectorStatus,
   getStoredAiConfig,
   prepareRoteChatContext,
-  searchMemoryWithFallback,
+  searchMemory,
   logAiTokenUsage,
 } from '../../utils/dbMethods';
 import { bodyTypeCheck, createResponse } from '../../utils/main';
@@ -291,7 +291,7 @@ aiRouter.post('/search', authenticateJWT, bodyTypeCheck, async (c: HonoContext) 
     return c.json(createResponse(null, 'Query is required'), 400);
   }
 
-  const { sources: results } = await searchMemoryWithFallback({
+  const { sources: results } = await searchMemory({
     query,
     ownerId: body?.scope === 'public' ? undefined : user.id,
     scope: body?.scope === 'public' ? 'public' : 'mine',
@@ -344,7 +344,7 @@ aiRouter.post('/related-notes', authenticateJWT, bodyTypeCheck, async (c: HonoCo
       )
     : ['rote', 'article'];
 
-  const { sources: results } = await searchMemoryWithFallback({
+  const { sources: results } = await searchMemory({
     query,
     ownerId: user.id,
     sourceTypes,

--- a/server/route/v2/ai.ts
+++ b/server/route/v2/ai.ts
@@ -69,6 +69,7 @@ function toClientSource(source: any) {
     sourceType: source.sourceType,
     sourceId: source.sourceId,
     similarity: Number(source.similarity) || 0,
+    retrievalMode: source.retrievalMode || metadata.retrievalMode || 'relevance',
     preview: normalizeSourcePreview(source.text),
     metadata: {
       title: typeof metadata.title === 'string' ? metadata.title : '',
@@ -76,6 +77,9 @@ function toClientSource(source: any) {
       state: typeof metadata.state === 'string' ? metadata.state : undefined,
       archived: typeof metadata.archived === 'boolean' ? metadata.archived : undefined,
       createdAt: metadata.createdAt,
+      updatedAt: metadata.updatedAt,
+      retrievalMode: source.retrievalMode || metadata.retrievalMode || 'relevance',
+      retrievalDateField: metadata.retrievalDateField,
     },
   };
 }

--- a/server/route/v2/aiClientAgent.ts
+++ b/server/route/v2/aiClientAgent.ts
@@ -52,11 +52,7 @@ function toClientSource(source: any) {
 }
 
 function sanitizeClientWarning(value: unknown): string {
-  const text = String(value || '').trim();
-  if (text.startsWith('semantic_search_fallback_text')) {
-    return 'semantic_search_fallback_text';
-  }
-  return text;
+  return String(value || '').trim();
 }
 
 function sanitizeWarningArray(value: unknown): string[] {
@@ -91,7 +87,7 @@ function sanitizeClientModelContent(value: string): string {
     }
     return JSON.stringify(parsed, null, 2);
   } catch {
-    return value.replace(/semantic_search_fallback_text:[^"\n]+/g, 'semantic_search_fallback_text');
+    return value;
   }
 }
 

--- a/server/route/v2/aiClientAgent.ts
+++ b/server/route/v2/aiClientAgent.ts
@@ -36,6 +36,7 @@ function toClientSource(source: any) {
     sourceType: source.sourceType,
     sourceId: source.sourceId,
     similarity: Number(source.similarity) || 0,
+    retrievalMode: source.retrievalMode || metadata.retrievalMode || 'relevance',
     preview: normalizeSourcePreview(source.text),
     metadata: {
       title: typeof metadata.title === `string` ? metadata.title : '',
@@ -43,6 +44,9 @@ function toClientSource(source: any) {
       state: typeof metadata.state === `string` ? metadata.state : undefined,
       archived: typeof metadata.archived === 'boolean' ? metadata.archived : undefined,
       createdAt: metadata.createdAt,
+      updatedAt: metadata.updatedAt,
+      retrievalMode: source.retrievalMode || metadata.retrievalMode || 'relevance',
+      retrievalDateField: metadata.retrievalDateField,
     },
   };
 }

--- a/server/tests/aiIntegration.test.ts
+++ b/server/tests/aiIntegration.test.ts
@@ -93,11 +93,10 @@ async function runChat(
 }
 
 function log(label: string, r: ChatResult) {
-  const tags = r.plan.filters?.tags?.include?.join(',') || '';
-  const time =
-    r.plan.filters?.time?.normalizedRange?.label || r.plan.filters?.time?.timeExpression || '';
+  const tags = r.plan.scope?.tags?.join(',') || '';
+  const time = r.plan.scope?.timeRange?.label || '';
   console.log(
-    `  [${label}] plan=${r.plan.retrievalNeeded ? 'retrieve' : 'chat'} tags=${tags} time=${time} sources=${r.sources.length} answer=${r.answer.length}ch plan=${r.planTime}ms total=${r.totalTime}ms`
+    `  [${label}] plan=${r.plan.retrievalNeeded ? 'retrieve' : 'chat'} selection=${r.plan.scope?.selection || ''} tags=${tags} time=${time} sources=${r.sources.length} answer=${r.answer.length}ch plan=${r.planTime}ms total=${r.totalTime}ms`
   );
 }
 
@@ -111,15 +110,14 @@ describe('Fast Path', () => {
     const r = await runChat(`#${tag}`);
     log(`#${tag}`, r);
     expect(r.plan.retrievalNeeded).toBe(true);
-    expect(r.plan.filters.tags.include).toContain(tag);
+    expect(r.plan.scope.tags).toContain(tag);
   }, 30_000);
 
   test('最近90天 → plan has time filter', async () => {
     const r = await runChat('最近90天');
     log('最近90天', r);
     expect(r.plan.retrievalNeeded).toBe(true);
-    expect(r.plan.filters.time).not.toBeNull();
-    expect(r.plan.filters.time?.normalizedRange).toBeDefined();
+    expect(r.plan.scope.timeRange).not.toBeNull();
   }, 30_000);
 
   test('#tag + query → query stripped of #tag', async () => {
@@ -128,8 +126,8 @@ describe('Fast Path', () => {
     const r = await runChat(`#${tag} 里面开心的事`);
     log(`#${tag}+query`, r);
     expect(r.plan.retrievalNeeded).toBe(true);
-    expect(r.plan.query).not.toContain(`#${tag}`);
-    expect(r.plan.query).toContain('开心');
+    expect(r.plan.scope.query).not.toContain(`#${tag}`);
+    expect(r.plan.scope.query).toContain('开心');
   }, 30_000);
 
   test('全部 → all_time, retrieves sources', async () => {
@@ -165,7 +163,7 @@ describe('LLM Planner', () => {
     const r = await runChat(tag);
     log(`bare:${tag}`, r);
     expect(r.plan.retrievalNeeded).toBe(true);
-    expect(r.plan.filters.tags.include.length).toBeGreaterThan(0);
+    expect(r.plan.scope.tags.length).toBeGreaterThan(0);
   }, 60_000);
 });
 
@@ -210,7 +208,7 @@ describe('Multi-turn', () => {
     const t2 = await runChat('看看更多的', { previousPlan: t1.plan, excludeIds: t1Ids, limit: 3 });
     log('T2:more', t2);
     expect(t2.plan.retrievalNeeded).toBe(true);
-    expect(t2.plan.pagination).toBe('more');
+    expect(t2.plan.scope.excludeIds).toEqual(expect.arrayContaining(t1Ids));
 
     const t2Ids = t2.sources.map((s) => `${s.sourceType}:${s.sourceId}`);
     const overlap12 = t1Ids.filter((id) => t2Ids.includes(id));

--- a/server/tests/aiRetrievalPlanner.test.ts
+++ b/server/tests/aiRetrievalPlanner.test.ts
@@ -137,6 +137,26 @@ describe('canonicalizeSearchRotesArgs', () => {
     expect(scope.timeRange?.label).toBe('最近30天');
   });
 
+  it('overrides unbounded relevance when the user clearly asks for recent records', () => {
+    const explicitRelevance = canonicalizeSearchRotesArgs({
+      ownerId: 'u1',
+      availableTags: AVAILABLE_TAGS,
+      message: '最近我的记录',
+      args: { query: '工作', selection: 'relevance' },
+    });
+    const invalidRecentExpression = canonicalizeSearchRotesArgs({
+      ownerId: 'u1',
+      availableTags: AVAILABLE_TAGS,
+      message: '最近我的记录',
+      args: { query: '工作', selection: 'relevance', timeExpression: '最近' },
+    });
+
+    expect(explicitRelevance.scope.selection).toBe('recent');
+    expect(explicitRelevance.scope.limit).toBe(30);
+    expect(invalidRecentExpression.scope.selection).toBe('recent');
+    expect(invalidRecentExpression.scope.timeRange).toBeNull();
+  });
+
   it('uses the recent corpus for broad analysis inside an explicit window', () => {
     const { scope } = canonicalizeSearchRotesArgs({
       ownerId: 'u1',

--- a/server/tests/aiRetrievalPlanner.test.ts
+++ b/server/tests/aiRetrievalPlanner.test.ts
@@ -105,6 +105,51 @@ describe('canonicalizeSearchRotesArgs', () => {
     expect(lifecycleScopeToArchived(scope.lifecycleScope)).toBe(true);
   });
 
+  it('defaults an unbounded recent request to the latest 30 created records', () => {
+    const { scope } = canonicalizeSearchRotesArgs({
+      ownerId: 'u1',
+      availableTags: AVAILABLE_TAGS,
+      message: '最近我的记录里有哪些反复出现的主题？',
+      args: { query: '反复出现的主题' },
+    });
+
+    expect(scope.selection).toBe('recent');
+    expect(scope.dateField).toBe('createdAt');
+    expect(scope.limit).toBe(30);
+    expect(scope.timeRange).toBeNull();
+  });
+
+  it('keeps explicit relevance searches and supports updated records', () => {
+    const { scope } = canonicalizeSearchRotesArgs({
+      ownerId: 'u1',
+      availableTags: AVAILABLE_TAGS,
+      message: '最近修改过的 iOS 笔记',
+      args: {
+        query: 'iOS',
+        selection: 'relevance',
+        dateField: 'updatedAt',
+        timeExpression: '最近30天',
+      },
+    });
+
+    expect(scope.selection).toBe('relevance');
+    expect(scope.dateField).toBe('updatedAt');
+    expect(scope.timeRange?.label).toBe('最近30天');
+  });
+
+  it('uses the recent corpus for broad analysis inside an explicit window', () => {
+    const { scope } = canonicalizeSearchRotesArgs({
+      ownerId: 'u1',
+      availableTags: AVAILABLE_TAGS,
+      message: '最近30天有哪些反复出现的主题？',
+      args: { timeExpression: '最近30天' },
+    });
+
+    expect(scope.selection).toBe('recent');
+    expect(scope.timeRange?.label).toBe('最近30天');
+    expect(scope.limit).toBe(30);
+  });
+
   it('canonicalizes time ranges', () => {
     expect(canonicalizeTimeRange({ from: '2026-01-01', to: '2026-01-03' })).toMatchObject({
       from: '2026-01-01T00:00:00+08:00',

--- a/server/utils/ai/agent/prompt.ts
+++ b/server/utils/ai/agent/prompt.ts
@@ -41,6 +41,7 @@ ${getNativeRoteSkillSummary()}
 - For TODO, Flag, task, or open-loop analysis, archived notes count as closed/completed.
 - Do not infer tag filters unless the user explicitly names a tag or asks for labels. Natural topic words can stay semantic.
 - If the evidence sample is small, say that clearly and keep conclusions tentative.
+- For broad questions about recent/latest records, recurring themes, or recent trends, use rote_search_notes with selection "recent", a default limit of 30 when no count is requested, and dateField "createdAt". Use updatedAt only for recently modified or activity-focused requests. For a focused topic within a recent window, use selection "relevance" with an explicit time range. Never treat limit alone as a recency filter.
 
 ## Language
 

--- a/server/utils/ai/agent/runtime.ts
+++ b/server/utils/ai/agent/runtime.ts
@@ -201,7 +201,8 @@ function buildRequestTimeContextMessage(state: RoteAgentClientState): ChatMessag
   lines.push(
     'Resolve relative date phrases such as today, yesterday, this month, last month, 最近, 本月, and 上月 using this context.',
     'When calling rote_search_notes for a relative date phrase, pass the phrase as timeExpression instead of inventing absolute from/to dates.',
-    'Use from/to only when the user explicitly provides absolute dates.'
+    'Use from/to only when the user explicitly provides absolute dates.',
+    'For broad recent/latest record reviews or recurring-theme analysis, use selection recent with a default limit of 30 and dateField createdAt. Use updatedAt for modification/activity wording. For focused topics, use selection relevance with an explicit time range.'
   );
 
   return { role: 'system', content: lines.join('\n') };

--- a/server/utils/ai/agent/toolDefinitions.ts
+++ b/server/utils/ai/agent/toolDefinitions.ts
@@ -54,6 +54,18 @@ export function createSearchNotesToolDefinition(params: {
             description:
               'Soft topic keywords for semantic retrieval. Use for themes and patterns that are not verified tags.',
           },
+          selection: {
+            type: 'string',
+            enum: ['relevance', 'recent'],
+            description:
+              'Choose relevance for focused topic lookup. Choose recent for broad analysis of the latest records; recent ignores semantic query ranking.',
+          },
+          dateField: {
+            type: 'string',
+            enum: ['createdAt', 'updatedAt'],
+            description:
+              'Date basis for recent retrieval. Use createdAt for recently written records and updatedAt for recently modified/activity records.',
+          },
           timeRange: {
             type: 'object',
             description:

--- a/server/utils/ai/agent/tools.ts
+++ b/server/utils/ai/agent/tools.ts
@@ -4,7 +4,7 @@ import db from '../../drizzle';
 import {
   findArticleById,
   findRoteById,
-  searchMemoryWithFallback,
+  searchMemory,
   searchRotesProbe,
   sanitizeExcludeIds,
   toPlannerAgentDto,
@@ -361,7 +361,7 @@ async function executeFindRelatedNotes(
     status: 'finding_related',
   });
   const { content } = await loadOwnedSource(ctx, sourceType, sourceId);
-  const { sources: foundSources, warnings } = await searchMemoryWithFallback({
+  const { sources: foundSources, warnings } = await searchMemory({
     query: content,
     ownerId: ctx.userId,
     sourceTypes: ['rote'],

--- a/server/utils/ai/agent/tools.ts
+++ b/server/utils/ai/agent/tools.ts
@@ -16,6 +16,8 @@ import {
   canonicalizeSearchRotesArgs,
   getUserRoteTags,
   type LifecycleScope,
+  type RetrievalDateField,
+  type RetrievalSelection,
   type SearchRotesArgs,
   type TaskStatusScope,
 } from '../retrievalPlan';
@@ -81,7 +83,13 @@ function formatSourceMetadata(source: SemanticSearchResult): Record<string, unkn
         : undefined,
     createdAt: metadata.createdAt || undefined,
     updatedAt: metadata.updatedAt || undefined,
-    similarity: Number.isFinite(source.similarity) ? Number(source.similarity.toFixed(3)) : null,
+    retrievalMode: source.retrievalMode || metadata.retrievalMode || 'relevance',
+    similarity:
+      source.retrievalMode === 'recent' || metadata.retrievalMode === 'recent'
+        ? null
+        : Number.isFinite(source.similarity)
+          ? Number(source.similarity.toFixed(3))
+          : null,
   };
 }
 
@@ -127,6 +135,14 @@ function parseSearchNotesInput(args: unknown, fallbackQuery: string): SearchRote
     timeExpression: typeof raw.timeExpression === 'string' ? raw.timeExpression.trim() : undefined,
     from: typeof raw.from === 'string' ? raw.from.trim() : undefined,
     to: typeof raw.to === 'string' ? raw.to.trim() : undefined,
+    selection:
+      raw.selection === 'relevance' || raw.selection === 'recent'
+        ? (raw.selection as RetrievalSelection)
+        : undefined,
+    dateField:
+      raw.dateField === 'createdAt' || raw.dateField === 'updatedAt'
+        ? (raw.dateField as RetrievalDateField)
+        : undefined,
     lifecycleScope: VALID_LIFECYCLE_SCOPES.has(raw.lifecycleScope as LifecycleScope)
       ? (raw.lifecycleScope as LifecycleScope)
       : VALID_LIFECYCLE_SCOPES.has(raw.archivedScope as LifecycleScope)
@@ -162,6 +178,7 @@ async function executeAgentSearch(
     ownerId: ctx.userId,
     args: input,
     availableTags,
+    message: ctx.request.message,
     excludeIds: sanitizeExcludeIds([
       ...(ctx.request.excludeIds || []),
       ...(ctx.state.seenSourceIds || []),

--- a/server/utils/ai/retrievalDate.ts
+++ b/server/utils/ai/retrievalDate.ts
@@ -1,0 +1,236 @@
+import type { AiTimeUnit, NormalizedTimeRange, RetrievalTimeContext } from './retrievalTypes';
+
+const DEFAULT_TIME_ZONE = 'Asia/Shanghai';
+const DEFAULT_UTC_OFFSET_MINUTES = 8 * 60;
+const RELATIVE_POINT_RE =
+  /^(\d+|[一二两三四五六七八九十]+)\s*(天|日|周|星期|个月|月|年|days?|weeks?|months?|years?)\s*ago$/i;
+const RELATIVE_POINT_ZH_RE = /^(\d+|[一二两三四五六七八九十]+)\s*(天|日|周|星期|个月|月|年)前$/;
+
+export function normalizeTimeZone(value: unknown): string {
+  if (typeof value !== 'string' || !value.trim()) return DEFAULT_TIME_ZONE;
+  const timeZone = value.trim();
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone }).format(new Date(0));
+    return timeZone;
+  } catch {
+    return DEFAULT_TIME_ZONE;
+  }
+}
+
+function parseReferenceNow(context?: RetrievalTimeContext): Date {
+  const raw = context?.nowIso || context?.localDateTime;
+  if (raw) {
+    const parsed = new Date(raw);
+    if (!Number.isNaN(parsed.getTime())) return parsed;
+  }
+  return new Date();
+}
+
+export function isValidDateParts(year: number, month: number, day: number): boolean {
+  if (!Number.isInteger(year) || year < 1000 || year > 9999) return false;
+  if (!Number.isInteger(month) || month < 1 || month > 12) return false;
+  const maxDay = new Date(Date.UTC(year, month, 0)).getUTCDate();
+  return Number.isInteger(day) && day >= 1 && day <= maxDay;
+}
+
+function parseLocalDate(value: unknown): Date | null {
+  if (typeof value !== 'string') return null;
+  const match = value.trim().match(/^(\d{4})-(\d{1,2})-(\d{1,2})$/);
+  if (!match) return null;
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  if (!isValidDateParts(year, month, day)) return null;
+
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+function getDatePartsInTimeZone(date: Date, timeZone: string) {
+  const formatter = new Intl.DateTimeFormat('en-CA', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+  const parts = Object.fromEntries(
+    formatter.formatToParts(date).map((part) => [part.type, part.value])
+  );
+  return { year: Number(parts.year), month: Number(parts.month), day: Number(parts.day) };
+}
+
+export function getTodayInTimeContext(context?: RetrievalTimeContext): Date {
+  const localDate = parseLocalDate(context?.localDate);
+  if (localDate) return localDate;
+
+  const timeZone = normalizeTimeZone(context?.timeZone);
+  const { year, month, day } = getDatePartsInTimeZone(parseReferenceNow(context), timeZone);
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+function pad(value: number): string {
+  return String(value).padStart(2, '0');
+}
+
+export function toDateString(date: Date): string {
+  return `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())}`;
+}
+
+function formatOffset(minutes: number): string {
+  const sign = minutes >= 0 ? '+' : '-';
+  const absolute = Math.abs(minutes);
+  return `${sign}${pad(Math.floor(absolute / 60))}:${pad(absolute % 60)}`;
+}
+
+function getTimeZoneOffsetMinutes(date: Date, timeZone: string): number | null {
+  try {
+    const formatter = new Intl.DateTimeFormat('en-US', {
+      timeZone,
+      hour12: false,
+      hourCycle: 'h23',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    });
+    const parts = Object.fromEntries(
+      formatter.formatToParts(date).map((part) => [part.type, part.value])
+    );
+    const zonedAsUtc = Date.UTC(
+      Number(parts.year),
+      Number(parts.month) - 1,
+      Number(parts.day),
+      Number(parts.hour),
+      Number(parts.minute),
+      Number(parts.second)
+    );
+    return Math.round((zonedAsUtc - date.getTime()) / 60_000);
+  } catch {
+    return null;
+  }
+}
+
+function offsetForCalendarDate(date: Date, context?: RetrievalTimeContext): string {
+  const timeZone = normalizeTimeZone(context?.timeZone);
+  const noonUtc = new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 12)
+  );
+  const offsetMinutes =
+    getTimeZoneOffsetMinutes(noonUtc, timeZone) ??
+    (Number.isFinite(context?.utcOffsetMinutes)
+      ? Math.trunc(context?.utcOffsetMinutes as number)
+      : DEFAULT_UTC_OFFSET_MINUTES);
+  return formatOffset(offsetMinutes);
+}
+
+export function startOfDay(date: Date, context?: RetrievalTimeContext): string {
+  return `${toDateString(date)}T00:00:00${offsetForCalendarDate(date, context)}`;
+}
+
+export function endOfDay(date: Date, context?: RetrievalTimeContext): string {
+  return `${toDateString(date)}T23:59:59${offsetForCalendarDate(date, context)}`;
+}
+
+export function addDays(date: Date, days: number): Date {
+  const next = new Date(date);
+  next.setUTCDate(next.getUTCDate() + days);
+  return next;
+}
+
+export function addMonths(date: Date, months: number): Date {
+  const next = new Date(date);
+  const day = next.getUTCDate();
+  next.setUTCDate(1);
+  next.setUTCMonth(next.getUTCMonth() + months);
+  const maxDay = new Date(Date.UTC(next.getUTCFullYear(), next.getUTCMonth() + 1, 0)).getUTCDate();
+  next.setUTCDate(Math.min(day, maxDay));
+  return next;
+}
+
+export function monthRange(
+  year: number,
+  monthIndex: number,
+  label: string,
+  context?: RetrievalTimeContext
+): NormalizedTimeRange {
+  const start = new Date(Date.UTC(year, monthIndex, 1));
+  const end = new Date(Date.UTC(year, monthIndex + 1, 0));
+  return { from: startOfDay(start, context), to: endOfDay(end, context), label };
+}
+
+export function isValidTimeParts(hour: number, minute: number, second: number): boolean {
+  return (
+    Number.isInteger(hour) &&
+    hour >= 0 &&
+    hour <= 23 &&
+    Number.isInteger(minute) &&
+    minute >= 0 &&
+    minute <= 59 &&
+    Number.isInteger(second) &&
+    second >= 0 &&
+    second <= 59
+  );
+}
+
+export function isValidTimezoneOffset(value: string): boolean {
+  if (value === 'Z') return true;
+  const match = value.match(/^([+-])(\d{2}):(\d{2})$/);
+  if (!match) return false;
+  const hours = Number(match[2]);
+  const minutes = Number(match[3]);
+  return hours >= 0 && hours <= 23 && minutes >= 0 && minutes <= 59;
+}
+
+export function chineseNumberToInt(value: string): number | null {
+  const numeric = Number(value);
+  if (Number.isFinite(numeric)) return Math.max(1, Math.floor(numeric));
+  const digits: Record<string, number> = {
+    零: 0,
+    一: 1,
+    二: 2,
+    两: 2,
+    三: 3,
+    四: 4,
+    五: 5,
+    六: 6,
+    七: 7,
+    八: 8,
+    九: 9,
+  };
+  if (value in digits) return digits[value];
+  if (value === '十') return 10;
+  if (value.startsWith('十')) return 10 + (digits[value.slice(1)] ?? 0);
+  if (value.includes('十')) {
+    const [tensText, onesText] = value.split('十');
+    return (digits[tensText] ?? 1) * 10 + (onesText ? (digits[onesText] ?? 0) : 0);
+  }
+  return null;
+}
+
+export function unitTextToUnit(value: string): AiTimeUnit {
+  const unitText = value.toLowerCase();
+  return unitText === '天' || unitText === '日' || unitText.startsWith('day')
+    ? 'day'
+    : unitText === '周' || unitText === '星期' || unitText.startsWith('week')
+      ? 'week'
+      : unitText === '年' || unitText.startsWith('year')
+        ? 'year'
+        : 'month';
+}
+
+export function addRelativeOffset(date: Date, amount: number, unit: AiTimeUnit): Date {
+  if (unit === 'month') return addMonths(date, -amount);
+  if (unit === 'year') return addMonths(date, -amount * 12);
+  return addDays(date, -(unit === 'day' ? amount : amount * 7));
+}
+
+export function parseRelativePointDate(value: string, context?: RetrievalTimeContext): Date | null {
+  const match = value.trim().match(RELATIVE_POINT_RE) || value.trim().match(RELATIVE_POINT_ZH_RE);
+  if (!match) return null;
+
+  const amount = chineseNumberToInt(match[1]);
+  if (!amount || amount > 10000) return null;
+  return addRelativeOffset(getTodayInTimeContext(context), amount, unitTextToUnit(match[2]));
+}

--- a/server/utils/ai/retrievalDateParsing.ts
+++ b/server/utils/ai/retrievalDateParsing.ts
@@ -1,0 +1,105 @@
+import {
+  endOfDay,
+  isValidDateParts,
+  isValidTimeParts,
+  isValidTimezoneOffset,
+  parseRelativePointDate,
+  startOfDay,
+} from './retrievalDate';
+import type { NormalizedTimeRange, RetrievalTimeContext } from './retrievalTypes';
+
+const DATE_ONLY_RE = /^(\d{4})[-/.](\d{1,2})[-/.](\d{1,2})$/;
+const ISO_DATE_TIME_WITH_ZONE_RE =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2})(\.\d{1,3})?)?(Z|[+-]\d{2}:\d{2})$/;
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function normalizeDateOnlyInput(
+  value: string,
+  end = false,
+  context?: RetrievalTimeContext
+): string | null {
+  const match = value.trim().match(DATE_ONLY_RE);
+  if (!match) return null;
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  if (!isValidDateParts(year, month, day)) return null;
+
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return end ? endOfDay(date, context) : startOfDay(date, context);
+}
+
+function normalizeIsoDateTimeInput(value: string): string | null {
+  const normalized = value.trim();
+  const match = normalized.match(ISO_DATE_TIME_WITH_ZONE_RE);
+  if (!match) return null;
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const hour = Number(match[4]);
+  const minute = Number(match[5]);
+  const second = match[6] ? Number(match[6]) : 0;
+  const zone = match[8];
+
+  if (!isValidDateParts(year, month, day)) return null;
+  if (!isValidTimeParts(hour, minute, second)) return null;
+  if (!isValidTimezoneOffset(zone)) return null;
+  if (!Number.isFinite(Date.parse(normalized))) return null;
+
+  return normalized;
+}
+
+function normalizeDateInput(
+  value: string,
+  end = false,
+  context?: RetrievalTimeContext
+): string | null {
+  const normalized = value.trim();
+  if (!normalized) return null;
+  if (normalized.includes('T')) return normalizeIsoDateTimeInput(normalized);
+
+  const dateOnly = normalizeDateOnlyInput(normalized, end, context);
+  if (dateOnly) return dateOnly;
+
+  const relativePoint = parseRelativePointDate(normalized, context);
+  if (relativePoint)
+    return end ? endOfDay(relativePoint, context) : startOfDay(relativePoint, context);
+
+  return null;
+}
+
+function isOrderedTimeRange(from: string, to: string): boolean {
+  const fromTime = Date.parse(from);
+  const toTime = Date.parse(to);
+  return Number.isFinite(fromTime) && Number.isFinite(toTime) && fromTime <= toTime;
+}
+
+export function normalizeTimeRangeInput(
+  value: unknown,
+  context?: RetrievalTimeContext
+): NormalizedTimeRange | null {
+  const raw = asRecord(value);
+  const from = typeof raw.from === 'string' ? raw.from.trim() : '';
+  const to = typeof raw.to === 'string' ? raw.to.trim() : '';
+  if (!from || !to) return null;
+
+  const normalizedFrom = normalizeDateInput(from, false, context);
+  const normalizedTo = normalizeDateInput(to, true, context);
+  if (!normalizedFrom || !normalizedTo || !isOrderedTimeRange(normalizedFrom, normalizedTo)) {
+    return null;
+  }
+
+  return {
+    from: normalizedFrom,
+    to: normalizedTo,
+    label:
+      typeof raw.label === 'string' && raw.label.trim() ? raw.label.trim() : `${from} 到 ${to}`,
+  };
+}

--- a/server/utils/ai/retrievalPlan.ts
+++ b/server/utils/ai/retrievalPlan.ts
@@ -1,7 +1,4 @@
-import { sql } from 'drizzle-orm';
-import { rotes } from '../../drizzle/schema';
 import type { AiConfig } from '../../types/config';
-import db from '../drizzle';
 import {
   createChatCompletionWithToolsStreaming,
   type ChatCompletionUsage,
@@ -9,171 +6,36 @@ import {
   type ChatToolCall,
   type ChatToolDefinition,
 } from './client';
+import { getTodayInTimeContext, normalizeTimeZone, toDateString } from './retrievalDate';
+import {
+  canonicalizeSearchRotesArgs,
+  getUserRoteTagCounts,
+  getUserRoteTags,
+} from './retrievalScope';
+import type {
+  PlannerAgentDto,
+  PlannerAgentResult,
+  PlannerDebugTrace,
+  RetrievalTimeContext,
+  SearchRotesArgs,
+  SearchRotesProbeExecutor,
+} from './retrievalTypes';
+import type { SearchRotesProbeResult } from './retrievalTypes';
 
-export type AiSourceType = 'rote' | 'article';
-export type LifecycleScope = 'active' | 'archived' | 'all' | 'unspecified';
-export type TaskStatusScope = 'open' | 'closed' | 'all' | 'unspecified';
-export type AiTimeUnit = 'day' | 'week' | 'month' | 'year';
+export * from './retrievalTypes';
+export {
+  canonicalizeSearchRotesArgs,
+  getUserRoteTagCounts,
+  getUserRoteTags,
+} from './retrievalScope';
+export { canonicalizeTimeRange } from './retrievalTimeRange';
+export { normalizeTimeRangeInput } from './retrievalDateParsing';
+export { lifecycleScopeToArchived } from './retrievalScope';
 
-export interface NormalizedTimeRange {
-  from: string;
-  to: string;
-  label: string;
-}
-
-export type StructuredTimeRangeType = 'absolute' | 'rolling' | 'relative_between' | 'preset';
-export type StructuredTimeRangePreset = 'today' | 'yesterday' | 'this_month' | 'last_month';
-
-export interface StructuredRelativeTimePoint {
-  amount?: number;
-  unit?: AiTimeUnit;
-  direction?: 'ago';
-}
-
-export interface StructuredTimeRange {
-  type?: StructuredTimeRangeType;
-  preset?: StructuredTimeRangePreset;
-  fromDate?: string;
-  toDate?: string;
-  amount?: number;
-  unit?: AiTimeUnit;
-  fromRelative?: StructuredRelativeTimePoint;
-  toRelative?: StructuredRelativeTimePoint;
-  label?: string;
-}
-
-export interface RetrievalScope {
-  ownerId: string;
-  query: string;
-  tags: string[];
-  excludeTags: string[];
-  semanticScope: string[];
-  sourceTypes: AiSourceType[];
-  timeRange: NormalizedTimeRange | null;
-  lifecycleScope: LifecycleScope;
-  taskStatusScope: TaskStatusScope;
-  limit: number;
-  cursor: string | null;
-  excludeIds: string[];
-}
-
-export interface SearchRotesArgs {
-  query?: string;
-  tags?: string[];
-  excludeTags?: string[];
-  semanticScope?: string[];
-  sourceTypes?: AiSourceType[];
-  timeRange?: StructuredTimeRange;
-  timeExpression?: string;
-  from?: string;
-  to?: string;
-  lifecycleScope?: LifecycleScope;
-  taskStatusScope?: TaskStatusScope;
-  limit?: number;
-  cursor?: string;
-}
-
-export interface RetrievalTimeContext {
-  nowIso?: string;
-  localDate?: string;
-  localDateTime?: string;
-  timeZone?: string;
-  utcOffsetMinutes?: number;
-}
-
-export interface RetrievalSnippet {
-  id: string;
-  sourceType: AiSourceType;
-  sourceId: string;
-  title?: string;
-  tags?: string[];
-  createdAt?: string;
-  similarity: number;
-  text: string;
-}
-
-export interface RetrievalToolResult {
-  canonicalizedArgs: RetrievalScope;
-  resultCount: number;
-  topSnippets: RetrievalSnippet[];
-  cursor: string | null;
-  warnings: string[];
-}
-
-export interface SearchRotesProbeResult {
-  toolResult: RetrievalToolResult;
-  sources: unknown[];
-}
-
-export interface PlannerDebugTrace {
-  toolCalls: Array<{
-    step: number;
-    name: string;
-    args: unknown;
-  }>;
-  canonicalizedArgs: RetrievalScope[];
-  warnings: string[];
-  probeCounts: number[];
-  finishReason?: string;
-  fallbackReason?: string;
-  providerError?: string;
-  toolError?: string;
-}
-
-export interface PlannerAgentResult {
-  originalMessage: string;
-  retrievalNeeded: boolean;
-  scope: RetrievalScope | null;
-  toolResult: RetrievalToolResult | null;
-  sources: unknown[];
-  clarification: { question: string; reason?: string } | null;
-  debugTrace: PlannerDebugTrace;
-}
-
-export interface PlannerAgentDto {
-  originalMessage: string;
-  retrievalNeeded: boolean;
-  scope: RetrievalScope | null;
-  toolResult: RetrievalToolResult | null;
-  clarification: { question: string; reason?: string } | null;
-  debugTrace: PlannerDebugTrace;
-}
-
-export type SearchRotesProbeExecutor = (scope: RetrievalScope) => Promise<SearchRotesProbeResult>;
-
-const VALID_SOURCE_TYPES = new Set<AiSourceType>(['rote', 'article']);
-const VALID_LIFECYCLE_SCOPES = new Set<LifecycleScope>([
-  'active',
-  'archived',
-  'all',
-  'unspecified',
-]);
-const VALID_TASK_STATUS_SCOPES = new Set<TaskStatusScope>(['open', 'closed', 'all', 'unspecified']);
-const VALID_STRUCTURED_TIME_TYPES = new Set<StructuredTimeRangeType>([
-  'absolute',
-  'rolling',
-  'relative_between',
-  'preset',
-]);
-const VALID_STRUCTURED_TIME_PRESETS = new Set<StructuredTimeRangePreset>([
-  'today',
-  'yesterday',
-  'this_month',
-  'last_month',
-]);
-const VALID_STRUCTURED_TIME_UNITS = new Set<AiTimeUnit>(['day', 'week', 'month', 'year']);
 const DEFAULT_LIMIT = 15;
 const MAX_LIMIT = 50;
 const MAX_STEPS = 6;
 const MAX_TOOL_CALLS = 10;
-const DEFAULT_TIME_ZONE = 'Asia/Shanghai';
-const DEFAULT_UTC_OFFSET_MINUTES = 8 * 60;
-const DATE_ONLY_RE = /^(\d{4})[-/.](\d{1,2})[-/.](\d{1,2})$/;
-const ISO_DATE_TIME_WITH_ZONE_RE =
-  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2})(\.\d{1,3})?)?(Z|[+-]\d{2}:\d{2})$/;
-const RELATIVE_POINT_RE =
-  /^(\d+|[一二两三四五六七八九十]+)\s*(天|日|周|星期|个月|月|年|days?|weeks?|months?|years?)\s*ago$/i;
-const RELATIVE_POINT_ZH_RE = /^(\d+|[一二两三四五六七八九十]+)\s*(天|日|周|星期|个月|月|年)前$/;
 
 function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value)
@@ -181,674 +43,10 @@ function asRecord(value: unknown): Record<string, unknown> {
     : {};
 }
 
-function uniqueStrings(value: unknown, limit = 30): string[] {
-  if (!Array.isArray(value)) return [];
-  return Array.from(
-    new Set(
-      value
-        .map((item) => (typeof item === 'string' ? item.trim().replace(/^#/, '') : ''))
-        .filter(Boolean)
-    )
-  ).slice(0, limit);
-}
-
 function clampLimit(value: unknown): number {
   const numeric = Number(value);
   if (!Number.isFinite(numeric)) return DEFAULT_LIMIT;
   return Math.min(Math.max(Math.floor(numeric), 1), MAX_LIMIT);
-}
-
-function normalizeSourceTypes(value: unknown, warnings: string[]): AiSourceType[] {
-  if (!Array.isArray(value)) return ['rote', 'article'];
-  const valid = uniqueStrings(value)
-    .filter((type): type is AiSourceType => VALID_SOURCE_TYPES.has(type as AiSourceType))
-    .slice(0, 2);
-  const invalid = uniqueStrings(value).filter(
-    (type) => !VALID_SOURCE_TYPES.has(type as AiSourceType)
-  );
-  invalid.forEach((type) => warnings.push(`invalid_source_type:${type}`));
-  return valid.length ? valid : ['rote', 'article'];
-}
-
-function normalizeLifecycleScope(value: unknown): LifecycleScope {
-  return VALID_LIFECYCLE_SCOPES.has(value as LifecycleScope)
-    ? (value as LifecycleScope)
-    : 'unspecified';
-}
-
-function normalizeTaskStatusScope(value: unknown): TaskStatusScope {
-  return VALID_TASK_STATUS_SCOPES.has(value as TaskStatusScope)
-    ? (value as TaskStatusScope)
-    : 'unspecified';
-}
-
-export function lifecycleScopeToArchived(scope: LifecycleScope): boolean | null {
-  if (scope === 'active') return false;
-  if (scope === 'archived') return true;
-  return null;
-}
-
-export async function getUserRoteTags(ownerId: string): Promise<string[]> {
-  const rows = (await db
-    .select({ tags: rotes.tags })
-    .from(rotes)
-    .where(sql`${rotes.authorid} = ${ownerId}`)) as Array<{ tags: string[] | null }>;
-  return Array.from(
-    new Set(rows.flatMap((row) => (Array.isArray(row.tags) ? row.tags : [])).filter(Boolean))
-  ).sort((a, b) => a.localeCompare(b));
-}
-
-export async function getUserRoteTagCounts(
-  ownerId: string
-): Promise<Array<{ name: string; count: number }>> {
-  const rows = (await db
-    .select({ tags: rotes.tags })
-    .from(rotes)
-    .where(sql`${rotes.authorid} = ${ownerId}`)) as Array<{ tags: string[] | null }>;
-  const counts = new Map<string, number>();
-  rows.forEach((row) => {
-    (Array.isArray(row.tags) ? row.tags : []).forEach((tag) => {
-      if (tag) counts.set(tag, (counts.get(tag) || 0) + 1);
-    });
-  });
-  return Array.from(counts.entries())
-    .map(([name, count]) => ({ name, count }))
-    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
-}
-
-function normalizeTimeZone(value: unknown): string {
-  if (typeof value !== 'string' || !value.trim()) return DEFAULT_TIME_ZONE;
-  const timeZone = value.trim();
-  try {
-    new Intl.DateTimeFormat('en-US', { timeZone }).format(new Date(0));
-    return timeZone;
-  } catch {
-    return DEFAULT_TIME_ZONE;
-  }
-}
-
-function parseReferenceNow(context?: RetrievalTimeContext): Date {
-  const raw = context?.nowIso || context?.localDateTime;
-  if (raw) {
-    const parsed = new Date(raw);
-    if (!Number.isNaN(parsed.getTime())) return parsed;
-  }
-  return new Date();
-}
-
-function parseLocalDate(value: unknown): Date | null {
-  if (typeof value !== 'string') return null;
-  const match = value.trim().match(/^(\d{4})-(\d{1,2})-(\d{1,2})$/);
-  if (!match) return null;
-
-  const year = Number(match[1]);
-  const month = Number(match[2]);
-  const day = Number(match[3]);
-  if (!isValidDateParts(year, month, day)) return null;
-
-  return new Date(Date.UTC(year, month - 1, day));
-}
-
-function getDatePartsInTimeZone(date: Date, timeZone: string) {
-  const formatter = new Intl.DateTimeFormat('en-CA', {
-    timeZone,
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  });
-  const parts = Object.fromEntries(
-    formatter.formatToParts(date).map((part) => [part.type, part.value])
-  );
-  return {
-    year: Number(parts.year),
-    month: Number(parts.month),
-    day: Number(parts.day),
-  };
-}
-
-function getTodayInTimeContext(context?: RetrievalTimeContext): Date {
-  const localDate = parseLocalDate(context?.localDate);
-  if (localDate) return localDate;
-
-  const timeZone = normalizeTimeZone(context?.timeZone);
-  const { year, month, day } = getDatePartsInTimeZone(parseReferenceNow(context), timeZone);
-  return new Date(Date.UTC(year, month - 1, day));
-}
-
-function pad(value: number): string {
-  return String(value).padStart(2, '0');
-}
-
-function toDateString(date: Date): string {
-  return `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())}`;
-}
-
-function formatOffset(minutes: number): string {
-  const sign = minutes >= 0 ? '+' : '-';
-  const absolute = Math.abs(minutes);
-  return `${sign}${pad(Math.floor(absolute / 60))}:${pad(absolute % 60)}`;
-}
-
-function getTimeZoneOffsetMinutes(date: Date, timeZone: string): number | null {
-  try {
-    const formatter = new Intl.DateTimeFormat('en-US', {
-      timeZone,
-      hour12: false,
-      hourCycle: 'h23',
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit',
-      hour: '2-digit',
-      minute: '2-digit',
-      second: '2-digit',
-    });
-    const parts = Object.fromEntries(
-      formatter.formatToParts(date).map((part) => [part.type, part.value])
-    );
-    const zonedAsUtc = Date.UTC(
-      Number(parts.year),
-      Number(parts.month) - 1,
-      Number(parts.day),
-      Number(parts.hour),
-      Number(parts.minute),
-      Number(parts.second)
-    );
-    return Math.round((zonedAsUtc - date.getTime()) / 60_000);
-  } catch {
-    return null;
-  }
-}
-
-function offsetForCalendarDate(date: Date, context?: RetrievalTimeContext): string {
-  const timeZone = normalizeTimeZone(context?.timeZone);
-  const noonUtc = new Date(
-    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 12)
-  );
-  const offsetMinutes =
-    getTimeZoneOffsetMinutes(noonUtc, timeZone) ??
-    (Number.isFinite(context?.utcOffsetMinutes)
-      ? Math.trunc(context?.utcOffsetMinutes as number)
-      : DEFAULT_UTC_OFFSET_MINUTES);
-  return formatOffset(offsetMinutes);
-}
-
-function startOfDay(date: Date, context?: RetrievalTimeContext): string {
-  return `${toDateString(date)}T00:00:00${offsetForCalendarDate(date, context)}`;
-}
-
-function endOfDay(date: Date, context?: RetrievalTimeContext): string {
-  return `${toDateString(date)}T23:59:59${offsetForCalendarDate(date, context)}`;
-}
-
-function addDays(date: Date, days: number): Date {
-  const next = new Date(date);
-  next.setUTCDate(next.getUTCDate() + days);
-  return next;
-}
-
-function addMonths(date: Date, months: number): Date {
-  const next = new Date(date);
-  const day = next.getUTCDate();
-  next.setUTCDate(1);
-  next.setUTCMonth(next.getUTCMonth() + months);
-  const maxDay = new Date(Date.UTC(next.getUTCFullYear(), next.getUTCMonth() + 1, 0)).getUTCDate();
-  next.setUTCDate(Math.min(day, maxDay));
-  return next;
-}
-
-function monthRange(
-  year: number,
-  monthIndex: number,
-  label: string,
-  context?: RetrievalTimeContext
-): NormalizedTimeRange {
-  const start = new Date(Date.UTC(year, monthIndex, 1));
-  const end = new Date(Date.UTC(year, monthIndex + 1, 0));
-  return { from: startOfDay(start, context), to: endOfDay(end, context), label };
-}
-
-function isValidDateParts(year: number, month: number, day: number): boolean {
-  if (!Number.isInteger(year) || year < 1000 || year > 9999) return false;
-  if (!Number.isInteger(month) || month < 1 || month > 12) return false;
-  const maxDay = new Date(Date.UTC(year, month, 0)).getUTCDate();
-  return Number.isInteger(day) && day >= 1 && day <= maxDay;
-}
-
-function isValidTimeParts(hour: number, minute: number, second: number): boolean {
-  return (
-    Number.isInteger(hour) &&
-    hour >= 0 &&
-    hour <= 23 &&
-    Number.isInteger(minute) &&
-    minute >= 0 &&
-    minute <= 59 &&
-    Number.isInteger(second) &&
-    second >= 0 &&
-    second <= 59
-  );
-}
-
-function isValidTimezoneOffset(value: string): boolean {
-  if (value === 'Z') return true;
-  const match = value.match(/^([+-])(\d{2}):(\d{2})$/);
-  if (!match) return false;
-  const hours = Number(match[2]);
-  const minutes = Number(match[3]);
-  return hours >= 0 && hours <= 23 && minutes >= 0 && minutes <= 59;
-}
-
-function chineseNumberToInt(value: string): number | null {
-  const numeric = Number(value);
-  if (Number.isFinite(numeric)) return Math.max(1, Math.floor(numeric));
-  const digits: Record<string, number> = {
-    零: 0,
-    一: 1,
-    二: 2,
-    两: 2,
-    三: 3,
-    四: 4,
-    五: 5,
-    六: 6,
-    七: 7,
-    八: 8,
-    九: 9,
-  };
-  if (value in digits) return digits[value];
-  if (value === '十') return 10;
-  if (value.startsWith('十')) return 10 + (digits[value.slice(1)] ?? 0);
-  if (value.includes('十')) {
-    const [tensText, onesText] = value.split('十');
-    return (digits[tensText] ?? 1) * 10 + (onesText ? (digits[onesText] ?? 0) : 0);
-  }
-  return null;
-}
-
-function unitTextToUnit(value: string): AiTimeUnit {
-  const unitText = value.toLowerCase();
-  return unitText === '天' || unitText === '日' || unitText.startsWith('day')
-    ? 'day'
-    : unitText === '周' || unitText === '星期' || unitText.startsWith('week')
-      ? 'week'
-      : unitText === '年' || unitText.startsWith('year')
-        ? 'year'
-        : 'month';
-}
-
-function addRelativeOffset(date: Date, amount: number, unit: AiTimeUnit): Date {
-  if (unit === 'month') return addMonths(date, -amount);
-  if (unit === 'year') return addMonths(date, -amount * 12);
-  return addDays(date, -(unit === 'day' ? amount : amount * 7));
-}
-
-function parseRelativePointDate(value: string, context?: RetrievalTimeContext): Date | null {
-  const match = value.trim().match(RELATIVE_POINT_RE) || value.trim().match(RELATIVE_POINT_ZH_RE);
-  if (!match) return null;
-
-  const amount = chineseNumberToInt(match[1]);
-  if (!amount || amount > 10000) return null;
-  return addRelativeOffset(getTodayInTimeContext(context), amount, unitTextToUnit(match[2]));
-}
-
-function normalizeDateOnlyInput(
-  value: string,
-  end = false,
-  context?: RetrievalTimeContext
-): string | null {
-  const match = value.trim().match(DATE_ONLY_RE);
-  if (!match) return null;
-
-  const year = Number(match[1]);
-  const month = Number(match[2]);
-  const day = Number(match[3]);
-  if (!isValidDateParts(year, month, day)) return null;
-
-  const date = new Date(Date.UTC(year, month - 1, day));
-  return end ? endOfDay(date, context) : startOfDay(date, context);
-}
-
-function normalizeIsoDateTimeInput(value: string): string | null {
-  const normalized = value.trim();
-  const match = normalized.match(ISO_DATE_TIME_WITH_ZONE_RE);
-  if (!match) return null;
-
-  const year = Number(match[1]);
-  const month = Number(match[2]);
-  const day = Number(match[3]);
-  const hour = Number(match[4]);
-  const minute = Number(match[5]);
-  const second = match[6] ? Number(match[6]) : 0;
-  const zone = match[8];
-
-  if (!isValidDateParts(year, month, day)) return null;
-  if (!isValidTimeParts(hour, minute, second)) return null;
-  if (!isValidTimezoneOffset(zone)) return null;
-  if (!Number.isFinite(Date.parse(normalized))) return null;
-
-  return normalized;
-}
-
-function normalizeDateInput(
-  value: string,
-  end = false,
-  context?: RetrievalTimeContext
-): string | null {
-  const normalized = value.trim();
-  if (!normalized) return null;
-  if (normalized.includes('T')) return normalizeIsoDateTimeInput(normalized);
-
-  const dateOnly = normalizeDateOnlyInput(normalized, end, context);
-  if (dateOnly) return dateOnly;
-
-  const relativePoint = parseRelativePointDate(normalized, context);
-  if (relativePoint)
-    return end ? endOfDay(relativePoint, context) : startOfDay(relativePoint, context);
-
-  return null;
-}
-
-function isOrderedTimeRange(from: string, to: string): boolean {
-  const fromTime = Date.parse(from);
-  const toTime = Date.parse(to);
-  return Number.isFinite(fromTime) && Number.isFinite(toTime) && fromTime <= toTime;
-}
-
-export function normalizeTimeRangeInput(
-  value: unknown,
-  context?: RetrievalTimeContext
-): NormalizedTimeRange | null {
-  const raw = asRecord(value);
-  const from = typeof raw.from === 'string' ? raw.from.trim() : '';
-  const to = typeof raw.to === 'string' ? raw.to.trim() : '';
-  if (!from || !to) return null;
-
-  const normalizedFrom = normalizeDateInput(from, false, context);
-  const normalizedTo = normalizeDateInput(to, true, context);
-  if (!normalizedFrom || !normalizedTo || !isOrderedTimeRange(normalizedFrom, normalizedTo)) {
-    return null;
-  }
-
-  return {
-    from: normalizedFrom,
-    to: normalizedTo,
-    label:
-      typeof raw.label === 'string' && raw.label.trim() ? raw.label.trim() : `${from} 到 ${to}`,
-  };
-}
-
-function normalizeStructuredTimeUnit(value: unknown): AiTimeUnit | null {
-  if (typeof value !== 'string') return null;
-  const unit = value.trim().toLowerCase();
-  if (unit === 'days') return 'day';
-  if (unit === 'weeks') return 'week';
-  if (unit === 'months') return 'month';
-  if (unit === 'years') return 'year';
-  return VALID_STRUCTURED_TIME_UNITS.has(unit as AiTimeUnit) ? (unit as AiTimeUnit) : null;
-}
-
-function normalizeStructuredAmount(value: unknown): number | null {
-  const amount = Number(value);
-  if (!Number.isFinite(amount)) return null;
-  const normalized = Math.floor(amount);
-  return normalized >= 1 && normalized <= 10000 ? normalized : null;
-}
-
-function structuredLabel(raw: Record<string, unknown>, fallback: string): string {
-  return typeof raw.label === 'string' && raw.label.trim() ? raw.label.trim() : fallback;
-}
-
-function formatRelativePointLabel(point: Record<string, unknown>): string {
-  const amount = normalizeStructuredAmount(point.amount) || 0;
-  const unit = normalizeStructuredTimeUnit(point.unit) || 'day';
-  return `${amount} ${unit}${amount === 1 ? '' : 's'} ago`;
-}
-
-function normalizeStructuredRelativePoint(
-  value: unknown,
-  end = false,
-  context?: RetrievalTimeContext
-): string | null {
-  const point = asRecord(value);
-  const amount = normalizeStructuredAmount(point.amount);
-  const unit = normalizeStructuredTimeUnit(point.unit);
-  const direction = typeof point.direction === 'string' ? point.direction.trim() : 'ago';
-  if (!amount || !unit || direction !== 'ago') return null;
-
-  const date = addRelativeOffset(getTodayInTimeContext(context), amount, unit);
-  return end ? endOfDay(date, context) : startOfDay(date, context);
-}
-
-function canonicalizePresetTimeRange(
-  preset: StructuredTimeRangePreset,
-  raw: Record<string, unknown>,
-  context?: RetrievalTimeContext
-): NormalizedTimeRange {
-  const today = getTodayInTimeContext(context);
-  if (preset === 'today') {
-    return {
-      from: startOfDay(today, context),
-      to: endOfDay(today, context),
-      label: structuredLabel(raw, '今天'),
-    };
-  }
-  if (preset === 'yesterday') {
-    const yesterday = addDays(today, -1);
-    return {
-      from: startOfDay(yesterday, context),
-      to: endOfDay(yesterday, context),
-      label: structuredLabel(raw, '昨天'),
-    };
-  }
-  if (preset === 'this_month') {
-    const start = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 1));
-    return {
-      from: startOfDay(start, context),
-      to: endOfDay(today, context),
-      label: structuredLabel(raw, '本月'),
-    };
-  }
-  const range = monthRange(today.getUTCFullYear(), today.getUTCMonth() - 1, '上个月', context);
-  return { ...range, label: structuredLabel(raw, range.label) };
-}
-
-function canonicalizeStructuredTimeRange(
-  value: unknown,
-  context?: RetrievalTimeContext
-): NormalizedTimeRange | null {
-  const raw = asRecord(value);
-  if (!Object.keys(raw).length) return null;
-
-  const type = VALID_STRUCTURED_TIME_TYPES.has(raw.type as StructuredTimeRangeType)
-    ? (raw.type as StructuredTimeRangeType)
-    : undefined;
-  const preset = VALID_STRUCTURED_TIME_PRESETS.has(raw.preset as StructuredTimeRangePreset)
-    ? (raw.preset as StructuredTimeRangePreset)
-    : undefined;
-
-  const parsePreset = () => {
-    if (!preset) return null;
-    return canonicalizePresetTimeRange(preset, raw, context);
-  };
-
-  const parseRolling = () => {
-    const amount = normalizeStructuredAmount(raw.amount);
-    const unit = normalizeStructuredTimeUnit(raw.unit);
-    if (!amount || !unit) return null;
-    const today = getTodayInTimeContext(context);
-    const start = addRelativeOffset(today, amount, unit);
-    return {
-      from: startOfDay(start, context),
-      to: endOfDay(today, context),
-      label: structuredLabel(raw, `last ${amount} ${unit}${amount === 1 ? '' : 's'}`),
-    };
-  };
-
-  const parseRelativeBetween = () => {
-    const from = normalizeStructuredRelativePoint(raw.fromRelative, false, context);
-    const to = normalizeStructuredRelativePoint(raw.toRelative, true, context);
-    if (!from || !to || !isOrderedTimeRange(from, to)) return null;
-    return {
-      from,
-      to,
-      label: structuredLabel(
-        raw,
-        `${formatRelativePointLabel(asRecord(raw.fromRelative))} 到 ${formatRelativePointLabel(
-          asRecord(raw.toRelative)
-        )}`
-      ),
-    };
-  };
-
-  const parseAbsolute = () =>
-    normalizeTimeRangeInput(
-      {
-        from: raw.fromDate,
-        to: raw.toDate,
-        label: raw.label,
-      },
-      context
-    );
-
-  if (type) {
-    if (type === 'absolute') return parseAbsolute();
-    if (type === 'rolling') return parseRolling();
-    if (type === 'relative_between') return parseRelativeBetween();
-    return parsePreset();
-  }
-
-  if (preset) return parsePreset();
-  if (raw.fromRelative || raw.toRelative) return parseRelativeBetween();
-  if (raw.amount !== undefined || raw.unit !== undefined) return parseRolling();
-  if (raw.fromDate !== undefined || raw.toDate !== undefined) return parseAbsolute();
-
-  return null;
-}
-
-export function canonicalizeTimeRange(
-  args: SearchRotesArgs,
-  warnings?: string[],
-  context?: RetrievalTimeContext
-): NormalizedTimeRange | null {
-  if (args.timeRange !== undefined) {
-    const structured = canonicalizeStructuredTimeRange(args.timeRange, context);
-    if (structured) return structured;
-    warnings?.push('invalid_time_range_ignored');
-  }
-
-  const from = typeof args.from === 'string' ? args.from.trim() : '';
-  const to = typeof args.to === 'string' ? args.to.trim() : '';
-  if (from && to) {
-    const normalized = normalizeTimeRangeInput({ from, to, label: `${from} 到 ${to}` }, context);
-    if (!normalized) warnings?.push('invalid_time_range_ignored');
-    return normalized;
-  }
-
-  const expression = typeof args.timeExpression === 'string' ? args.timeExpression.trim() : '';
-  if (!expression) return null;
-
-  const today = getTodayInTimeContext(context);
-  if (/今天|今日|today/i.test(expression)) {
-    return { from: startOfDay(today, context), to: endOfDay(today, context), label: '今天' };
-  }
-  if (/昨天|昨日|yesterday/i.test(expression)) {
-    const yesterday = addDays(today, -1);
-    return {
-      from: startOfDay(yesterday, context),
-      to: endOfDay(yesterday, context),
-      label: '昨天',
-    };
-  }
-  if (/本月|这个月|this month/i.test(expression)) {
-    const start = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 1));
-    return { from: startOfDay(start, context), to: endOfDay(today, context), label: '本月' };
-  }
-  if (/上个月|上月|last month/i.test(expression)) {
-    return monthRange(today.getUTCFullYear(), today.getUTCMonth() - 1, '上个月', context);
-  }
-
-  const rollingMatch = expression.match(
-    /(?:最近|近|过去|前|last|past|previous|recent)\s*(\d+|[一二两三四五六七八九十]+)\s*(天|日|周|星期|个月|月|年|days?|weeks?|months?|years?)/i
-  );
-  if (rollingMatch) {
-    const amount = chineseNumberToInt(rollingMatch[1]);
-    if (amount) {
-      const start = addRelativeOffset(today, amount, unitTextToUnit(rollingMatch[2]));
-      return {
-        from: startOfDay(start, context),
-        to: endOfDay(today, context),
-        label: rollingMatch[0],
-      };
-    }
-  }
-
-  const explicitRange = expression.match(
-    /(\d{4}[-/.]\d{1,2}[-/.]\d{1,2})\s*(?:到|至|~|-|—)\s*(\d{4}[-/.]\d{1,2}[-/.]\d{1,2})/
-  );
-  if (explicitRange) {
-    const normalized = normalizeTimeRangeInput(
-      {
-        from: explicitRange[1],
-        to: explicitRange[2],
-        label: explicitRange[0],
-      },
-      context
-    );
-    if (!normalized) warnings?.push('invalid_time_range_ignored');
-    return normalized;
-  }
-
-  return null;
-}
-
-export function canonicalizeSearchRotesArgs(params: {
-  ownerId: string;
-  args: SearchRotesArgs;
-  availableTags: string[];
-  excludeIds?: string[];
-  timeContext?: RetrievalTimeContext | null;
-}): { scope: RetrievalScope; warnings: string[] } {
-  const warnings: string[] = [];
-  const availableTagSet = new Set(params.availableTags);
-  const semanticScope = new Set(uniqueStrings(params.args.semanticScope));
-  const tags: string[] = [];
-  const excludeTags: string[] = [];
-
-  uniqueStrings(params.args.tags).forEach((tag) => {
-    if (availableTagSet.has(tag)) {
-      tags.push(tag);
-    } else {
-      semanticScope.add(tag);
-      warnings.push(`unknown_tag_downgraded:${tag}`);
-    }
-  });
-
-  uniqueStrings(params.args.excludeTags).forEach((tag) => {
-    if (availableTagSet.has(tag)) {
-      excludeTags.push(tag);
-    } else {
-      semanticScope.add(tag);
-      warnings.push(`unknown_exclude_tag_downgraded:${tag}`);
-    }
-  });
-
-  const scope: RetrievalScope = {
-    ownerId: params.ownerId,
-    query: typeof params.args.query === 'string' ? params.args.query.trim() : '',
-    tags: Array.from(new Set(tags)),
-    excludeTags: Array.from(new Set(excludeTags)),
-    semanticScope: Array.from(semanticScope).slice(0, 30),
-    sourceTypes: normalizeSourceTypes(params.args.sourceTypes, warnings),
-    timeRange: canonicalizeTimeRange(params.args, warnings, params.timeContext || undefined),
-    lifecycleScope: normalizeLifecycleScope(params.args.lifecycleScope),
-    taskStatusScope: normalizeTaskStatusScope(params.args.taskStatusScope),
-    limit: clampLimit(params.args.limit),
-    cursor:
-      typeof params.args.cursor === 'string' && params.args.cursor.trim()
-        ? params.args.cursor.trim()
-        : null,
-    excludeIds: params.excludeIds || [],
-  };
-
-  return { scope, warnings };
 }
 
 export function toPlannerAgentDto(result: PlannerAgentResult): PlannerAgentDto {
@@ -885,6 +83,18 @@ function plannerTools(): ChatToolDefinition[] {
             tags: { type: 'array', items: { type: 'string' } },
             excludeTags: { type: 'array', items: { type: 'string' } },
             semanticScope: { type: 'array', items: { type: 'string' } },
+            selection: {
+              type: 'string',
+              enum: ['relevance', 'recent'],
+              description:
+                'Use relevance for focused topic lookup. Use recent for broad analysis of the latest records; recent ignores semantic query ranking.',
+            },
+            dateField: {
+              type: 'string',
+              enum: ['createdAt', 'updatedAt'],
+              description:
+                'Date basis for recent retrieval: createdAt for recently written records, updatedAt for recently modified/activity records.',
+            },
             sourceTypes: { type: 'array', items: { type: 'string', enum: ['rote', 'article'] } },
             timeRange: {
               type: 'object',
@@ -899,16 +109,8 @@ function plannerTools(): ChatToolDefinition[] {
                   type: 'string',
                   enum: ['today', 'yesterday', 'this_month', 'last_month'],
                 },
-                fromDate: {
-                  type: 'string',
-                  description:
-                    'For absolute ranges only. ISO date/datetime such as 2026-05-08 or 2026-05-08T00:00:00+08:00.',
-                },
-                toDate: {
-                  type: 'string',
-                  description:
-                    'For absolute ranges only. ISO date/datetime such as 2026-05-09 or 2026-05-09T23:59:59+08:00.',
-                },
+                fromDate: { type: 'string' },
+                toDate: { type: 'string' },
                 amount: { type: 'number', description: 'For rolling ranges, e.g. 7.' },
                 unit: {
                   type: 'string',
@@ -917,7 +119,6 @@ function plannerTools(): ChatToolDefinition[] {
                 },
                 fromRelative: {
                   type: 'object',
-                  description: 'For relative_between ranges, e.g. 60 days ago.',
                   properties: {
                     amount: { type: 'number' },
                     unit: { type: 'string', enum: ['day', 'week', 'month', 'year'] },
@@ -926,7 +127,6 @@ function plannerTools(): ChatToolDefinition[] {
                 },
                 toRelative: {
                   type: 'object',
-                  description: 'For relative_between ranges, e.g. 30 days ago.',
                   properties: {
                     amount: { type: 'number' },
                     unit: { type: 'string', enum: ['day', 'week', 'month', 'year'] },
@@ -941,16 +141,8 @@ function plannerTools(): ChatToolDefinition[] {
               description:
                 'Relative range expression such as today, yesterday, last 7 days, or 最近7天.',
             },
-            from: {
-              type: 'string',
-              description:
-                'Absolute ISO date/datetime only, such as 2026-05-08 or 2026-05-08T00:00:00+08:00. Use timeExpression for relative ranges.',
-            },
-            to: {
-              type: 'string',
-              description:
-                'Absolute ISO date/datetime only, such as 2026-05-09 or 2026-05-09T23:59:59+08:00. Use timeExpression for relative ranges.',
-            },
+            from: { type: 'string' },
+            to: { type: 'string' },
             lifecycleScope: {
               type: 'string',
               enum: ['active', 'archived', 'all', 'unspecified'],
@@ -959,8 +151,7 @@ function plannerTools(): ChatToolDefinition[] {
             taskStatusScope: {
               type: 'string',
               enum: ['open', 'closed', 'all', 'unspecified'],
-              description:
-                'Task/open-loop semantic scope only. It is independent from lifecycleScope and does not map to archived.',
+              description: 'Task/open-loop semantic scope only.',
             },
             limit: { type: 'number' },
             cursor: { type: 'string' },
@@ -999,10 +190,7 @@ function plannerTools(): ChatToolDefinition[] {
         description: 'Ask the user one concise clarification question before retrieval.',
         parameters: {
           type: 'object',
-          properties: {
-            question: { type: 'string' },
-            reason: { type: 'string' },
-          },
+          properties: { question: { type: 'string' }, reason: { type: 'string' } },
           required: ['question'],
         },
       },
@@ -1028,21 +216,17 @@ Tools:
 
 Keep lifecycleScope and taskStatusScope independent. lifecycleScope is note archived/unarchived lifecycle. taskStatusScope is task/open-loop semantics and must not stand in for archived state.
 For relative date phrases, prefer structured timeRange preset/rolling/relative_between or pass the original phrase as timeExpression. Do not invent absolute from/to dates unless the user explicitly supplied absolute dates.
+For broad questions about recent/latest records, recurring themes, or recent trends, set selection to recent, use limit 30 when no count is requested, and use dateField createdAt unless the user asks about modifications or activity. For a focused topic within a recent window, use selection relevance plus an explicit timeRange/timeExpression. Never leave a clear recent request as an unbounded relevance search.
 Do not answer the user here.`;
 }
 
 function createEmptyTrace(): PlannerDebugTrace {
-  return {
-    toolCalls: [],
-    canonicalizedArgs: [],
-    warnings: [],
-    probeCounts: [],
-  };
+  return { toolCalls: [], canonicalizedArgs: [], warnings: [], probeCounts: [] };
 }
 
 function noRetrievalResult(
   message: string,
-  trace: PlannerDebugTrace,
+  trace: ReturnType<typeof createEmptyTrace>,
   reason: string
 ): PlannerAgentResult {
   return {
@@ -1079,12 +263,7 @@ export async function createRetrievalPlan(params: {
     { role: 'system', content: buildPlannerSystemPrompt(params.timeContext || undefined) },
   ];
   if (params.history?.length) {
-    messages.push(
-      ...params.history.slice(-8).map((message) => ({
-        role: message.role,
-        content: message.content,
-      }))
-    );
+    messages.push(...params.history.slice(-8).map((message) => ({ ...message })));
   }
   messages.push({ role: 'user', content: params.message });
 
@@ -1110,13 +289,11 @@ export async function createRetrievalPlan(params: {
     }
 
     if (response.usage) await params.onUsage?.(response.usage);
-
     const calls = response.message.tool_calls || [];
     if (!calls.length) {
       trace.fallbackReason = 'assistant_returned_no_tool_call';
       return noRetrievalResult(params.message, trace, 'assistant_returned_no_tool_call');
     }
-
     messages.push({
       role: 'assistant',
       content: response.message.content || null,
@@ -1147,17 +324,11 @@ export async function createRetrievalPlan(params: {
           ownerId: params.ownerId,
           args: asRecord(args) as SearchRotesArgs,
           availableTags,
+          message: params.message,
           excludeIds: params.excludeIds,
           timeContext: params.timeContext,
         });
-        let probe: SearchRotesProbeResult;
-        try {
-          probe = await params.executeSearch(scope);
-        } catch (error: any) {
-          trace.toolError = error?.message || String(error);
-          trace.fallbackReason = 'tool_error';
-          throw error;
-        }
+        const probe = await params.executeSearch(scope);
         lastSearch = {
           toolResult: {
             ...probe.toolResult,
@@ -1174,8 +345,7 @@ export async function createRetrievalPlan(params: {
           content: JSON.stringify(lastSearch.toolResult),
         });
       } else if (call.function.name === 'list_tags') {
-        const raw = asRecord(args);
-        const limit = clampLimit(raw.limit);
+        const limit = clampLimit(asRecord(args).limit);
         const tags = (
           await (params.getTagCounts || (() => getUserRoteTagCounts(params.ownerId)))()
         ).slice(0, limit);
@@ -1199,9 +369,7 @@ export async function createRetrievalPlan(params: {
             debugTrace: trace,
           };
         }
-        if (raw.retrievalNeeded === false) {
-          return noRetrievalResult(params.message, trace, reason);
-        }
+        if (raw.retrievalNeeded === false) return noRetrievalResult(params.message, trace, reason);
         messages.push({
           role: 'tool',
           tool_call_id: call.id,

--- a/server/utils/ai/retrievalScope.ts
+++ b/server/utils/ai/retrievalScope.ts
@@ -99,15 +99,6 @@ function hasBroadRecentAnalysis(message?: string): boolean {
   return /主题|趋势|重复|反复|模式|总结|themes?|trends?|patterns?|review/i.test(message || '');
 }
 
-function hasExplicitTimeInput(args: SearchRotesArgs): boolean {
-  return Boolean(
-    args.timeRange ||
-    args.timeExpression?.trim() ||
-    (typeof args.from === 'string' && args.from.trim()) ||
-    (typeof args.to === 'string' && args.to.trim())
-  );
-}
-
 function inferDateField(message?: string): RetrievalDateField {
   return /修改|更新|活动|改过|updated|modified|activity/i.test(message || '')
     ? 'updatedAt'
@@ -177,12 +168,11 @@ export function canonicalizeSearchRotesArgs(params: {
     }
   });
 
+  const timeRange = canonicalizeTimeRange(params.args, warnings, params.timeContext || undefined);
   const requestedSelection = normalizeRetrievalSelection(params.args.selection, warnings);
-  const inferredRecentSelection =
-    params.args.selection === undefined &&
-    hasRecentLanguage(params.message) &&
-    (!hasExplicitTimeInput(params.args) || hasBroadRecentAnalysis(params.message));
-  const selection = requestedSelection || (inferredRecentSelection ? 'recent' : 'relevance');
+  const recentSafetyRequired =
+    hasRecentLanguage(params.message) && (!timeRange || hasBroadRecentAnalysis(params.message));
+  const selection = recentSafetyRequired ? 'recent' : requestedSelection || 'relevance';
   const requestedDateField = normalizeRetrievalDateField(params.args.dateField, warnings);
   const dateField = requestedDateField || inferDateField(params.message);
   const defaultLimit =
@@ -198,7 +188,7 @@ export function canonicalizeSearchRotesArgs(params: {
       excludeTags: Array.from(new Set(excludeTags)),
       semanticScope: Array.from(semanticScope).slice(0, 30),
       sourceTypes: normalizeSourceTypes(params.args.sourceTypes, warnings),
-      timeRange: canonicalizeTimeRange(params.args, warnings, params.timeContext || undefined),
+      timeRange,
       selection,
       dateField,
       lifecycleScope: normalizeLifecycleScope(params.args.lifecycleScope),

--- a/server/utils/ai/retrievalScope.ts
+++ b/server/utils/ai/retrievalScope.ts
@@ -1,0 +1,215 @@
+import { sql } from 'drizzle-orm';
+import { rotes } from '../../drizzle/schema';
+import db from '../drizzle';
+import { canonicalizeTimeRange } from './retrievalTimeRange';
+import type {
+  AiSourceType,
+  LifecycleScope,
+  RetrievalDateField,
+  RetrievalScope,
+  RetrievalSelection,
+  RetrievalTimeContext,
+  SearchRotesArgs,
+  TaskStatusScope,
+} from './retrievalTypes';
+
+const VALID_SOURCE_TYPES = new Set<AiSourceType>(['rote', 'article']);
+const VALID_RETRIEVAL_SELECTIONS = new Set<RetrievalSelection>(['relevance', 'recent']);
+const VALID_RETRIEVAL_DATE_FIELDS = new Set<RetrievalDateField>(['createdAt', 'updatedAt']);
+const VALID_LIFECYCLE_SCOPES = new Set<LifecycleScope>([
+  'active',
+  'archived',
+  'all',
+  'unspecified',
+]);
+const VALID_TASK_STATUS_SCOPES = new Set<TaskStatusScope>(['open', 'closed', 'all', 'unspecified']);
+const DEFAULT_LIMIT = 15;
+const DEFAULT_RECENT_LIMIT = 30;
+const MAX_LIMIT = 50;
+
+function uniqueStrings(value: unknown, limit = 30): string[] {
+  if (!Array.isArray(value)) return [];
+  return Array.from(
+    new Set(
+      value
+        .map((item) => (typeof item === 'string' ? item.trim().replace(/^#/, '') : ''))
+        .filter(Boolean)
+    )
+  ).slice(0, limit);
+}
+
+function clampLimit(value: unknown, fallback = DEFAULT_LIMIT): number {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return fallback;
+  return Math.min(Math.max(Math.floor(numeric), 1), MAX_LIMIT);
+}
+
+function normalizeSourceTypes(value: unknown, warnings: string[]): AiSourceType[] {
+  if (!Array.isArray(value)) return ['rote', 'article'];
+  const valid = uniqueStrings(value)
+    .filter((type): type is AiSourceType => VALID_SOURCE_TYPES.has(type as AiSourceType))
+    .slice(0, 2);
+  uniqueStrings(value)
+    .filter((type) => !VALID_SOURCE_TYPES.has(type as AiSourceType))
+    .forEach((type) => warnings.push(`invalid_source_type:${type}`));
+  return valid.length ? valid : ['rote', 'article'];
+}
+
+function normalizeLifecycleScope(value: unknown): LifecycleScope {
+  return VALID_LIFECYCLE_SCOPES.has(value as LifecycleScope)
+    ? (value as LifecycleScope)
+    : 'unspecified';
+}
+
+function normalizeTaskStatusScope(value: unknown): TaskStatusScope {
+  return VALID_TASK_STATUS_SCOPES.has(value as TaskStatusScope)
+    ? (value as TaskStatusScope)
+    : 'unspecified';
+}
+
+function normalizeRetrievalSelection(
+  value: unknown,
+  warnings: string[]
+): RetrievalSelection | null {
+  if (value === undefined) return null;
+  if (VALID_RETRIEVAL_SELECTIONS.has(value as RetrievalSelection)) {
+    return value as RetrievalSelection;
+  }
+  warnings.push(`invalid_selection:${String(value)}`);
+  return null;
+}
+
+function normalizeRetrievalDateField(
+  value: unknown,
+  warnings: string[]
+): RetrievalDateField | null {
+  if (value === undefined) return null;
+  if (VALID_RETRIEVAL_DATE_FIELDS.has(value as RetrievalDateField)) {
+    return value as RetrievalDateField;
+  }
+  warnings.push(`invalid_date_field:${String(value)}`);
+  return null;
+}
+
+function hasRecentLanguage(message?: string): boolean {
+  return /最近|近期|最新|近来|recent|latest/i.test(message || '');
+}
+
+function hasBroadRecentAnalysis(message?: string): boolean {
+  return /主题|趋势|重复|反复|模式|总结|themes?|trends?|patterns?|review/i.test(message || '');
+}
+
+function hasExplicitTimeInput(args: SearchRotesArgs): boolean {
+  return Boolean(
+    args.timeRange ||
+    args.timeExpression?.trim() ||
+    (typeof args.from === 'string' && args.from.trim()) ||
+    (typeof args.to === 'string' && args.to.trim())
+  );
+}
+
+function inferDateField(message?: string): RetrievalDateField {
+  return /修改|更新|活动|改过|updated|modified|activity/i.test(message || '')
+    ? 'updatedAt'
+    : 'createdAt';
+}
+
+export function lifecycleScopeToArchived(scope: LifecycleScope): boolean | null {
+  if (scope === 'active') return false;
+  if (scope === 'archived') return true;
+  return null;
+}
+
+export async function getUserRoteTags(ownerId: string): Promise<string[]> {
+  const rows = (await db
+    .select({ tags: rotes.tags })
+    .from(rotes)
+    .where(sql`${rotes.authorid} = ${ownerId}`)) as Array<{ tags: string[] | null }>;
+  return Array.from(
+    new Set(rows.flatMap((row) => (Array.isArray(row.tags) ? row.tags : [])).filter(Boolean))
+  ).sort((a, b) => a.localeCompare(b));
+}
+
+export async function getUserRoteTagCounts(
+  ownerId: string
+): Promise<Array<{ name: string; count: number }>> {
+  const rows = (await db
+    .select({ tags: rotes.tags })
+    .from(rotes)
+    .where(sql`${rotes.authorid} = ${ownerId}`)) as Array<{ tags: string[] | null }>;
+  const counts = new Map<string, number>();
+  rows.forEach((row) => {
+    (Array.isArray(row.tags) ? row.tags : []).forEach((tag) => {
+      if (tag) counts.set(tag, (counts.get(tag) || 0) + 1);
+    });
+  });
+  return Array.from(counts.entries())
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+}
+
+export function canonicalizeSearchRotesArgs(params: {
+  ownerId: string;
+  args: SearchRotesArgs;
+  availableTags: string[];
+  message?: string;
+  excludeIds?: string[];
+  timeContext?: RetrievalTimeContext | null;
+}): { scope: RetrievalScope; warnings: string[] } {
+  const warnings: string[] = [];
+  const availableTagSet = new Set(params.availableTags);
+  const semanticScope = new Set(uniqueStrings(params.args.semanticScope));
+  const tags: string[] = [];
+  const excludeTags: string[] = [];
+
+  uniqueStrings(params.args.tags).forEach((tag) => {
+    if (availableTagSet.has(tag)) tags.push(tag);
+    else {
+      semanticScope.add(tag);
+      warnings.push(`unknown_tag_downgraded:${tag}`);
+    }
+  });
+  uniqueStrings(params.args.excludeTags).forEach((tag) => {
+    if (availableTagSet.has(tag)) excludeTags.push(tag);
+    else {
+      semanticScope.add(tag);
+      warnings.push(`unknown_exclude_tag_downgraded:${tag}`);
+    }
+  });
+
+  const requestedSelection = normalizeRetrievalSelection(params.args.selection, warnings);
+  const inferredRecentSelection =
+    params.args.selection === undefined &&
+    hasRecentLanguage(params.message) &&
+    (!hasExplicitTimeInput(params.args) || hasBroadRecentAnalysis(params.message));
+  const selection = requestedSelection || (inferredRecentSelection ? 'recent' : 'relevance');
+  const requestedDateField = normalizeRetrievalDateField(params.args.dateField, warnings);
+  const dateField = requestedDateField || inferDateField(params.message);
+  const defaultLimit =
+    selection === 'recent' && params.args.limit === undefined
+      ? DEFAULT_RECENT_LIMIT
+      : DEFAULT_LIMIT;
+
+  return {
+    scope: {
+      ownerId: params.ownerId,
+      query: typeof params.args.query === 'string' ? params.args.query.trim() : '',
+      tags: Array.from(new Set(tags)),
+      excludeTags: Array.from(new Set(excludeTags)),
+      semanticScope: Array.from(semanticScope).slice(0, 30),
+      sourceTypes: normalizeSourceTypes(params.args.sourceTypes, warnings),
+      timeRange: canonicalizeTimeRange(params.args, warnings, params.timeContext || undefined),
+      selection,
+      dateField,
+      lifecycleScope: normalizeLifecycleScope(params.args.lifecycleScope),
+      taskStatusScope: normalizeTaskStatusScope(params.args.taskStatusScope),
+      limit: clampLimit(params.args.limit, defaultLimit),
+      cursor:
+        typeof params.args.cursor === 'string' && params.args.cursor.trim()
+          ? params.args.cursor.trim()
+          : null,
+      excludeIds: params.excludeIds || [],
+    },
+    warnings,
+  };
+}

--- a/server/utils/ai/retrievalTimeRange.ts
+++ b/server/utils/ai/retrievalTimeRange.ts
@@ -1,0 +1,259 @@
+import {
+  addDays,
+  addMonths,
+  addRelativeOffset,
+  chineseNumberToInt,
+  endOfDay,
+  getTodayInTimeContext,
+  monthRange,
+  startOfDay,
+  unitTextToUnit,
+} from './retrievalDate';
+import { normalizeTimeRangeInput } from './retrievalDateParsing';
+import type {
+  AiTimeUnit,
+  NormalizedTimeRange,
+  RetrievalTimeContext,
+  SearchRotesArgs,
+  StructuredTimeRangePreset,
+  StructuredTimeRangeType,
+} from './retrievalTypes';
+
+const VALID_STRUCTURED_TIME_TYPES = new Set<StructuredTimeRangeType>([
+  'absolute',
+  'rolling',
+  'relative_between',
+  'preset',
+]);
+const VALID_STRUCTURED_TIME_PRESETS = new Set<StructuredTimeRangePreset>([
+  'today',
+  'yesterday',
+  'this_month',
+  'last_month',
+]);
+const VALID_STRUCTURED_TIME_UNITS = new Set<AiTimeUnit>(['day', 'week', 'month', 'year']);
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function normalizeStructuredTimeUnit(value: unknown): AiTimeUnit | null {
+  if (typeof value !== 'string') return null;
+  const unit = value.trim().toLowerCase();
+  if (unit === 'days') return 'day';
+  if (unit === 'weeks') return 'week';
+  if (unit === 'months') return 'month';
+  if (unit === 'years') return 'year';
+  return VALID_STRUCTURED_TIME_UNITS.has(unit as AiTimeUnit) ? (unit as AiTimeUnit) : null;
+}
+
+function normalizeStructuredAmount(value: unknown): number | null {
+  const amount = Number(value);
+  if (!Number.isFinite(amount)) return null;
+  const normalized = Math.floor(amount);
+  return normalized >= 1 && normalized <= 10000 ? normalized : null;
+}
+
+function structuredLabel(raw: Record<string, unknown>, fallback: string): string {
+  return typeof raw.label === 'string' && raw.label.trim() ? raw.label.trim() : fallback;
+}
+
+function formatRelativePointLabel(point: Record<string, unknown>): string {
+  const amount = normalizeStructuredAmount(point.amount) || 0;
+  const unit = normalizeStructuredTimeUnit(point.unit) || 'day';
+  return `${amount} ${unit}${amount === 1 ? '' : 's'} ago`;
+}
+
+function normalizeStructuredRelativePoint(
+  value: unknown,
+  end = false,
+  context?: RetrievalTimeContext
+): string | null {
+  const point = asRecord(value);
+  const amount = normalizeStructuredAmount(point.amount);
+  const unit = normalizeStructuredTimeUnit(point.unit);
+  const direction = typeof point.direction === 'string' ? point.direction.trim() : 'ago';
+  if (!amount || !unit || direction !== 'ago') return null;
+
+  const today = getTodayInTimeContext(context);
+  const date =
+    unit === 'month'
+      ? addMonths(today, -amount)
+      : unit === 'year'
+        ? addMonths(today, -amount * 12)
+        : addDays(today, -(unit === 'day' ? amount : amount * 7));
+  return end ? endOfDay(date, context) : startOfDay(date, context);
+}
+
+function isOrderedTimeRange(from: string, to: string): boolean {
+  const fromTime = Date.parse(from);
+  const toTime = Date.parse(to);
+  return Number.isFinite(fromTime) && Number.isFinite(toTime) && fromTime <= toTime;
+}
+
+function canonicalizePresetTimeRange(
+  preset: StructuredTimeRangePreset,
+  raw: Record<string, unknown>,
+  context?: RetrievalTimeContext
+): NormalizedTimeRange {
+  const today = getTodayInTimeContext(context);
+  if (preset === 'today') {
+    return {
+      from: startOfDay(today, context),
+      to: endOfDay(today, context),
+      label: structuredLabel(raw, '今天'),
+    };
+  }
+  if (preset === 'yesterday') {
+    const yesterday = addDays(today, -1);
+    return {
+      from: startOfDay(yesterday, context),
+      to: endOfDay(yesterday, context),
+      label: structuredLabel(raw, '昨天'),
+    };
+  }
+  if (preset === 'this_month') {
+    const start = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 1));
+    return {
+      from: startOfDay(start, context),
+      to: endOfDay(today, context),
+      label: structuredLabel(raw, '本月'),
+    };
+  }
+  const range = monthRange(today.getUTCFullYear(), today.getUTCMonth() - 1, '上个月', context);
+  return { ...range, label: structuredLabel(raw, range.label) };
+}
+
+function canonicalizeStructuredTimeRange(
+  value: unknown,
+  context?: RetrievalTimeContext
+): NormalizedTimeRange | null {
+  const raw = asRecord(value);
+  if (!Object.keys(raw).length) return null;
+
+  const type = VALID_STRUCTURED_TIME_TYPES.has(raw.type as StructuredTimeRangeType)
+    ? (raw.type as StructuredTimeRangeType)
+    : undefined;
+  const preset = VALID_STRUCTURED_TIME_PRESETS.has(raw.preset as StructuredTimeRangePreset)
+    ? (raw.preset as StructuredTimeRangePreset)
+    : undefined;
+
+  const parsePreset = () => (preset ? canonicalizePresetTimeRange(preset, raw, context) : null);
+  const parseRolling = () => {
+    const amount = normalizeStructuredAmount(raw.amount);
+    const unit = normalizeStructuredTimeUnit(raw.unit);
+    if (!amount || !unit) return null;
+    const today = getTodayInTimeContext(context);
+    const start =
+      unit === 'month'
+        ? addMonths(today, -amount)
+        : unit === 'year'
+          ? addMonths(today, -amount * 12)
+          : addDays(today, -(unit === 'day' ? amount : amount * 7));
+    return {
+      from: startOfDay(start, context),
+      to: endOfDay(today, context),
+      label: structuredLabel(raw, `last ${amount} ${unit}${amount === 1 ? '' : 's'}`),
+    };
+  };
+  const parseRelativeBetween = () => {
+    const from = normalizeStructuredRelativePoint(raw.fromRelative, false, context);
+    const to = normalizeStructuredRelativePoint(raw.toRelative, true, context);
+    if (!from || !to || !isOrderedTimeRange(from, to)) return null;
+    return {
+      from,
+      to,
+      label: structuredLabel(
+        raw,
+        `${formatRelativePointLabel(asRecord(raw.fromRelative))} 到 ${formatRelativePointLabel(asRecord(raw.toRelative))}`
+      ),
+    };
+  };
+  const parseAbsolute = () =>
+    normalizeTimeRangeInput({ from: raw.fromDate, to: raw.toDate, label: raw.label }, context);
+
+  if (type === 'absolute') return parseAbsolute();
+  if (type === 'rolling') return parseRolling();
+  if (type === 'relative_between') return parseRelativeBetween();
+  if (type === 'preset') return parsePreset();
+  if (preset) return parsePreset();
+  if (raw.fromRelative || raw.toRelative) return parseRelativeBetween();
+  if (raw.amount !== undefined || raw.unit !== undefined) return parseRolling();
+  if (raw.fromDate !== undefined || raw.toDate !== undefined) return parseAbsolute();
+  return null;
+}
+
+export function canonicalizeTimeRange(
+  args: SearchRotesArgs,
+  warnings?: string[],
+  context?: RetrievalTimeContext
+): NormalizedTimeRange | null {
+  if (args.timeRange !== undefined) {
+    const structured = canonicalizeStructuredTimeRange(args.timeRange, context);
+    if (structured) return structured;
+    warnings?.push('invalid_time_range_ignored');
+  }
+
+  const from = typeof args.from === 'string' ? args.from.trim() : '';
+  const to = typeof args.to === 'string' ? args.to.trim() : '';
+  if (from && to) {
+    const normalized = normalizeTimeRangeInput({ from, to, label: `${from} 到 ${to}` }, context);
+    if (!normalized) warnings?.push('invalid_time_range_ignored');
+    return normalized;
+  }
+
+  const expression = typeof args.timeExpression === 'string' ? args.timeExpression.trim() : '';
+  if (!expression) return null;
+
+  const today = getTodayInTimeContext(context);
+  if (/今天|今日|today/i.test(expression)) {
+    return { from: startOfDay(today, context), to: endOfDay(today, context), label: '今天' };
+  }
+  if (/昨天|昨日|yesterday/i.test(expression)) {
+    const yesterday = addDays(today, -1);
+    return {
+      from: startOfDay(yesterday, context),
+      to: endOfDay(yesterday, context),
+      label: '昨天',
+    };
+  }
+  if (/本月|这个月|this month/i.test(expression)) {
+    const start = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 1));
+    return { from: startOfDay(start, context), to: endOfDay(today, context), label: '本月' };
+  }
+  if (/上个月|上月|last month/i.test(expression)) {
+    return monthRange(today.getUTCFullYear(), today.getUTCMonth() - 1, '上个月', context);
+  }
+
+  const rollingMatch = expression.match(
+    /(?:最近|近|过去|前|last|past|previous|recent)\s*(\d+|[一二两三四五六七八九十]+)\s*(天|日|周|星期|个月|月|年|days?|weeks?|months?|years?)/i
+  );
+  if (rollingMatch) {
+    const normalizedAmount = chineseNumberToInt(rollingMatch[1]);
+    if (normalizedAmount) {
+      const offsetUnit = unitTextToUnit(rollingMatch[2]);
+      const start = addRelativeOffset(today, normalizedAmount, offsetUnit);
+      return {
+        from: startOfDay(start, context),
+        to: endOfDay(today, context),
+        label: rollingMatch[0],
+      };
+    }
+  }
+
+  const explicitRange = expression.match(
+    /(\d{4}[-/.]\d{1,2}[-/.]\d{1,2})\s*(?:到|至|~|-|—)\s*(\d{4}[-/.]\d{1,2}[-/.]\d{1,2})/
+  );
+  if (explicitRange) {
+    const normalized = normalizeTimeRangeInput(
+      { from: explicitRange[1], to: explicitRange[2], label: explicitRange[0] },
+      context
+    );
+    if (!normalized) warnings?.push('invalid_time_range_ignored');
+    return normalized;
+  }
+
+  return null;
+}

--- a/server/utils/ai/retrievalTypes.ts
+++ b/server/utils/ai/retrievalTypes.ts
@@ -1,0 +1,138 @@
+export type AiSourceType = 'rote' | 'article';
+export type LifecycleScope = 'active' | 'archived' | 'all' | 'unspecified';
+export type TaskStatusScope = 'open' | 'closed' | 'all' | 'unspecified';
+export type AiTimeUnit = 'day' | 'week' | 'month' | 'year';
+export type RetrievalSelection = 'relevance' | 'recent';
+export type RetrievalDateField = 'createdAt' | 'updatedAt';
+
+export interface NormalizedTimeRange {
+  from: string;
+  to: string;
+  label: string;
+}
+
+export type StructuredTimeRangeType = 'absolute' | 'rolling' | 'relative_between' | 'preset';
+export type StructuredTimeRangePreset = 'today' | 'yesterday' | 'this_month' | 'last_month';
+
+export interface StructuredRelativeTimePoint {
+  amount?: number;
+  unit?: AiTimeUnit;
+  direction?: 'ago';
+}
+
+export interface StructuredTimeRange {
+  type?: StructuredTimeRangeType;
+  preset?: StructuredTimeRangePreset;
+  fromDate?: string;
+  toDate?: string;
+  amount?: number;
+  unit?: AiTimeUnit;
+  fromRelative?: StructuredRelativeTimePoint;
+  toRelative?: StructuredRelativeTimePoint;
+  label?: string;
+}
+
+export interface RetrievalScope {
+  ownerId: string;
+  query: string;
+  tags: string[];
+  excludeTags: string[];
+  semanticScope: string[];
+  sourceTypes: AiSourceType[];
+  timeRange: NormalizedTimeRange | null;
+  selection: RetrievalSelection;
+  dateField: RetrievalDateField;
+  lifecycleScope: LifecycleScope;
+  taskStatusScope: TaskStatusScope;
+  limit: number;
+  cursor: string | null;
+  excludeIds: string[];
+}
+
+export interface SearchRotesArgs {
+  query?: string;
+  tags?: string[];
+  excludeTags?: string[];
+  semanticScope?: string[];
+  sourceTypes?: AiSourceType[];
+  timeRange?: StructuredTimeRange;
+  timeExpression?: string;
+  from?: string;
+  to?: string;
+  selection?: RetrievalSelection;
+  dateField?: RetrievalDateField;
+  lifecycleScope?: LifecycleScope;
+  taskStatusScope?: TaskStatusScope;
+  limit?: number;
+  cursor?: string;
+}
+
+export interface RetrievalTimeContext {
+  nowIso?: string;
+  localDate?: string;
+  localDateTime?: string;
+  timeZone?: string;
+  utcOffsetMinutes?: number;
+}
+
+export interface RetrievalSnippet {
+  id: string;
+  sourceType: AiSourceType;
+  sourceId: string;
+  title?: string;
+  tags?: string[];
+  createdAt?: string;
+  updatedAt?: string;
+  retrievalMode?: RetrievalSelection;
+  similarity: number;
+  text: string;
+}
+
+export interface RetrievalToolResult {
+  canonicalizedArgs: RetrievalScope;
+  resultCount: number;
+  topSnippets: RetrievalSnippet[];
+  cursor: string | null;
+  warnings: string[];
+}
+
+export interface SearchRotesProbeResult {
+  toolResult: RetrievalToolResult;
+  sources: unknown[];
+}
+
+export interface PlannerDebugTrace {
+  toolCalls: Array<{
+    step: number;
+    name: string;
+    args: unknown;
+  }>;
+  canonicalizedArgs: RetrievalScope[];
+  warnings: string[];
+  probeCounts: number[];
+  finishReason?: string;
+  fallbackReason?: string;
+  providerError?: string;
+  toolError?: string;
+}
+
+export interface PlannerAgentResult {
+  originalMessage: string;
+  retrievalNeeded: boolean;
+  scope: RetrievalScope | null;
+  toolResult: RetrievalToolResult | null;
+  sources: unknown[];
+  clarification: { question: string; reason?: string } | null;
+  debugTrace: PlannerDebugTrace;
+}
+
+export interface PlannerAgentDto {
+  originalMessage: string;
+  retrievalNeeded: boolean;
+  scope: RetrievalScope | null;
+  toolResult: RetrievalToolResult | null;
+  clarification: { question: string; reason?: string } | null;
+  debugTrace: PlannerDebugTrace;
+}
+
+export type SearchRotesProbeExecutor = (scope: RetrievalScope) => Promise<SearchRotesProbeResult>;

--- a/server/utils/dbMethods/ai.ts
+++ b/server/utils/dbMethods/ai.ts
@@ -32,7 +32,7 @@ export {
   retryFailedEmbeddingJobs,
   setIndexingPaused,
 } from './ai/jobs';
-export { searchMemoryWithFallback, semanticSearch, textSearchMemory } from './ai/search';
+export { searchMemory, semanticSearch, textSearchMemory } from './ai/search';
 export {
   buildAnswerMessagesFromPlannerResult,
   chatWithRoteContext,

--- a/server/utils/dbMethods/ai.ts
+++ b/server/utils/dbMethods/ai.ts
@@ -5,6 +5,8 @@ export type {
   NormalizedTimeRange,
   PlannerAgentDto,
   PlannerAgentResult,
+  RetrievalDateField,
+  RetrievalSelection,
   RetrievalScope,
   RetrievalToolResult,
   SearchRotesArgs,

--- a/server/utils/dbMethods/ai/chat.ts
+++ b/server/utils/dbMethods/ai/chat.ts
@@ -9,7 +9,7 @@ import {
 import { logAiTokenUsage } from '../aiToken';
 import { getStoredAiConfig } from './config';
 import { fallbackAnswer } from './documents';
-import { searchMemoryWithFallback } from './search';
+import { searchMemory } from './search';
 import type {
   PlannerAgentDto,
   PlannerAgentResult,
@@ -86,7 +86,7 @@ export async function searchRotesProbe(scope: RetrievalScope): Promise<SearchRot
   if (scope.cursor && cursorExcludeIds.length === 0) warnings.push('invalid_cursor_ignored');
   const excludeIds = sanitizeExcludeIds([...scope.excludeIds, ...cursorExcludeIds]);
 
-  const { sources, warnings: searchWarnings } = await searchMemoryWithFallback({
+  const { sources, warnings: searchWarnings } = await searchMemory({
     query: scope.query,
     ownerId: scope.ownerId,
     sourceTypes: scope.sourceTypes,

--- a/server/utils/dbMethods/ai/chat.ts
+++ b/server/utils/dbMethods/ai/chat.ts
@@ -53,6 +53,8 @@ function sourceToSnippet(source: SemanticSearchResult): RetrievalSnippet {
       ? metadata.tags.filter((tag: unknown) => typeof tag === 'string')
       : [],
     createdAt: typeof metadata.createdAt === 'string' ? metadata.createdAt : undefined,
+    updatedAt: typeof metadata.updatedAt === 'string' ? metadata.updatedAt : undefined,
+    retrievalMode: source.retrievalMode,
     similarity: Number(source.similarity.toFixed(3)),
     text: source.text.replace(/\s+/g, ' ').trim().slice(0, 600),
   };
@@ -89,6 +91,8 @@ export async function searchRotesProbe(scope: RetrievalScope): Promise<SearchRot
     ownerId: scope.ownerId,
     sourceTypes: scope.sourceTypes,
     timeRange: scope.timeRange,
+    selection: scope.selection,
+    dateField: scope.dateField,
     tags: {
       include: scope.tags,
       exclude: scope.excludeTags,
@@ -130,7 +134,11 @@ function buildProbeEvidence(result: PlannerAgentResult): string {
       const createdAt = snippet.createdAt
         ? `\nCreated: ${formatEvidenceDate(snippet.createdAt)}`
         : '';
-      return `[${index + 1}] ${snippet.sourceType}:${snippet.sourceId}${title}${tags}${createdAt}\nSimilarity: ${snippet.similarity}\nExcerpt:\n${snippet.text}`;
+      const ranking =
+        snippet.retrievalMode === 'recent'
+          ? '\nSelection: recent records'
+          : `\nSimilarity: ${snippet.similarity}`;
+      return `[${index + 1}] ${snippet.sourceType}:${snippet.sourceId}${title}${tags}${createdAt}${ranking}\nExcerpt:\n${snippet.text}`;
     })
     .join('\n\n');
 }
@@ -145,6 +153,8 @@ function buildScopeText(scope: RetrievalScope | null): string {
       semanticScope: scope.semanticScope,
       sourceTypes: scope.sourceTypes,
       timeRange: scope.timeRange,
+      selection: scope.selection,
+      dateField: scope.dateField,
       lifecycleScope: scope.lifecycleScope,
       taskStatusScope: scope.taskStatusScope,
       limit: scope.limit,

--- a/server/utils/dbMethods/ai/search.ts
+++ b/server/utils/dbMethods/ai/search.ts
@@ -1,2 +1,2 @@
 export { semanticSearch } from './semanticSearch';
-export { searchMemoryWithFallback, textSearchMemory } from './textSearch';
+export { searchMemory, textSearchMemory } from './textSearch';

--- a/server/utils/dbMethods/ai/semanticSearch.ts
+++ b/server/utils/dbMethods/ai/semanticSearch.ts
@@ -12,7 +12,12 @@ import {
   normalizeSearchTimeRange,
   VALID_SOURCE_TYPES,
 } from './documents';
-import type { AiSourceType, NormalizedTimeRange, SemanticSearchResult } from './types';
+import type {
+  AiSourceType,
+  NormalizedTimeRange,
+  RetrievalDateField,
+  SemanticSearchResult,
+} from './types';
 
 export async function semanticSearch(params: {
   query: string;
@@ -20,6 +25,7 @@ export async function semanticSearch(params: {
   scope?: 'mine' | 'public';
   sourceTypes?: AiSourceType[];
   timeRange?: NormalizedTimeRange | null;
+  dateField?: RetrievalDateField;
   tags?: { include?: string[]; exclude?: string[]; match?: 'any' | 'all' };
   semanticScope?: string[];
   state?: 'private' | 'public' | 'all';
@@ -39,6 +45,7 @@ export async function semanticSearch(params: {
   const dimensions = normalizeEmbeddingDimensions(config.embedding.dimensions);
   const limit = normalizeLimit(params.limit);
   const { timeRange } = normalizeSearchTimeRange(params.timeRange);
+  const dateField = params.dateField === 'updatedAt' ? 'updatedAt' : 'createdAt';
   const queryText = [params.query, ...(params.semanticScope || [])].filter(Boolean).join('\n');
 
   let queryEmbedding: number[];
@@ -125,9 +132,9 @@ export async function semanticSearch(params: {
   const timeRangeSql = timeRange
     ? sql`
       AND (
-        (de."sourceType" = 'rote' AND r."createdAt" >= ${timeRange.from}::timestamptz AND r."createdAt" <= ${timeRange.to}::timestamptz)
+        (de."sourceType" = 'rote' AND r.${sql.raw(`"${dateField}"`)} >= ${timeRange.from}::timestamptz AND r.${sql.raw(`"${dateField}"`)} <= ${timeRange.to}::timestamptz)
         OR
-        (de."sourceType" = 'article' AND a."createdAt" >= ${timeRange.from}::timestamptz AND a."createdAt" <= ${timeRange.to}::timestamptz)
+        (de."sourceType" = 'article' AND a.${sql.raw(`"${dateField}"`)} >= ${timeRange.from}::timestamptz AND a.${sql.raw(`"${dateField}"`)} <= ${timeRange.to}::timestamptz)
       )
     `
     : sql``;

--- a/server/utils/dbMethods/ai/textSearch.ts
+++ b/server/utils/dbMethods/ai/textSearch.ts
@@ -267,10 +267,10 @@ export async function textSearchMemory(params: {
   };
 
   const matched = await runSearch(terms);
-  return matched.length || terms.length === 0 ? matched : runSearch([]);
+  return matched;
 }
 
-export async function searchMemoryWithFallback(params: {
+export async function searchMemory(params: {
   query: string;
   ownerId?: string;
   scope?: 'mine' | 'public';
@@ -294,13 +294,5 @@ export async function searchMemoryWithFallback(params: {
       warnings,
     };
   }
-  try {
-    return { sources: await semanticSearch(safeParams), warnings };
-  } catch (error: any) {
-    if (params.scope === 'public') throw error;
-    return {
-      sources: await textSearchMemory(safeParams),
-      warnings: [...warnings, 'semantic_search_fallback_text'],
-    };
-  }
+  return { sources: await semanticSearch(safeParams), warnings };
 }

--- a/server/utils/dbMethods/ai/textSearch.ts
+++ b/server/utils/dbMethods/ai/textSearch.ts
@@ -114,7 +114,7 @@ function buildTextSearchTimeSql(
 
 function buildTextSearchOrderSql(alias: 'r' | 'a', dateField: RetrievalDateField = 'updatedAt') {
   const column = dateField === 'updatedAt' ? 'updatedAt' : 'createdAt';
-  return sql`${alias}.${sql.raw(`"${column}"`)} DESC, ${alias}."id" DESC`;
+  return sql`${sql.raw(`${alias}."${column}"`)} DESC, ${sql.raw(`${alias}."id"`)} DESC`;
 }
 
 function getResultDate(result: SemanticSearchResult, dateField: RetrievalDateField): number {

--- a/server/utils/dbMethods/ai/textSearch.ts
+++ b/server/utils/dbMethods/ai/textSearch.ts
@@ -7,7 +7,13 @@ import {
 } from './documents';
 import db from '../../drizzle';
 import { semanticSearch } from './semanticSearch';
-import type { AiSourceType, NormalizedTimeRange, SemanticSearchResult } from './types';
+import type {
+  AiSourceType,
+  NormalizedTimeRange,
+  RetrievalDateField,
+  RetrievalSelection,
+  SemanticSearchResult,
+} from './types';
 
 function extractTextSearchTerms(...values: Array<string | string[] | undefined>): string[] {
   const text = values.flat().filter(Boolean).join(' ');
@@ -20,7 +26,13 @@ function maybeDateString(value: unknown): string | undefined {
   return typeof value === 'string' ? value : undefined;
 }
 
-function buildTextSearchResult(row: any, sourceType: AiSourceType, similarity: number) {
+function buildTextSearchResult(
+  row: any,
+  sourceType: AiSourceType,
+  similarity: number,
+  retrievalMode: RetrievalSelection = 'relevance',
+  dateField: RetrievalDateField = 'createdAt'
+) {
   if (sourceType === 'rote') {
     const text = `Title: ${row.title || ''}\nTags: ${(row.tags || []).join(', ')}\n${row.content || ''}`;
     return {
@@ -31,6 +43,7 @@ function buildTextSearchResult(row: any, sourceType: AiSourceType, similarity: n
       chunkIndex: 0,
       text,
       similarity,
+      retrievalMode,
       metadata: {
         title: row.title || '',
         tags: row.tags || [],
@@ -38,6 +51,8 @@ function buildTextSearchResult(row: any, sourceType: AiSourceType, similarity: n
         archived: row.archived,
         createdAt: maybeDateString(row.createdAt),
         updatedAt: maybeDateString(row.updatedAt),
+        retrievalMode,
+        retrievalDateField: dateField,
       },
     } satisfies SemanticSearchResult;
   }
@@ -50,9 +65,12 @@ function buildTextSearchResult(row: any, sourceType: AiSourceType, similarity: n
     chunkIndex: 0,
     text: row.content || '',
     similarity,
+    retrievalMode,
     metadata: {
       createdAt: maybeDateString(row.createdAt),
       updatedAt: maybeDateString(row.updatedAt),
+      retrievalMode,
+      retrievalDateField: dateField,
     },
   } satisfies SemanticSearchResult;
 }
@@ -82,11 +100,27 @@ function buildArticleTextTermSql(terms: string[]) {
   return sql`AND (${sql.join(clauses, sql` OR `)})`;
 }
 
-function buildTextSearchTimeSql(alias: 'r' | 'a', timeRange?: NormalizedTimeRange | null) {
+function buildTextSearchTimeSql(
+  alias: 'r' | 'a',
+  timeRange?: NormalizedTimeRange | null,
+  dateField: RetrievalDateField = 'createdAt'
+) {
   if (!timeRange) return sql``;
+  const column = dateField === 'updatedAt' ? 'updatedAt' : 'createdAt';
   return alias === 'r'
-    ? sql`AND r."createdAt" >= ${timeRange.from}::timestamptz AND r."createdAt" <= ${timeRange.to}::timestamptz`
-    : sql`AND a."createdAt" >= ${timeRange.from}::timestamptz AND a."createdAt" <= ${timeRange.to}::timestamptz`;
+    ? sql`AND r.${sql.raw(`"${column}"`)} >= ${timeRange.from}::timestamptz AND r.${sql.raw(`"${column}"`)} <= ${timeRange.to}::timestamptz`
+    : sql`AND a.${sql.raw(`"${column}"`)} >= ${timeRange.from}::timestamptz AND a.${sql.raw(`"${column}"`)} <= ${timeRange.to}::timestamptz`;
+}
+
+function buildTextSearchOrderSql(alias: 'r' | 'a', dateField: RetrievalDateField = 'updatedAt') {
+  const column = dateField === 'updatedAt' ? 'updatedAt' : 'createdAt';
+  return sql`${alias}.${sql.raw(`"${column}"`)} DESC, ${alias}."id" DESC`;
+}
+
+function getResultDate(result: SemanticSearchResult, dateField: RetrievalDateField): number {
+  const value = result.metadata?.[dateField] || result.metadata?.createdAt;
+  const timestamp = Date.parse(String(value || ''));
+  return Number.isFinite(timestamp) ? timestamp : 0;
 }
 
 export async function textSearchMemory(params: {
@@ -94,6 +128,8 @@ export async function textSearchMemory(params: {
   ownerId?: string;
   sourceTypes?: AiSourceType[];
   timeRange?: NormalizedTimeRange | null;
+  selection?: RetrievalSelection;
+  dateField?: RetrievalDateField;
   tags?: { include?: string[]; exclude?: string[]; match?: 'any' | 'all' };
   semanticScope?: string[];
   state?: 'private' | 'public' | 'all';
@@ -108,7 +144,10 @@ export async function textSearchMemory(params: {
   const sourceTypes = new Set(
     (params.sourceTypes || ['rote', 'article']).filter((type) => VALID_SOURCE_TYPES.has(type))
   );
-  const terms = extractTextSearchTerms(params.query, params.semanticScope);
+  const selection = params.selection === 'recent' ? 'recent' : 'relevance';
+  const dateField = params.dateField === 'updatedAt' ? 'updatedAt' : 'createdAt';
+  const terms =
+    selection === 'recent' ? [] : extractTextSearchTerms(params.query, params.semanticScope);
   const runSearch = async (activeTerms: string[]) => {
     const results: SemanticSearchResult[] = [];
     const excludeRoteIds = [
@@ -163,12 +202,16 @@ export async function textSearchMemory(params: {
           ${excludeTagsSql}
           ${stateSql}
           ${archivedSql}
-          ${buildTextSearchTimeSql('r', timeRange)}
+          ${buildTextSearchTimeSql('r', timeRange, dateField)}
           ${excludeSql}
-        ORDER BY r."updatedAt" DESC
+        ORDER BY ${buildTextSearchOrderSql('r', selection === 'recent' ? dateField : 'updatedAt')}
         LIMIT ${limit}
       `)) as any[];
-      results.push(...rows.map((row) => buildTextSearchResult(row, 'rote', 0.2)));
+      results.push(
+        ...rows.map((row) =>
+          buildTextSearchResult(row, 'rote', selection === 'recent' ? 0 : 0.2, selection, dateField)
+        )
+      );
     }
 
     if (
@@ -190,16 +233,32 @@ export async function textSearchMemory(params: {
         FROM "articles" a
         WHERE a."authorId" = ${params.ownerId}
           ${buildArticleTextTermSql(activeTerms)}
-          ${buildTextSearchTimeSql('a', timeRange)}
+          ${buildTextSearchTimeSql('a', timeRange, dateField)}
           ${excludeSql}
-        ORDER BY a."updatedAt" DESC
+        ORDER BY ${buildTextSearchOrderSql('a', selection === 'recent' ? dateField : 'updatedAt')}
         LIMIT ${limit}
       `)) as any[];
-      results.push(...rows.map((row) => buildTextSearchResult(row, 'article', 0.15)));
+      results.push(
+        ...rows.map((row) =>
+          buildTextSearchResult(
+            row,
+            'article',
+            selection === 'recent' ? 0 : 0.15,
+            selection,
+            dateField
+          )
+        )
+      );
     }
 
     return results
       .sort((a, b) => {
+        if (selection === 'recent') {
+          return (
+            getResultDate(b, dateField) - getResultDate(a, dateField) ||
+            `${b.sourceType}:${b.sourceId}`.localeCompare(`${a.sourceType}:${a.sourceId}`)
+          );
+        }
         const aTime = Date.parse(String(a.metadata?.updatedAt || a.metadata?.createdAt || ''));
         const bTime = Date.parse(String(b.metadata?.updatedAt || b.metadata?.createdAt || ''));
         return (Number.isFinite(bTime) ? bTime : 0) - (Number.isFinite(aTime) ? aTime : 0);
@@ -217,6 +276,8 @@ export async function searchMemoryWithFallback(params: {
   scope?: 'mine' | 'public';
   sourceTypes?: AiSourceType[];
   timeRange?: NormalizedTimeRange | null;
+  selection?: RetrievalSelection;
+  dateField?: RetrievalDateField;
   tags?: { include?: string[]; exclude?: string[]; match?: 'any' | 'all' };
   semanticScope?: string[];
   state?: 'private' | 'public' | 'all';
@@ -227,6 +288,12 @@ export async function searchMemoryWithFallback(params: {
 }): Promise<{ sources: SemanticSearchResult[]; warnings: string[] }> {
   const { timeRange, warnings } = normalizeSearchTimeRange(params.timeRange);
   const safeParams = { ...params, timeRange };
+  if (params.selection === 'recent') {
+    return {
+      sources: await textSearchMemory({ ...safeParams, query: '', selection: 'recent' }),
+      warnings,
+    };
+  }
   try {
     return { sources: await semanticSearch(safeParams), warnings };
   } catch (error: any) {

--- a/server/utils/dbMethods/ai/types.ts
+++ b/server/utils/dbMethods/ai/types.ts
@@ -1,3 +1,5 @@
+import type { RetrievalSelection } from '../../ai/retrievalPlan';
+
 export type AiSourceType = 'rote' | 'article';
 export type EmbeddingJobAction = 'upsert' | 'delete' | 'reindex';
 export type EmbeddingJobStatus = 'pending' | 'running' | 'succeeded' | 'failed';
@@ -6,6 +8,8 @@ export type {
   NormalizedTimeRange,
   PlannerAgentDto,
   PlannerAgentResult,
+  RetrievalDateField,
+  RetrievalSelection,
   RetrievalScope,
   RetrievalSnippet,
   RetrievalTimeContext,
@@ -22,5 +26,6 @@ export interface SemanticSearchResult {
   chunkIndex: number;
   text: string;
   similarity: number;
+  retrievalMode?: RetrievalSelection;
   metadata: any;
 }

--- a/web/src/components/ai/AiMessageStatus.tsx
+++ b/web/src/components/ai/AiMessageStatus.tsx
@@ -19,15 +19,17 @@ function buildScopeSummary(plan: PlannerAgentDto, t: ReturnType<typeof useTransl
   if (!scope) return summary;
   const listSeparator = t('scope.listSeparator');
 
-  if (scope.selection === 'recent') {
+  if (scope.timeRange) {
+    summary.push(t('scope.time', { label: scope.timeRange.label }));
+  }
+
+  if (scope.selection === 'recent' && !scope.timeRange) {
     summary.push(
       t('scope.latestItems', {
         count: scope.limit,
         field: t(`scope.dateFields.${scope.dateField}`),
       })
     );
-  } else if (scope.timeRange) {
-    summary.push(t('scope.time', { label: scope.timeRange.label }));
   }
 
   if (scope.tags.length) {

--- a/web/src/components/ai/AiMessageStatus.tsx
+++ b/web/src/components/ai/AiMessageStatus.tsx
@@ -100,14 +100,7 @@ function buildDebugSummary(plan: PlannerAgentDto, t: ReturnType<typeof useTransl
   }
 
   if (trace.warnings.length > 0) {
-    const warnings = trace.warnings
-      .slice(0, 3)
-      .map((warning) =>
-        warning.startsWith('semantic_search_fallback_text')
-          ? t('debug.warningLabels.semanticSearchTextFallback')
-          : warning
-      )
-      .join(' / ');
+    const warnings = trace.warnings.slice(0, 3).join(' / ');
     summary.push(t('debug.warnings', { warnings }));
   }
 

--- a/web/src/components/ai/AiMessageStatus.tsx
+++ b/web/src/components/ai/AiMessageStatus.tsx
@@ -19,7 +19,16 @@ function buildScopeSummary(plan: PlannerAgentDto, t: ReturnType<typeof useTransl
   if (!scope) return summary;
   const listSeparator = t('scope.listSeparator');
 
-  if (scope.timeRange) summary.push(t('scope.time', { label: scope.timeRange.label }));
+  if (scope.selection === 'recent') {
+    summary.push(
+      t('scope.latestItems', {
+        count: scope.limit,
+        field: t(`scope.dateFields.${scope.dateField}`),
+      })
+    );
+  } else if (scope.timeRange) {
+    summary.push(t('scope.time', { label: scope.timeRange.label }));
+  }
 
   if (scope.tags.length) {
     summary.push(t('scope.tags', { tags: scope.tags.map((tag) => `#${tag}`).join(listSeparator) }));

--- a/web/src/components/ai/AiSourceList.tsx
+++ b/web/src/components/ai/AiSourceList.tsx
@@ -26,6 +26,22 @@ function getSimilarityPercent(source: AiSemanticResult) {
   return Math.max(0, Math.min(100, Math.round(source.similarity * 100)));
 }
 
+function formatSourceDate(value: unknown, locale: string): string | null {
+  if (typeof value !== 'string') return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return new Intl.DateTimeFormat(locale, {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(date);
+}
+
+function getSourceDateValue(source: AiSemanticResult): unknown {
+  const dateField = source.metadata?.retrievalDateField === 'updatedAt' ? 'updatedAt' : 'createdAt';
+  return source.metadata?.[dateField];
+}
+
 export function AiSourceList({
   sources,
   title,
@@ -39,7 +55,7 @@ export function AiSourceList({
   className?: string;
   compact?: boolean;
 }) {
-  const { t } = useTranslation('translation', { keyPrefix: 'components.aiSourceList' });
+  const { t, i18n } = useTranslation('translation', { keyPrefix: 'components.aiSourceList' });
   const visibleSources = useMemo(() => sources || [], [sources]);
 
   return (
@@ -68,7 +84,9 @@ export function AiSourceList({
                         {source.sourceType === 'article' ? t('article') : t('rote')}
                       </span>
                       <span className="ml-auto shrink-0 font-mono">
-                        {getSimilarityPercent(source)}%
+                        {source.retrievalMode === 'recent'
+                          ? formatSourceDate(getSourceDateValue(source), i18n.language) || '-'
+                          : `${getSimilarityPercent(source)}%`}
                       </span>
                     </div>
                     <div

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -692,10 +692,7 @@
         "fallback": "Fallback: {{reason}}",
         "providerError": "Model tool calling failed",
         "toolError": "Retrieval tool failed",
-        "warnings": "Warnings: {{warnings}}",
-        "warningLabels": {
-          "semanticSearchTextFallback": "Semantic search is unavailable; text search was used"
-        }
+        "warnings": "Warnings: {{warnings}}"
       },
       "timeline": {
         "title": "Progress",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -653,6 +653,11 @@
         "title": "Scope",
         "paginationMore": "More results",
         "time": "Time: {{label}}",
+        "latestItems": "Latest {{count}} records ({{field}})",
+        "dateFields": {
+          "createdAt": "created",
+          "updatedAt": "updated"
+        },
         "tags": "Tags: {{tags}}",
         "excludeTags": "Exclude tags: {{tags}}",
         "semanticScope": "Keywords: {{keywords}}",

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -696,10 +696,7 @@
         "fallback": "フォールバック：{{reason}}",
         "providerError": "モデルのツール呼び出しに失敗",
         "toolError": "検索ツールに失敗",
-        "warnings": "警告：{{warnings}}",
-        "warningLabels": {
-          "semanticSearchTextFallback": "セマンティック検索が利用できないため、テキスト検索を使用しました"
-        }
+        "warnings": "警告：{{warnings}}"
       },
       "timeline": {
         "title": "進捗",

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -657,6 +657,11 @@
         "title": "範囲",
         "paginationMore": "さらに表示",
         "time": "時間：{{label}}",
+        "latestItems": "最新{{count}}件（{{field}}）",
+        "dateFields": {
+          "createdAt": "作成日時",
+          "updatedAt": "更新日時"
+        },
         "tags": "タグ：{{tags}}",
         "excludeTags": "除外タグ：{{tags}}",
         "semanticScope": "キーワード：{{keywords}}",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -682,10 +682,7 @@
         "fallback": "降级原因：{{reason}}",
         "providerError": "模型工具调用失败",
         "toolError": "检索工具失败",
-        "warnings": "提示：{{warnings}}",
-        "warningLabels": {
-          "semanticSearchTextFallback": "语义检索不可用，已使用文本搜索"
-        }
+        "warnings": "提示：{{warnings}}"
       },
       "timeline": {
         "title": "进度",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -643,6 +643,11 @@
         "title": "范围",
         "paginationMore": "查看更多",
         "time": "时间：{{label}}",
+        "latestItems": "最近 {{count}} 条（按{{field}}）",
+        "dateFields": {
+          "createdAt": "创建时间",
+          "updatedAt": "更新时间"
+        },
         "tags": "标签：{{tags}}",
         "excludeTags": "排除标签：{{tags}}",
         "semanticScope": "关键词：{{keywords}}",

--- a/web/src/utils/aiApi.ts
+++ b/web/src/utils/aiApi.ts
@@ -1,228 +1,27 @@
 import { authService } from './auth';
 import { get, getApiUrl, post, refreshAccessToken } from './api';
+import type {
+  AiAgentClientState,
+  AiAgentPhase,
+  AiAgentToolProgressStatus,
+  AiChatPayload,
+  AiChatStreamHandlers,
+  AiClientRequestContext,
+  AiClarification,
+  AiProviderTestProgressHandler,
+  AiProviderTestResult,
+  AiSemanticResult,
+  AiStatus,
+  AiThinkingPhase,
+  AiTokenUsage,
+  AiUsagePhase,
+  ClientAgentBootstrap,
+  ClientAgentToolResult,
+  PlannerAgentDto,
+  AiSourceType,
+} from './aiTypes';
 
-export type AiSourceType = 'rote' | 'article';
-
-export interface AiStatus {
-  enabled: boolean;
-  vectorEnabled: boolean;
-  publicExploreVectorEnabled: boolean;
-  eligible: boolean;
-  available: boolean;
-  memoryAvailable?: boolean;
-  chatAvailable?: boolean;
-  chatAllowed?: boolean;
-  chatProviderId?: string;
-  chatModel?: string;
-  chatMode?: 'disabled' | 'site' | 'local';
-  memoryStats?: {
-    roteCount: number;
-    indexedRoteCount: number;
-  };
-}
-
-export interface AiSemanticResult {
-  id?: string;
-  ownerId?: string;
-  sourceType: AiSourceType;
-  sourceId: string;
-  chunkIndex?: number;
-  text?: string;
-  preview?: string;
-  similarity: number;
-  metadata: {
-    title?: string;
-    tags?: string[];
-    state?: string;
-    archived?: boolean;
-    createdAt?: string;
-    updatedAt?: string;
-    [key: string]: unknown;
-  };
-}
-
-export type AiToolCallingProbeResult = {
-  supported: boolean;
-  message: string;
-  toolName?: string;
-  arguments?: Record<string, unknown>;
-  rawContent?: string;
-  error?: string;
-};
-
-export interface AiProviderTestResult {
-  success: boolean;
-  eligible?: boolean;
-  chatAvailable?: boolean;
-  vectorAvailable?: boolean;
-  model?: string;
-  latencyMs?: number;
-  sample?: string;
-  usage?: AiTokenUsage;
-  toolCalling?: AiToolCallingProbeResult;
-}
-
-export type AiProviderTestProgressStep = 'site' | 'personal_remote' | 'local_chat' | 'tool_calling';
-
-export type AiProviderTestProgressHandler = (step: AiProviderTestProgressStep) => void;
-
-export type LifecycleScope = 'active' | 'archived' | 'all' | 'unspecified';
-export type TaskStatusScope = 'open' | 'closed' | 'all' | 'unspecified';
-
-export interface NormalizedTimeRange {
-  from: string;
-  to: string;
-  label: string;
-}
-
-export interface RetrievalScope {
-  ownerId: string;
-  query: string;
-  tags: string[];
-  excludeTags: string[];
-  semanticScope: string[];
-  sourceTypes: AiSourceType[];
-  timeRange: NormalizedTimeRange | null;
-  lifecycleScope: LifecycleScope;
-  taskStatusScope: TaskStatusScope;
-  limit: number;
-  cursor: string | null;
-  excludeIds: string[];
-}
-
-export interface RetrievalSnippet {
-  id: string;
-  sourceType: AiSourceType;
-  sourceId: string;
-  title?: string;
-  tags?: string[];
-  createdAt?: string;
-  similarity: number;
-  text: string;
-}
-
-export interface RetrievalToolResult {
-  canonicalizedArgs: RetrievalScope;
-  resultCount: number;
-  topSnippets: RetrievalSnippet[];
-  cursor: string | null;
-  warnings: string[];
-}
-
-export interface PlannerDebugTrace {
-  toolCalls: Array<{ step: number; name: string; args: unknown }>;
-  canonicalizedArgs: RetrievalScope[];
-  warnings: string[];
-  probeCounts: number[];
-  finishReason?: string;
-  fallbackReason?: string;
-  providerError?: string;
-  toolError?: string;
-}
-
-export interface PlannerAgentDto {
-  originalMessage: string;
-  retrievalNeeded: boolean;
-  scope: RetrievalScope | null;
-  toolResult: RetrievalToolResult | null;
-  clarification: { question: string; reason?: string } | null;
-  debugTrace: PlannerDebugTrace;
-}
-
-export interface AiClarification {
-  question: string;
-  pendingPlan?: PlannerAgentDto | null;
-}
-
-export type AiAgentPhase =
-  | 'understanding'
-  | 'planning'
-  | 'tool_calling'
-  | 'retrieving'
-  | 'reading'
-  | 'answering';
-
-export type AiAgentToolProgressStatus =
-  | 'determining_scope'
-  | 'retrieving_sources'
-  | 'reading_source'
-  | 'finding_related'
-  | 'loading_tags';
-
-export type AiUsagePhase = 'planning' | 'tool_decision' | 'answer';
-export type AiThinkingPhase =
-  | 'route_decision'
-  | 'evidence_decision'
-  | 'retrieval_planning'
-  | 'answer';
-
-export type AiTokenUsage = {
-  prompt_tokens: number;
-  completion_tokens: number;
-  total_tokens: number;
-};
-
-export interface AiAgentClientState {
-  conversationId?: string;
-  previousPlan?: PlannerAgentDto | null;
-  seenSourceIds?: string[];
-  selectedContext?: {
-    currentRoteId?: string;
-    currentArticleId?: string;
-    selectedSourceIds?: string[];
-    selectedTags?: string[];
-  } | null;
-  clientContext?: AiClientRequestContext | null;
-  stateVersion?: number;
-}
-
-export type AiChatStreamHandlers = {
-  onRunStarted?: (runId: string) => void;
-  onProgress?: (phase: AiAgentPhase) => void;
-  onHeartbeat?: (heartbeat: { phase: AiAgentPhase; seq: number; timestamp: string }) => void;
-  onToolStarted?: (toolName: string, args?: unknown) => void;
-  onToolProgress?: (toolName: string, status: AiAgentToolProgressStatus) => void;
-  onToolFinished?: (toolName: string, summary?: string) => void;
-  onPlan?: (plan: PlannerAgentDto) => void;
-  onClarification?: (clarification: AiClarification) => void;
-  onSources?: (sources: AiSemanticResult[]) => void;
-  onThinking?: (phase: AiThinkingPhase, text: string) => void;
-  onDelta?: (text: string) => void;
-  onStatePatch?: (state: Partial<AiAgentClientState>) => void;
-  onUsage?: (usage: AiTokenUsage, phase: AiUsagePhase) => void;
-  onDone?: () => void;
-  onError?: (message: string) => void;
-};
-
-export type ClientAgentBootstrap = {
-  systemPrompt: string;
-  finalAnswerInstruction: string;
-  tools: Array<{
-    type: 'function';
-    function: {
-      name: string;
-      description: string;
-      parameters: Record<string, unknown>;
-    };
-  }>;
-  policy: {
-    maxIterations: number;
-    maxToolCalls: number;
-    maxSources: number;
-  };
-};
-
-export type ClientAgentToolResult = {
-  observations: string[];
-  displaySummary?: unknown;
-  modelContent: string;
-  sources: AiSemanticResult[];
-  plan?: PlannerAgentDto;
-  statePatch?: Partial<AiAgentClientState>;
-  state: AiAgentClientState;
-  sourceKeys: string[];
-  clarification?: AiClarification;
-};
+export type * from './aiTypes';
 
 export const getAiStatus = () => get('/ai/status').then((res) => res.data as AiStatus);
 
@@ -233,31 +32,6 @@ export const testSiteAiProvider = (onProgress?: AiProviderTestProgressHandler) =
     message: res.message,
   }));
 };
-
-export type AiChatPayload = {
-  message: string;
-  mode?: 'chat' | 'review' | 'organize';
-  limit?: number;
-  pendingPlan?: PlannerAgentDto | null;
-  clarificationAnswer?: string;
-  previousPlan?: PlannerAgentDto | null;
-  excludeIds?: string[];
-  history?: { role: 'user' | 'assistant'; content: string }[];
-  state?: AiAgentClientState | null;
-  clientContext?: AiClientRequestContext | null;
-  debug?: boolean;
-  enableThinking?: boolean;
-};
-
-export interface AiClientRequestContext {
-  nowIso: string;
-  localDate: string;
-  localDateTime: string;
-  timeZone?: string;
-  utcOffsetMinutes: number;
-  locale?: string;
-  calendar?: string;
-}
 
 function padDatePart(value: number): string {
   return String(value).padStart(2, '0');
@@ -306,6 +80,7 @@ export function buildAiClientTimeContextMessage(context: AiClientRequestContext)
     context.calendar ? `Client calendar: ${context.calendar}` : null,
     'Resolve relative date phrases such as today, yesterday, this month, last month, 最近, 本月, and 上月 using this context.',
     'For Rote search tools, prefer structured timeRange preset/rolling/relative_between or pass the original phrase as timeExpression. Use from/to only for explicit absolute dates.',
+    'For broad recent/latest record reviews or recurring-theme analysis, use selection recent with a default limit of 30 and dateField createdAt. Use updatedAt for modification/activity wording. For focused topics, use selection relevance with an explicit time range.',
   ]
     .filter((line): line is string => Boolean(line))
     .join('\n');
@@ -397,17 +172,11 @@ async function readResponseError(response: Response): Promise<string> {
 function parseSseEvent(block: string): { event: string; data: unknown } | null {
   let event = 'message';
   const dataLines: string[] = [];
-
   block.split('\n').forEach((line) => {
-    if (line.startsWith('event:')) {
-      event = line.slice(6).trim();
-    } else if (line.startsWith('data:')) {
-      dataLines.push(line.slice(5).trimStart());
-    }
+    if (line.startsWith('event:')) event = line.slice(6).trim();
+    else if (line.startsWith('data:')) dataLines.push(line.slice(5).trimStart());
   });
-
   if (dataLines.length === 0) return null;
-
   const dataText = dataLines.join('\n');
   try {
     return { event, data: JSON.parse(dataText) };
@@ -438,12 +207,8 @@ async function readAiStreamResponse(
   response: Response,
   handlers: AiChatStreamHandlers
 ): Promise<void> {
-  if (!response.ok) {
-    throw new Error(await readResponseError(response));
-  }
-  if (!response.body) {
-    throw new Error('Streaming response is not supported in this browser');
-  }
+  if (!response.ok) throw new Error(await readResponseError(response));
+  if (!response.body) throw new Error('Streaming response is not supported in this browser');
 
   const reader = response.body.getReader();
   const decoder = new TextDecoder();
@@ -458,7 +223,7 @@ async function readAiStreamResponse(
       const runId = (parsed.data as { runId?: string })?.runId;
       if (runId) handlers.onRunStarted?.(runId);
     } else if (parsed.event === 'progress') {
-      const data = parsed.data as { phase?: AiAgentPhase; message?: string };
+      const data = parsed.data as { phase?: AiAgentPhase };
       if (data.phase) handlers.onProgress?.(data.phase);
     } else if (parsed.event === 'heartbeat') {
       const data = parsed.data as { phase?: AiAgentPhase; seq?: number; timestamp?: string };
@@ -469,14 +234,8 @@ async function readAiStreamResponse(
       const data = parsed.data as { toolName?: string; args?: unknown };
       if (data.toolName) handlers.onToolStarted?.(data.toolName, data.args);
     } else if (parsed.event === 'tool_progress') {
-      const data = parsed.data as {
-        toolName?: string;
-        status?: AiAgentToolProgressStatus;
-        message?: string;
-      };
-      if (data.toolName && data.status) {
-        handlers.onToolProgress?.(data.toolName, data.status);
-      }
+      const data = parsed.data as { toolName?: string; status?: AiAgentToolProgressStatus };
+      if (data.toolName && data.status) handlers.onToolProgress?.(data.toolName, data.status);
     } else if (parsed.event === 'tool_finished') {
       const data = parsed.data as { toolName?: string; summary?: string };
       if (data.toolName) handlers.onToolFinished?.(data.toolName, data.summary);
@@ -485,9 +244,7 @@ async function readAiStreamResponse(
       if (plan) handlers.onPlan?.(plan);
     } else if (parsed.event === 'clarification') {
       const clarification = parsed.data as AiClarification;
-      if (clarification?.question) {
-        handlers.onClarification?.(clarification);
-      }
+      if (clarification?.question) handlers.onClarification?.(clarification);
     } else if (parsed.event === 'sources') {
       const sources = (parsed.data as { sources?: AiSemanticResult[] })?.sources;
       handlers.onSources?.(Array.isArray(sources) ? sources : []);
@@ -509,14 +266,10 @@ async function readAiStreamResponse(
       const state = (parsed.data as { state?: Partial<AiAgentClientState> })?.state;
       if (state) handlers.onStatePatch?.(state);
     } else if (parsed.event === 'usage') {
-      const data = parsed.data as {
-        phase?: AiUsagePhase;
-        usage?: Partial<AiTokenUsage>;
-      };
+      const data = parsed.data as { phase?: AiUsagePhase; usage?: Partial<AiTokenUsage> };
       const rawUsage = data.usage;
-      const phase = data.phase;
       if (
-        phase &&
+        data.phase &&
         rawUsage &&
         typeof rawUsage.prompt_tokens === 'number' &&
         typeof rawUsage.completion_tokens === 'number' &&
@@ -528,7 +281,7 @@ async function readAiStreamResponse(
             completion_tokens: rawUsage.completion_tokens,
             total_tokens: rawUsage.total_tokens,
           },
-          phase
+          data.phase
         );
       }
     } else if (parsed.event === 'done') {
@@ -545,9 +298,7 @@ async function readAiStreamResponse(
     while (true) {
       const { done, value } = await reader.read();
       if (done) break;
-
       buffer += decoder.decode(value, { stream: true }).replace(/\r\n/g, '\n');
-
       let boundary = buffer.indexOf('\n\n');
       while (boundary !== -1) {
         const block = buffer.slice(0, boundary);
@@ -556,7 +307,6 @@ async function readAiStreamResponse(
         boundary = buffer.indexOf('\n\n');
       }
     }
-
     const tail = buffer.trim();
     if (tail) dispatch(tail);
     if (!doneReceived) handlers.onDone?.();

--- a/web/src/utils/aiTypes.ts
+++ b/web/src/utils/aiTypes.ts
@@ -1,0 +1,240 @@
+export type AiSourceType = 'rote' | 'article';
+
+export interface AiStatus {
+  enabled: boolean;
+  vectorEnabled: boolean;
+  publicExploreVectorEnabled: boolean;
+  eligible: boolean;
+  available: boolean;
+  memoryAvailable?: boolean;
+  chatAvailable?: boolean;
+  chatAllowed?: boolean;
+  chatProviderId?: string;
+  chatModel?: string;
+  chatMode?: 'disabled' | 'site' | 'local';
+  memoryStats?: { roteCount: number; indexedRoteCount: number };
+}
+
+export type RetrievalSelection = 'relevance' | 'recent';
+export type RetrievalDateField = 'createdAt' | 'updatedAt';
+export type LifecycleScope = 'active' | 'archived' | 'all' | 'unspecified';
+export type TaskStatusScope = 'open' | 'closed' | 'all' | 'unspecified';
+
+export interface AiSemanticResult {
+  id?: string;
+  ownerId?: string;
+  sourceType: AiSourceType;
+  sourceId: string;
+  chunkIndex?: number;
+  text?: string;
+  preview?: string;
+  similarity: number;
+  retrievalMode?: RetrievalSelection;
+  metadata: {
+    title?: string;
+    tags?: string[];
+    state?: string;
+    archived?: boolean;
+    createdAt?: string;
+    updatedAt?: string;
+    [key: string]: unknown;
+  };
+}
+
+export type AiToolCallingProbeResult = {
+  supported: boolean;
+  message: string;
+  toolName?: string;
+  arguments?: Record<string, unknown>;
+  rawContent?: string;
+  error?: string;
+};
+
+export interface AiProviderTestResult {
+  success: boolean;
+  eligible?: boolean;
+  chatAvailable?: boolean;
+  vectorAvailable?: boolean;
+  model?: string;
+  latencyMs?: number;
+  sample?: string;
+  usage?: AiTokenUsage;
+  toolCalling?: AiToolCallingProbeResult;
+}
+
+export type AiProviderTestProgressStep = 'site' | 'personal_remote' | 'local_chat' | 'tool_calling';
+export type AiProviderTestProgressHandler = (step: AiProviderTestProgressStep) => void;
+
+export interface NormalizedTimeRange {
+  from: string;
+  to: string;
+  label: string;
+}
+
+export interface RetrievalScope {
+  ownerId: string;
+  query: string;
+  tags: string[];
+  excludeTags: string[];
+  semanticScope: string[];
+  sourceTypes: AiSourceType[];
+  timeRange: NormalizedTimeRange | null;
+  selection: RetrievalSelection;
+  dateField: RetrievalDateField;
+  lifecycleScope: LifecycleScope;
+  taskStatusScope: TaskStatusScope;
+  limit: number;
+  cursor: string | null;
+  excludeIds: string[];
+}
+
+export interface RetrievalSnippet {
+  id: string;
+  sourceType: AiSourceType;
+  sourceId: string;
+  title?: string;
+  tags?: string[];
+  createdAt?: string;
+  updatedAt?: string;
+  retrievalMode?: RetrievalSelection;
+  similarity: number;
+  text: string;
+}
+
+export interface RetrievalToolResult {
+  canonicalizedArgs: RetrievalScope;
+  resultCount: number;
+  topSnippets: RetrievalSnippet[];
+  cursor: string | null;
+  warnings: string[];
+}
+
+export interface PlannerDebugTrace {
+  toolCalls: Array<{ step: number; name: string; args: unknown }>;
+  canonicalizedArgs: RetrievalScope[];
+  warnings: string[];
+  probeCounts: number[];
+  finishReason?: string;
+  fallbackReason?: string;
+  providerError?: string;
+  toolError?: string;
+}
+
+export interface PlannerAgentDto {
+  originalMessage: string;
+  retrievalNeeded: boolean;
+  scope: RetrievalScope | null;
+  toolResult: RetrievalToolResult | null;
+  clarification: { question: string; reason?: string } | null;
+  debugTrace: PlannerDebugTrace;
+}
+
+export interface AiClarification {
+  question: string;
+  pendingPlan?: PlannerAgentDto | null;
+}
+
+export type AiAgentPhase =
+  | 'understanding'
+  | 'planning'
+  | 'tool_calling'
+  | 'retrieving'
+  | 'reading'
+  | 'answering';
+export type AiAgentToolProgressStatus =
+  | 'determining_scope'
+  | 'retrieving_sources'
+  | 'reading_source'
+  | 'finding_related'
+  | 'loading_tags';
+export type AiUsagePhase = 'planning' | 'tool_decision' | 'answer';
+export type AiThinkingPhase =
+  | 'route_decision'
+  | 'evidence_decision'
+  | 'retrieval_planning'
+  | 'answer';
+
+export type AiTokenUsage = {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+};
+
+export interface AiClientRequestContext {
+  nowIso: string;
+  localDate: string;
+  localDateTime: string;
+  timeZone?: string;
+  utcOffsetMinutes: number;
+  locale?: string;
+  calendar?: string;
+}
+
+export interface AiAgentClientState {
+  conversationId?: string;
+  previousPlan?: PlannerAgentDto | null;
+  seenSourceIds?: string[];
+  selectedContext?: {
+    currentRoteId?: string;
+    currentArticleId?: string;
+    selectedSourceIds?: string[];
+    selectedTags?: string[];
+  } | null;
+  clientContext?: AiClientRequestContext | null;
+  stateVersion?: number;
+}
+
+export type AiChatStreamHandlers = {
+  onRunStarted?: (runId: string) => void;
+  onProgress?: (phase: AiAgentPhase) => void;
+  onHeartbeat?: (heartbeat: { phase: AiAgentPhase; seq: number; timestamp: string }) => void;
+  onToolStarted?: (toolName: string, args?: unknown) => void;
+  onToolProgress?: (toolName: string, status: AiAgentToolProgressStatus) => void;
+  onToolFinished?: (toolName: string, summary?: string) => void;
+  onPlan?: (plan: PlannerAgentDto) => void;
+  onClarification?: (clarification: AiClarification) => void;
+  onSources?: (sources: AiSemanticResult[]) => void;
+  onThinking?: (phase: AiThinkingPhase, text: string) => void;
+  onDelta?: (text: string) => void;
+  onStatePatch?: (state: Partial<AiAgentClientState>) => void;
+  onUsage?: (usage: AiTokenUsage, phase: AiUsagePhase) => void;
+  onDone?: () => void;
+  onError?: (message: string) => void;
+};
+
+export type ClientAgentBootstrap = {
+  systemPrompt: string;
+  finalAnswerInstruction: string;
+  tools: Array<{
+    type: 'function';
+    function: { name: string; description: string; parameters: Record<string, unknown> };
+  }>;
+  policy: { maxIterations: number; maxToolCalls: number; maxSources: number };
+};
+
+export type ClientAgentToolResult = {
+  observations: string[];
+  displaySummary?: unknown;
+  modelContent: string;
+  sources: AiSemanticResult[];
+  plan?: PlannerAgentDto;
+  statePatch?: Partial<AiAgentClientState>;
+  state: AiAgentClientState;
+  sourceKeys: string[];
+  clarification?: AiClarification;
+};
+
+export type AiChatPayload = {
+  message: string;
+  mode?: 'chat' | 'review' | 'organize';
+  limit?: number;
+  pendingPlan?: PlannerAgentDto | null;
+  clarificationAnswer?: string;
+  previousPlan?: PlannerAgentDto | null;
+  excludeIds?: string[];
+  history?: { role: 'user' | 'assistant'; content: string }[];
+  state?: AiAgentClientState | null;
+  clientContext?: AiClientRequestContext | null;
+  debug?: boolean;
+  enableThinking?: boolean;
+};


### PR DESCRIPTION
## Summary

- Add explicit `selection: relevance | recent` and `dateField: createdAt | updatedAt` retrieval semantics across planner, server, and client types.
- Make generic “recent/latest” requests default to the newest 30 records by creation time, with backend canonicalization as a safety net.
- Force clear unbounded recent requests into bounded chronological retrieval even when the model emits `selection: relevance` or an invalid/partial time expression.
- Add a chronological database retrieval path that does not depend on vector embeddings.
- Enforce time ranges as SQL filters for both chronological and semantic retrieval.
- Do not silently downgrade relevance retrieval to text matching when vector search fails; semantic errors now remain visible.
- Do not broaden unmatched text terms into an unfiltered search.
- Show explicit time ranges separately from latest-record ordering in the UI with English, Chinese, and Japanese localization.
- Update integration assertions to the current `plan.scope` protocol.
- Fix SQL identifier handling so chronological ordering executes correctly in PostgreSQL.

## Root cause

The previous search protocol only expressed semantic relevance. A numeric limit did not mean “latest”, and the backend had no chronological mode, so a request for recent notes could search and return older semantically related records. It also hid vector-search failures by silently changing the retrieval algorithm. The first review pass additionally found that an explicit model-provided `relevance` selection could bypass the recent safety net and that the UI hid explicit time windows.

## Validation

- `server/: bun run lint` ✅
- `server/: bun run build` ✅
- `server/: POSTGRESQL_URL=... bun test tests/aiRetrievalPlanner.test.ts tests/aiClientRuntime.test.ts` ✅ 23 tests
- Docker PostgreSQL smoke test for `createdAt` and `updatedAt` chronological retrieval ✅ 19 records each, correctly sorted, no vector index required
- `web/: bun run test` ✅ 39 tests
- `web/: bun run lint && bun run build` ✅
- Full AI integration reaches the persisted DashScope provider, but remains environment/model-dependent: the configured model did not consistently recognize the `#todo` test tag and one relative-time case exceeded its 30-second test timeout.