### PR TITLE
Parse grouped AI citations

### DIFF
--- a/web/src/components/ai/AiStreamingMarkdown.test.ts
+++ b/web/src/components/ai/AiStreamingMarkdown.test.ts
@@ -1,0 +1,38 @@
+import type { AiSemanticResult } from '@/utils/aiApi';
+import { describe, expect, it } from 'vitest';
+import { linkifyCitations } from './AiStreamingMarkdown';
+
+const sources = [
+  {
+    sourceType: 'rote',
+    sourceId: 'rote-1',
+    similarity: 1,
+    text: 'First source',
+  },
+  {
+    sourceType: 'article',
+    sourceId: 'article-2',
+    similarity: 1,
+    metadata: { title: 'Second source' },
+  },
+] as AiSemanticResult[];
+
+describe('linkifyCitations', () => {
+  it('linkifies every citation in a comma-separated group', () => {
+    expect(linkifyCitations('Answer [1,2].', sources)).toBe(
+      'Answer [\\[1\\]](/rote/rote-1 "First source"),[\\[2\\]](/article/article-2 "Second source").'
+    );
+  });
+
+  it('preserves group separators and unsupported citation numbers', () => {
+    expect(linkifyCitations('Answer [1, 99，2].', sources)).toBe(
+      'Answer [\\[1\\]](/rote/rote-1 "First source"), [99]，[\\[2\\]](/article/article-2 "Second source").'
+    );
+  });
+
+  it('does not rewrite existing markdown links or footnotes', () => {
+    expect(linkifyCitations('[1,2](https://example.com) [^1]', sources)).toBe(
+      '[1,2](https://example.com) [^1]'
+    );
+  });
+});

--- a/web/src/components/ai/AiStreamingMarkdown.test.ts
+++ b/web/src/components/ai/AiStreamingMarkdown.test.ts
@@ -31,8 +31,32 @@ describe('linkifyCitations', () => {
   });
 
   it('does not rewrite existing markdown links or footnotes', () => {
-    expect(linkifyCitations('[1,2](https://example.com) [^1]', sources)).toBe(
-      '[1,2](https://example.com) [^1]'
+    expect(
+      linkifyCitations(
+        '[1,2](https://example.com) [1,2][details] [^1]\n\n[details]: https://example.com',
+        sources
+      )
+    ).toBe('[1,2](https://example.com) [1,2][details] [^1]\n\n[details]: https://example.com');
+  });
+
+  it('does not rewrite citations inside inline or fenced code', () => {
+    const content = 'Use `[1,2]` here.\n\n```ts\nconst sourceIds = [1,2];\n```\n\nCite [1,2].';
+
+    expect(linkifyCitations(content, sources)).toBe(
+      'Use `[1,2]` here.\n\n```ts\nconst sourceIds = [1,2];\n```\n\nCite [\\[1\\]](/rote/rote-1 "First source"),[\\[2\\]](/article/article-2 "Second source").'
+    );
+  });
+
+  it('escapes quotes and backslashes in source titles', () => {
+    const quotedSources = [
+      {
+        ...sources[0],
+        metadata: { title: 'He said "hello" from C:\\notes' },
+      },
+    ];
+
+    expect(linkifyCitations('Answer [1].', quotedSources)).toBe(
+      'Answer [\\[1\\]](/rote/rote-1 "He said \\"hello\\" from C:\\\\notes").'
     );
   });
 });

--- a/web/src/components/ai/AiStreamingMarkdown.tsx
+++ b/web/src/components/ai/AiStreamingMarkdown.tsx
@@ -22,11 +22,26 @@ interface AiStreamingMarkdownProps {
 export function linkifyCitations(content: string, sources: AiSemanticResult[]): string {
   if (sources.length === 0) return content;
 
+  const codePattern = /(`+|~{3,})[\s\S]*?\1/g;
+  let result = '';
+  let lastIndex = 0;
+
+  for (const match of content.matchAll(codePattern)) {
+    const matchIndex = match.index;
+    result += linkifyCitationText(content.slice(lastIndex, matchIndex), sources);
+    result += match[0];
+    lastIndex = matchIndex + match[0].length;
+  }
+
+  return result + linkifyCitationText(content.slice(lastIndex), sources);
+}
+
+function linkifyCitationText(content: string, sources: AiSemanticResult[]): string {
   // Match [N] or comma-separated groups such as [N,M], but not markers
-  // preceded by [ or followed by ( or ].
+  // preceded by [ or followed by (, [, or ].
   // This avoids matching inside existing markdown links like [text](url)
-  // or reference-style [^1] footnotes
-  return content.replace(/(?<!\[)\[(\d+(?:\s*[,，]\s*\d+)*)\](?!\(|\])/g, (_, group) =>
+  // or [text][label], and reference-style [^1] footnotes.
+  return content.replace(/(?<!\[)\[(\d+(?:\s*[,，]\s*\d+)*)\](?![([\]])/g, (_, group) =>
     group
       .split(/(\s*[,，]\s*)/)
       .map((part: string) => {
@@ -45,8 +60,9 @@ function linkifyCitation(numStr: string, sources: AiSemanticResult[]): string | 
   const source = sources[index];
   const path = getAiSourcePath(source);
   const cleanText = source.preview || cleanSourceText(source.text || '');
-  const title = source.metadata?.title || cleanText.slice(0, 30).replace(/\s+/g, ' ').trim();
-  return `[\\[${numStr}\\]](${path} "${title}")`;
+  const title = (source.metadata?.title || cleanText.slice(0, 30)).replace(/\s+/g, ' ').trim();
+  const escapedTitle = title.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  return `[\\[${numStr}\\]](${path} "${escapedTitle}")`;
 }
 
 function AiStreamingMarkdown({

--- a/web/src/components/ai/AiStreamingMarkdown.tsx
+++ b/web/src/components/ai/AiStreamingMarkdown.tsx
@@ -12,28 +12,41 @@ interface AiStreamingMarkdownProps {
 }
 
 /**
- * Replace bare `[N]` citation markers with markdown links that point to the
- * referenced source.  Only markers whose index falls within the sources array
- * are converted — others are left untouched.
+ * Replace bare citation markers such as `[N]` and `[N,M]` with markdown links
+ * that point to the referenced sources. Only markers whose index falls within
+ * the sources array are converted — others are left untouched.
  *
  * We deliberately skip `[N]` that are already part of a markdown link (e.g.
  * `[text](url)` or `[^N]`) to avoid double-linking.
  */
-function linkifyCitations(content: string, sources: AiSemanticResult[]): string {
+export function linkifyCitations(content: string, sources: AiSemanticResult[]): string {
   if (sources.length === 0) return content;
 
-  // Match [N] not preceded by [ or followed by ( or ]
+  // Match [N] or comma-separated groups such as [N,M], but not markers
+  // preceded by [ or followed by ( or ].
   // This avoids matching inside existing markdown links like [text](url)
   // or reference-style [^1] footnotes
-  return content.replace(/(?<!\[)\[(\d+)\](?!\(|\])/g, (match, numStr) => {
-    const index = parseInt(numStr, 10) - 1; // AI uses 1-indexed
-    if (index < 0 || index >= sources.length) return match;
-    const source = sources[index];
-    const path = getAiSourcePath(source);
-    const cleanText = source.preview || cleanSourceText(source.text || '');
-    const title = source.metadata?.title || cleanText.slice(0, 30).replace(/\s+/g, ' ').trim();
-    return `[\\[${numStr}\\]](${path} "${title}")`;
-  });
+  return content.replace(/(?<!\[)\[(\d+(?:\s*[,，]\s*\d+)*)\](?!\(|\])/g, (_, group) =>
+    group
+      .split(/(\s*[,，]\s*)/)
+      .map((part: string) => {
+        if (!/^\d+$/.test(part)) return part;
+
+        const citation = linkifyCitation(part, sources);
+        return citation || `[${part}]`;
+      })
+      .join('')
+  );
+}
+
+function linkifyCitation(numStr: string, sources: AiSemanticResult[]): string | null {
+  const index = parseInt(numStr, 10) - 1; // AI uses 1-indexed
+  if (index < 0 || index >= sources.length) return null;
+  const source = sources[index];
+  const path = getAiSourcePath(source);
+  const cleanText = source.preview || cleanSourceText(source.text || '');
+  const title = source.metadata?.title || cleanText.slice(0, 30).replace(/\s+/g, ' ').trim();
+  return `[\\[${numStr}\\]](${path} "${title}")`;
 }
 
 function AiStreamingMarkdown({


### PR DESCRIPTION
## Summary

- parse grouped AI citation markers such as `[1,2]`, `[1, 2]`, and `[1，2]`
- preserve separators and unsupported citation numbers
- avoid rewriting existing Markdown links and footnotes
- add focused citation parser coverage

## Why

AI responses sometimes combine multiple source references inside one bracket pair. The existing parser only recognized a single numeric marker, so grouped references were rendered as plain text instead of source links.

## Validation

- `bun run test -- AiStreamingMarkdown.test.ts`
- `bun run lint`
- `bun run build`