### PR TITLE
Fix AI search UUID exclusions

### DIFF
--- a/server/tests/aiTextSearch.test.ts
+++ b/server/tests/aiTextSearch.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { buildSourceIdExclusionSql } from '../utils/dbMethods/ai/textSearchSql';
+
+const dialect = new PgDialect();
+const roteId = '4c67fd19-1961-4942-a2ef-f61e203be40f';
+const articleId = '2aecb5c7-7b92-4d1c-bf85-2becd86b5a06';
+
+describe('textSearchMemory exclusion queries', () => {
+  test.each([
+    { sourceType: 'rote' as const, sourceId: roteId, alias: 'r' },
+    { sourceType: 'article' as const, sourceId: articleId, alias: 'a' },
+  ])('casts $sourceType exclusions to uuid[]', ({ sourceId, alias }) => {
+    const query = dialect.sqlToQuery(buildSourceIdExclusionSql(alias, [sourceId]));
+
+    expect(query.sql).toContain(`${alias}."id" = ANY(`);
+    expect(query.sql).toContain('::uuid[]');
+    expect(query.sql).not.toContain('::text[]');
+    expect(query.params).toContain(sourceId);
+  });
+
+  test('omits the exclusion clause when no IDs have been seen', () => {
+    const query = dialect.sqlToQuery(buildSourceIdExclusionSql('r', []));
+
+    expect(query.sql).toBe('');
+    expect(query.params).toEqual([]);
+  });
+});

--- a/server/tests/aiTextSearch.test.ts
+++ b/server/tests/aiTextSearch.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { PgDialect } from 'drizzle-orm/pg-core';
+import { sanitizeExcludeIds } from '../utils/dbMethods/ai/sourceIds';
 import { buildSourceIdExclusionSql } from '../utils/dbMethods/ai/textSearchSql';
 
 const dialect = new PgDialect();
@@ -24,5 +25,31 @@ describe('textSearchMemory exclusion queries', () => {
 
     expect(query.sql).toBe('');
     expect(query.params).toEqual([]);
+  });
+
+  test('ignores malformed UUIDs before constructing the database cast', () => {
+    const query = dialect.sqlToQuery(buildSourceIdExclusionSql('r', ['not-a-uuid', roteId]));
+
+    expect(query.sql).toContain('::uuid[]');
+    expect(query.params).toEqual([roteId]);
+  });
+});
+
+describe('sanitizeExcludeIds', () => {
+  test('keeps UUID source keys and drops malformed client state', () => {
+    expect(
+      sanitizeExcludeIds([
+        `rote:${roteId}`,
+        'rote:not-a-uuid',
+        `article:${articleId}`,
+        'unknown:4c67fd19-1961-4942-a2ef-f61e203be40f',
+        42,
+      ])
+    ).toEqual([`rote:${roteId}`, `article:${articleId}`]);
+  });
+
+  test('rejects non-array and fully invalid input', () => {
+    expect(sanitizeExcludeIds(`rote:${roteId}`)).toBeUndefined();
+    expect(sanitizeExcludeIds(['rote:not-a-uuid'])).toBeUndefined();
   });
 });

--- a/server/utils/dbMethods/ai.ts
+++ b/server/utils/dbMethods/ai.ts
@@ -37,7 +37,7 @@ export {
   buildAnswerMessagesFromPlannerResult,
   chatWithRoteContext,
   prepareRoteChatContext,
-  sanitizeExcludeIds,
   searchRotesProbe,
 } from './ai/chat';
+export { sanitizeExcludeIds } from './ai/sourceIds';
 export { toPlannerAgentDto } from '../ai/retrievalPlan';

--- a/server/utils/dbMethods/ai/chat.ts
+++ b/server/utils/dbMethods/ai/chat.ts
@@ -10,6 +10,7 @@ import { logAiTokenUsage } from '../aiToken';
 import { getStoredAiConfig } from './config';
 import { fallbackAnswer } from './documents';
 import { searchMemory } from './search';
+import { sanitizeExcludeIds } from './sourceIds';
 import type {
   PlannerAgentDto,
   PlannerAgentResult,
@@ -237,12 +238,6 @@ export async function chatWithRoteContext(params: {
   const answer = content.trim() || fallbackAnswer(sources);
 
   return { answer, sources, plan };
-}
-
-export function sanitizeExcludeIds(ids: string[] | undefined): string[] | undefined {
-  if (!ids?.length) return undefined;
-  const sanitized = ids.filter((id) => /^(rote|article):[a-zA-Z0-9_-]+$/.test(id)).slice(0, 500);
-  return sanitized.length > 0 ? sanitized : undefined;
 }
 
 export async function prepareRoteChatContext(params: {

--- a/server/utils/dbMethods/ai/sourceIds.ts
+++ b/server/utils/dbMethods/ai/sourceIds.ts
@@ -1,0 +1,20 @@
+const UUID_PATTERN = /^[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/i;
+
+export function isUuid(value: unknown): value is string {
+  return typeof value === 'string' && UUID_PATTERN.test(value);
+}
+
+function isSourceKey(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+  const separatorIndex = value.indexOf(':');
+  if (separatorIndex < 0 || value.indexOf(':', separatorIndex + 1) >= 0) return false;
+  const sourceType = value.slice(0, separatorIndex);
+  const sourceId = value.slice(separatorIndex + 1);
+  return (sourceType === 'rote' || sourceType === 'article') && isUuid(sourceId);
+}
+
+export function sanitizeExcludeIds(ids: unknown): string[] | undefined {
+  if (!Array.isArray(ids)) return undefined;
+  const sanitized = ids.filter(isSourceKey).slice(0, 500);
+  return sanitized.length > 0 ? sanitized : undefined;
+}

--- a/server/utils/dbMethods/ai/textSearch.ts
+++ b/server/utils/dbMethods/ai/textSearch.ts
@@ -7,6 +7,7 @@ import {
 } from './documents';
 import db from '../../drizzle';
 import { semanticSearch } from './semanticSearch';
+import { buildSourceIdExclusionSql } from './textSearchSql';
 import type {
   AiSourceType,
   NormalizedTimeRange,
@@ -180,10 +181,7 @@ export async function textSearchMemory(params: {
         params.state && params.state !== 'all' ? sql`AND r."state" = ${params.state}` : sql``;
       const archivedSql =
         typeof params.archived === 'boolean' ? sql`AND r."archived" = ${params.archived}` : sql``;
-      const excludeSql =
-        excludeRoteIds.length > 0
-          ? sql`AND NOT (r."id" = ANY(${buildTextArraySql(excludeRoteIds)}))`
-          : sql``;
+      const excludeSql = buildSourceIdExclusionSql('r', excludeRoteIds);
       const rows = (await db.execute(sql`
         SELECT
           r."id",
@@ -219,10 +217,7 @@ export async function textSearchMemory(params: {
       !params.tags?.include?.length &&
       !params.tags?.exclude?.length
     ) {
-      const excludeSql =
-        excludeArticleIds.length > 0
-          ? sql`AND NOT (a."id" = ANY(${buildTextArraySql(excludeArticleIds)}))`
-          : sql``;
+      const excludeSql = buildSourceIdExclusionSql('a', excludeArticleIds);
       const rows = (await db.execute(sql`
         SELECT
           a."id",

--- a/server/utils/dbMethods/ai/textSearchSql.ts
+++ b/server/utils/dbMethods/ai/textSearchSql.ts
@@ -1,0 +1,14 @@
+import { sql } from 'drizzle-orm';
+
+export function buildSourceIdExclusionSql(alias: 'r' | 'a', sourceIds: string[]) {
+  if (sourceIds.length === 0) return sql``;
+
+  const uuidArray = sql`ARRAY[${sql.join(
+    sourceIds.map((sourceId) => sql`${sourceId}`),
+    sql`, `
+  )}]::uuid[]`;
+
+  return alias === 'r'
+    ? sql`AND NOT (r."id" = ANY(${uuidArray}))`
+    : sql`AND NOT (a."id" = ANY(${uuidArray}))`;
+}

--- a/server/utils/dbMethods/ai/textSearchSql.ts
+++ b/server/utils/dbMethods/ai/textSearchSql.ts
@@ -1,10 +1,12 @@
 import { sql } from 'drizzle-orm';
+import { isUuid } from './sourceIds';
 
 export function buildSourceIdExclusionSql(alias: 'r' | 'a', sourceIds: string[]) {
-  if (sourceIds.length === 0) return sql``;
+  const validSourceIds = sourceIds.filter(isUuid);
+  if (validSourceIds.length === 0) return sql``;
 
   const uuidArray = sql`ARRAY[${sql.join(
-    sourceIds.map((sourceId) => sql`${sourceId}`),
+    validSourceIds.map((sourceId) => sql`${sourceId}`),
     sql`, `
   )}]::uuid[]`;
 


### PR DESCRIPTION
## Summary

- build text-search source ID exclusions as PostgreSQL `uuid[]` values
- apply the typed exclusion clause to both Rote and Article retrieval
- add regression coverage for UUID casts and empty exclusion lists

## Root cause

Follow-up searches pass previously seen source IDs through `excludeIds`. The recent/text retrieval path compared the UUID primary keys on `rotes` and `articles` against an array cast to `text[]`, causing PostgreSQL error `42883` (`operator does not exist: uuid = text`). The failed tool call then terminated the agent SSE stream, which appeared on Web and iOS as a response that stopped after announcing another search.

## Impact

Continuation and pagination searches can now exclude previously returned notes and articles without terminating the AI stream. No database migration is required.

## Validation

- `bun test tests/aiTextSearch.test.ts` — 3 passed
- `POSTGRESQL_URL=postgres://test:test@127.0.0.1:1/test bun test tests/aiRetrievalPlanner.test.ts` — 21 passed
- `bun run lint`
- `bun run build`