### PR TITLE
Use semantic info text color

### DIFF
--- a/web/src/components/experiment/SubList.tsx
+++ b/web/src/components/experiment/SubList.tsx
@@ -158,7 +158,7 @@ export default function SubList() {
       {isLoading ? (
         <LoadingPlaceholder className="py-8" size={6} />
       ) : error ? (
-        <div className="py-4 text-center text-gray-500">
+        <div className="text-info py-4 text-center">
           {error.response?.status === 404 || error.response?.status === 401
             ? t('noSubscriptions')
             : t('messages.loadFailed', {
@@ -240,7 +240,7 @@ export default function SubList() {
                 </div>
               ))
             ) : (
-              <div className="py-4 text-center text-gray-500">{t('noSubscriptions')}</div>
+              <div className="text-info py-4 text-center">{t('noSubscriptions')}</div>
             )}
           </div>
         </div>

--- a/web/src/components/openKey/openKey.tsx
+++ b/web/src/components/openKey/openKey.tsx
@@ -135,7 +135,7 @@ function OpenKeyItem({ openKey, mutate }: { openKey: OpenKey; mutate?: KeyedMuta
   }
 
   function getStatusColor(statusCode: number | null): string {
-    if (!statusCode) return 'text-gray-400';
+    if (!statusCode) return 'text-info';
     if (statusCode >= 200 && statusCode < 300) return 'text-green-500';
     if (statusCode >= 400) return 'text-red-500';
     return 'text-yellow-500';

--- a/web/src/pages/home/index.tsx
+++ b/web/src/pages/home/index.tsx
@@ -27,7 +27,7 @@ function MainPageHeader({
   const navigate = useNavigate();
 
   return (
-    <div className="bg-background sticky top-0 z-10 flex items-center justify-between p-4 font-light text-gray-600">
+    <div className="bg-background text-info sticky top-0 z-10 flex items-center justify-between p-4 font-light">
       <div className="group flex cursor-pointer items-center gap-2" onClick={refreshData}>
         <Logo className="h-5 w-auto" color="#3ECF4A" />
         <img


### PR DESCRIPTION
## Summary

- replace remaining informational `text-gray-*` utilities with the semantic `text-info` token
- cover subscription empty/error states, the home header, and missing OpenKey status codes
- retain the neutral gray fallback badge for unknown HTTP methods because its foreground and background form a deliberate status treatment

## Why

Several informational labels still used fixed Tailwind gray shades. Those colors bypass the project semantic color token and can render inconsistently across themes.

## Impact

Informational text now follows the centralized theme-aware color definition. There is no behavior or localization change.

## Validation

- `bun run lint`
- `bun run build`
