### PR TITLE
fix(ai): restore final answer streaming

### DIFF
--- a/server/tests/aiAgentRuntime.test.ts
+++ b/server/tests/aiAgentRuntime.test.ts
@@ -67,10 +67,16 @@ describe('agent tool decision output', () => {
           },
         ]);
       }
+      if (requestCount === 2) {
+        return sseResponse([
+          {
+            choices: [{ delta: { content: 'I can answer now.' }, finish_reason: 'stop' }],
+          },
+        ]);
+      }
       return sseResponse([
-        {
-          choices: [{ delta: { content: 'Final answer' }, finish_reason: 'stop' }],
-        },
+        { choices: [{ delta: { content: 'Final ' } }] },
+        { choices: [{ delta: { content: 'answer' }, finish_reason: 'stop' }] },
       ]);
     }) as typeof fetch;
     const events: RoteAgentStreamEvent[] = [];
@@ -85,10 +91,52 @@ describe('agent tool decision output', () => {
     });
 
     expect(events.filter((event) => event.type === 'delta')).toEqual([
-      { type: 'delta', text: 'Final answer' },
+      { type: 'delta', text: 'Final ' },
+      { type: 'delta', text: 'answer' },
     ]);
+    expect(requestCount).toBe(3);
     expect(events.filter((event) => event.type === 'done')).toHaveLength(1);
     expect(events.some((event) => event.type === 'error')).toBe(false);
+  });
+
+  it('streams the final answer after a no-tool decision instead of flushing decision content', async () => {
+    process.env.POSTGRESQL_URL ||= 'postgres://test:test@127.0.0.1:5432/test';
+    const { runRoteAgentStream } = await import('../utils/ai/agent/runtime');
+    let requestCount = 0;
+    globalThis.fetch = (async () => {
+      requestCount += 1;
+      if (requestCount === 1) {
+        return sseResponse([
+          {
+            choices: [{ delta: { content: 'Cached direct answer' }, finish_reason: 'stop' }],
+          },
+        ]);
+      }
+      return sseResponse([
+        { choices: [{ delta: { content: 'Direct ' } }] },
+        { choices: [{ delta: { content: 'answer' }, finish_reason: 'stop' }] },
+      ]);
+    }) as typeof fetch;
+    const events: RoteAgentStreamEvent[] = [];
+
+    await runRoteAgentStream({
+      userId: '00000000-0000-4000-8000-000000000001',
+      request: { message: 'Say hello', enableThinking: true },
+      config,
+      emit: (event) => {
+        events.push(event);
+      },
+    });
+
+    expect(events.filter((event) => event.type === 'delta')).toEqual([
+      { type: 'delta', text: 'Direct ' },
+      { type: 'delta', text: 'answer' },
+    ]);
+    expect(
+      events.some((event) => event.type === 'delta' && event.text === 'Cached direct answer')
+    ).toBe(false);
+    expect(requestCount).toBe(2);
+    expect(events.filter((event) => event.type === 'done')).toHaveLength(1);
   });
 
   it('uses error as the only terminal event when no answer is produced', async () => {

--- a/server/utils/ai/agent/runtime.ts
+++ b/server/utils/ai/agent/runtime.ts
@@ -238,7 +238,6 @@ export async function runRoteAgentStream(params: {
 
     for (let step = 0; step < policy.maxIterations; step += 1) {
       const phase: RoteAgentPhase = step === 0 ? 'planning' : 'tool_calling';
-      const decisionContentChunks: string[] = [];
       let assistantMessage: ChatMessage;
       let responseUsage: Awaited<
         ReturnType<typeof createChatCompletionWithToolsStreaming>
@@ -259,9 +258,6 @@ export async function runRoteAgentStream(params: {
                   phase: step === 0 ? 'route_decision' : 'evidence_decision',
                   text,
                 }),
-              onContent: (text) => {
-                decisionContentChunks.push(text);
-              },
             }
           )
         );
@@ -282,18 +278,10 @@ export async function runRoteAgentStream(params: {
 
       const toolCalls = assistantMessage.tool_calls || [];
       if (!toolCalls.length) {
-        hasFinalAnswer = !!assistantMessage.content?.trim();
-        if (hasFinalAnswer) {
-          if (decisionContentChunks.length) {
-            for (const text of decisionContentChunks) await emit({ type: 'delta', text });
-          } else if (assistantMessage.content) {
-            await emit({ type: 'delta', text: assistantMessage.content });
-          }
-        }
         if (responseUsage) {
           await emit({
             type: 'usage',
-            phase: hasFinalAnswer ? 'answer' : step === 0 ? 'planning' : 'tool_decision',
+            phase: step === 0 ? 'planning' : 'tool_decision',
             usage: responseUsage,
           });
         }


### PR DESCRIPTION
## Summary

- Restores final answer output to the dedicated streaming answer pass after tool/no-tool decisions.
- Keeps tool-decision draft content hidden so phrases like “let me inspect that first” still do not leak to users.
- Adds regression coverage for tool follow-up answers and no-tool direct answers emitting chunked delta events.

## Root Cause

The previous hardening change buffered content emitted during the tool-decision request. When that same request ended without tool calls, runtime treated the buffered decision content as the final answer and flushed it only after completion. That protected against draft leakage, but it made final answers appear non-streaming.

## Validation

- server: bun test tests/aiAgentRuntime.test.ts tests/aiSse.test.ts tests/aiClient.test.ts tests/aiAgentBudget.test.ts
- server: bun run lint
- server: bun run build

Note: full server bun test was attempted, but this environment does not have the local Postgres/test services required by integration tests, so it fails before/inside DB-backed tests with missing POSTGRESQL_URL and ECONNREFUSED 127.0.0.1:5432.