### PR TITLE
Harden Live Photo cover fallback

### DIFF
--- a/server/route/v2/openKeyRouter.ts
+++ b/server/route/v2/openKeyRouter.ts
@@ -12,6 +12,8 @@ import {
   extractPosterUuid,
   getUploadExtension,
 } from '../../attachments/uploadKeys';
+import { ensureLivePhotoCover } from '../../attachments/livePhotoCover';
+import { isHeicLikeUpload } from '../../attachments/uploadMedia';
 import { getAttachmentUploadPolicy } from '../../attachments/uploadPolicy';
 import { requireStorageConfig } from '../../middleware/configCheck';
 import type { StorageConfig } from '../../types/config';
@@ -1074,7 +1076,7 @@ router.post(
           },
         };
 
-        if (mediaKind === 'image' || mediaKind === 'livePhoto') {
+        if (mediaKind === 'image') {
           const compressedKey = `users/${openKey.userid}/compressed/${uuid}.webp`;
           const compressed = await presignPutUrl(compressedKey, 'image/webp', 15 * 60);
           result.compressed = {
@@ -1255,10 +1257,13 @@ router.post(
         normalizedAttachment.posterKey = undefined;
       }
 
-      if (
-        (mediaKind === 'image' || mediaKind === 'livePhoto') &&
-        normalizedAttachment.compressedKey
-      ) {
+      // Live Photo covers are generated and verified by the server. Never
+      // trust legacy client-provided WebP keys, which may contain JPEG bytes.
+      if (mediaKind === 'livePhoto') {
+        normalizedAttachment.compressedKey = undefined;
+      }
+
+      if (mediaKind === 'image' && normalizedAttachment.compressedKey) {
         const compressedExists = await checkObjectExists(normalizedAttachment.compressedKey);
         if (!compressedExists) {
           validationErrors.push(
@@ -1391,6 +1396,23 @@ router.post(
       validateRoteAttachmentDetails(
         mergeUniqueRoteAttachmentDetails(currentAttachments, pendingAttachments)
       );
+    }
+
+    for (const attachment of validAttachments) {
+      const mediaKind = inferAttachmentMediaKind({
+        mediaKind: attachment.mediaKind,
+        mimetype: attachment.mimetype,
+        pairedVideoKey: attachment.pairedVideoKey,
+        key: attachment.originalKey,
+      });
+      if (mediaKind !== 'livePhoto') continue;
+
+      if (isHeicLikeUpload(attachment)) {
+        const cover = await ensureLivePhotoCover(attachment.originalKey);
+        attachment.compressedKey = cover.key;
+      } else {
+        attachment.compressedKey = attachment.originalKey;
+      }
     }
 
     const uploads: UploadResult[] = validAttachments.map((a) => {

--- a/server/route/v2/openKeyRouter.ts
+++ b/server/route/v2/openKeyRouter.ts
@@ -12,7 +12,10 @@ import {
   extractPosterUuid,
   getUploadExtension,
 } from '../../attachments/uploadKeys';
-import { ensureLivePhotoCover } from '../../attachments/livePhotoCover';
+import {
+  assertLivePhotoFinalizeBatch,
+  ensureLivePhotoCover,
+} from '../../attachments/livePhotoCover';
 import { isHeicLikeUpload } from '../../attachments/uploadMedia';
 import { getAttachmentUploadPolicy } from '../../attachments/uploadPolicy';
 import { requireStorageConfig } from '../../middleware/configCheck';
@@ -1151,6 +1154,7 @@ router.post(
     if (attachments.length > MAX_BATCH_SIZE) {
       throw new Error(`Maximum ${MAX_BATCH_SIZE} attachments can be finalized at once`);
     }
+    assertLivePhotoFinalizeBatch(attachments);
 
     // Ownership check: keys must stay under the current user's prefix
     const prefix = `users/${openKey.userid}/`;

--- a/web/src/components/rote/AttachmentsGrid.test.tsx
+++ b/web/src/components/rote/AttachmentsGrid.test.tsx
@@ -130,4 +130,17 @@ describe('AttachmentsGrid Live Photo mix', () => {
     ).toBe(true);
     expect(container.querySelectorAll('video')).toHaveLength(1);
   });
+
+  it('keeps a full-width preview frame when a single Live Photo cover is unavailable', () => {
+    const attachment = {
+      ...mockAttachments[0],
+      compressUrl: '',
+      posterUrl: '',
+    };
+    const { container } = render(<AttachmentsGrid attachments={[attachment]} />);
+
+    expect(container.querySelector('img')).not.toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'imageUnavailable' })).toBeVisible();
+    expect(container.firstElementChild).toHaveClass('w-full', 'max-w-[500px]');
+  });
 });

--- a/web/src/components/rote/AttachmentsGrid.tsx
+++ b/web/src/components/rote/AttachmentsGrid.tsx
@@ -27,7 +27,7 @@ export default function AttachmentsGrid({ attachments, withTimeStamp }: Attachme
 
   return (
     attachments.length > 0 && (
-      <div className="my-2 flex w-fit flex-wrap gap-1 overflow-hidden rounded-2xl">
+      <div className="my-2 flex w-full max-w-[500px] flex-wrap gap-1 overflow-hidden rounded-2xl">
         {hasVideo ? (
           sortedAttachments.map((file, index) => (
             <VideoAttachmentPreview


### PR DESCRIPTION
## Summary
- keep the legacy OpenKey Live Photo upload path consistent with the shared presign/finalize flow
- never presign a client WebP target for Live Photos and generate a verified JPEG cover during finalize
- keep missing-cover attachment placeholders at a stable responsive width instead of collapsing

## Verification
- server Live Photo tests: 14 passed
- web tests: 73 passed
- server lint/build passed
- web lint/build passed
- production Worker path successfully converted the reported HEIC into a valid JPEG

## Reported attachment
- note: `6033d9c9-4d98-46a7-b896-023a092cf5b9`
- attachment: `2453b0dd-ae0c-4854-add9-6292e47cbfbf`
- the attachment predates PR #294; its deterministic cover URL is currently 404 and will be populated by the automatic backfill after backend deployment.