### PR TITLE
feat: add configurable head scripts

### DIFF
--- a/server/bun.lock
+++ b/server/bun.lock
@@ -16,6 +16,7 @@
         "jose": "^6.1.3",
         "jpeg-js": "^0.4.4",
         "moment": "^2.30.1",
+        "parse5": "^8.0.1",
         "postgres": "^3.4.5",
         "rate-limiter-flexible": "^9.0.0",
         "web-push": "^3.6.7",
@@ -589,7 +590,7 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.18.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.2.0" } }, "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg=="],
 
-    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+    "entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
 
     "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
@@ -931,6 +932,8 @@
 
     "parse-statements": ["parse-statements@1.0.11", "", {}, "sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA=="],
 
+    "parse5": ["parse5@8.0.1", "", { "dependencies": { "entities": "^8.0.0" } }, "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw=="],
+
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
@@ -1152,6 +1155,8 @@
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
     "@typescript-eslint/typescript-estree/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+
+    "@vue/compiler-core/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 

--- a/server/package.json
+++ b/server/package.json
@@ -51,6 +51,7 @@
     "jose": "^6.1.3",
     "jpeg-js": "^0.4.4",
     "moment": "^2.30.1",
+    "parse5": "^8.0.1",
     "postgres": "^3.4.5",
     "rate-limiter-flexible": "^9.0.0",
     "web-push": "^3.6.7",

--- a/server/route/v2/admin.ts
+++ b/server/route/v2/admin.ts
@@ -24,6 +24,7 @@ import {
   validateNotificationConfig,
 } from '../../utils/adminHooks';
 import { ConfigTester } from '../../utils/configTester';
+import { resolveCustomHeadScriptsUpdate } from '../../utils/customHeadScripts';
 import { createResponse, getApiUrl } from '../../utils/main';
 import {
   getStorageFriendlyError,
@@ -139,6 +140,27 @@ adminRouter.put('/settings', authenticateJWT, requireAdmin, async (c: HonoContex
     const user = c.get('user') as any;
     if (group === 'system' && user?.role !== 'super_admin') {
       return c.json(createResponse(null, 'Only super admin can modify system configuration'), 403);
+    }
+
+    if (group === 'site') {
+      try {
+        const existingSiteConfig = (await getConfig('site')) as Record<string, any> | null;
+        const incomingScripts = resolveCustomHeadScriptsUpdate(
+          existingSiteConfig?.customHeadScripts,
+          config.customHeadScripts,
+          user?.role === 'super_admin'
+        );
+
+        config = { ...config };
+        if (incomingScripts === undefined) delete config.customHeadScripts;
+        else config.customHeadScripts = incomingScripts;
+      } catch (error: any) {
+        const message = error instanceof Error ? error.message : String(error ?? '');
+        return c.json(
+          createResponse(null, message),
+          message === 'Only super admin can modify custom head scripts' ? 403 : 400
+        );
+      }
     }
 
     // 如果是存储配置，需要先验证配置是否可用

--- a/server/route/v2/site.ts
+++ b/server/route/v2/site.ts
@@ -155,6 +155,7 @@ siteRouter.get('/status', async (c: HonoContext) => {
         defaultLanguage: (siteConfig as any)?.defaultLanguage || 'zh-CN',
         icpRecord: (siteConfig as any)?.icpRecord || undefined,
         announcement: (siteConfig as any)?.announcement || undefined,
+        customHeadScripts: (siteConfig as any)?.customHeadScripts || undefined,
       },
 
       // 系统信息

--- a/server/types/config.ts
+++ b/server/types/config.ts
@@ -5,6 +5,7 @@ export type ConfigGroup = 'site' | 'storage' | 'security' | 'notification' | 'ui
 export interface SiteConfig {
   name: string;
   frontendUrl: string; // 前端 URL，用于生成 RSS Feed 链接等
+  customHeadScripts?: string;
   description?: string;
   defaultLanguage?: string;
   allowedOrigins?: string[]; // CORS 允许的 origin 列表，为空或不设置则允许所有

--- a/server/utils/customHeadScripts.test.ts
+++ b/server/utils/customHeadScripts.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  CUSTOM_HEAD_SCRIPTS_MAX_BYTES,
+  normalizeCustomHeadScripts,
+  resolveCustomHeadScriptsUpdate,
+} from './customHeadScripts';
+
+describe('normalizeCustomHeadScripts', () => {
+  it('accepts multiple external and inline scripts', () => {
+    const value = `
+      <!-- analytics -->
+      <script defer src="https://example.com/telemetry.js" data-product-id="123"></script>
+      <script>window.exampleReady = true;</script>
+    `;
+
+    expect(normalizeCustomHeadScripts(value)).toBe(value);
+  });
+
+  it('normalizes an empty value to undefined', () => {
+    expect(normalizeCustomHeadScripts('')).toBeUndefined();
+    expect(normalizeCustomHeadScripts(undefined)).toBeUndefined();
+  });
+
+  it('rejects non-script HTML', () => {
+    expect(() => normalizeCustomHeadScripts('<meta name="theme-color" content="red">')).toThrow(
+      'may only contain <script> tags'
+    );
+  });
+
+  it('rejects malformed HTML', () => {
+    expect(() => normalizeCustomHeadScripts('<script src="broken></script>')).toThrow(
+      'malformed HTML'
+    );
+  });
+
+  it('rejects values larger than 64 KiB', () => {
+    const oversized = `<script>${'a'.repeat(CUSTOM_HEAD_SCRIPTS_MAX_BYTES)}</script>`;
+    expect(() => normalizeCustomHeadScripts(oversized)).toThrow('must not exceed 64 KiB');
+  });
+});
+
+describe('resolveCustomHeadScriptsUpdate', () => {
+  const existing = '<script src="https://example.com/old.js"></script>';
+  const incoming = '<script src="https://example.com/new.js"></script>';
+
+  it('allows a super admin to change or clear scripts', () => {
+    expect(resolveCustomHeadScriptsUpdate(existing, incoming, true)).toBe(incoming);
+    expect(resolveCustomHeadScriptsUpdate(existing, '', true)).toBeUndefined();
+  });
+
+  it('allows an admin to save an unchanged value', () => {
+    expect(resolveCustomHeadScriptsUpdate(existing, existing, false)).toBe(existing);
+  });
+
+  it('prevents an admin from changing or clearing scripts', () => {
+    expect(() => resolveCustomHeadScriptsUpdate(existing, incoming, false)).toThrow(
+      'Only super admin can modify custom head scripts'
+    );
+    expect(() => resolveCustomHeadScriptsUpdate(existing, '', false)).toThrow(
+      'Only super admin can modify custom head scripts'
+    );
+  });
+});

--- a/server/utils/customHeadScripts.ts
+++ b/server/utils/customHeadScripts.ts
@@ -1,0 +1,47 @@
+import { parseFragment } from 'parse5';
+
+export const CUSTOM_HEAD_SCRIPTS_MAX_BYTES = 64 * 1024;
+
+export function normalizeCustomHeadScripts(value: unknown): string | undefined {
+  if (value === undefined || value === null || value === '') return undefined;
+  if (typeof value !== 'string') {
+    throw new Error('Custom head scripts must be a string');
+  }
+
+  if (new TextEncoder().encode(value).byteLength > CUSTOM_HEAD_SCRIPTS_MAX_BYTES) {
+    throw new Error('Custom head scripts must not exceed 64 KiB');
+  }
+
+  const parseErrors: unknown[] = [];
+  const fragment = parseFragment(value, {
+    onParseError: (error) => parseErrors.push(error),
+  });
+
+  if (parseErrors.length > 0) {
+    throw new Error('Custom head scripts contain malformed HTML');
+  }
+
+  for (const node of fragment.childNodes) {
+    if (node.nodeName === '#comment') continue;
+    if (node.nodeName === '#text' && 'value' in node && node.value.trim() === '') continue;
+    if (node.nodeName === 'script') continue;
+    throw new Error('Custom head scripts may only contain <script> tags');
+  }
+
+  return value;
+}
+
+export function resolveCustomHeadScriptsUpdate(
+  existingValue: unknown,
+  incomingValue: unknown,
+  isSuperAdmin: boolean
+): string | undefined {
+  const existingScripts = normalizeCustomHeadScripts(existingValue);
+  const incomingScripts = normalizeCustomHeadScripts(incomingValue);
+
+  if (existingScripts !== incomingScripts && !isSuperAdmin) {
+    throw new Error('Only super admin can modify custom head scripts');
+  }
+
+  return incomingScripts;
+}

--- a/web/index.html
+++ b/web/index.html
@@ -57,12 +57,6 @@
         }
       })();
     </script>
-    <!-- Umami -->
-    <script
-      defer
-      src="https://umami.rote.ink/script.js"
-      data-website-id="99c1821a-4d53-47b5-9014-f74bfa60cd0a"
-    ></script>
     <!-- React Scan - Development only -->
     <script type="module">
       if (import.meta.env.DEV) {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import { useEffect } from 'react';
 import { SWRConfig } from 'swr';
 import { ThemeProvider } from './components/theme-provider';
+import CustomHeadScripts from './components/CustomHeadScripts';
 import GlobalRouterProvider from './route/main';
 
 const AppHelmet = () => {
@@ -28,7 +29,6 @@ const AppHelmet = () => {
 const AppWrapper = () => (
   <React.StrictMode>
     <HelmetProvider>
-      <AppHelmet />
       <SWRConfig
         value={{
           onErrorRetry: (error, key, _config, _revalidate, { retryCount }) => {
@@ -39,6 +39,8 @@ const AppWrapper = () => (
           },
         }}
       >
+        <AppHelmet />
+        <CustomHeadScripts />
         <ThemeProvider defaultTheme="system" storageKey="vite-ui-theme">
           <AuthBootstrap />
           <GlobalRouterProvider />

--- a/web/src/components/CustomHeadScripts.test.ts
+++ b/web/src/components/CustomHeadScripts.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { injectCustomHeadScripts } from './CustomHeadScripts';
+
+const selector = '[data-rote-custom-head-script="true"]';
+
+afterEach(() => {
+  document.head.querySelectorAll(selector).forEach((script) => script.remove());
+});
+
+describe('injectCustomHeadScripts', () => {
+  it('copies external script attributes and inline content into document.head', async () => {
+    await injectCustomHeadScripts(`
+      <script async src="https://example.com/telemetry.js" data-product-id="product-1"></script>
+      <script>window.customTelemetryLoaded = true;</script>
+    `);
+
+    const scripts = Array.from(document.head.querySelectorAll<HTMLScriptElement>(selector));
+    expect(scripts).toHaveLength(2);
+    expect(scripts[0]).toHaveAttribute('src', 'https://example.com/telemetry.js');
+    expect(scripts[0]).toHaveAttribute('async');
+    expect(scripts[0]).toHaveAttribute('data-product-id', 'product-1');
+    expect(scripts[1].textContent).toContain('window.customTelemetryLoaded = true');
+  });
+
+  it('waits for a blocking external script before appending the next script', async () => {
+    const injection = injectCustomHeadScripts(`
+      <script src="https://example.com/dependency.js"></script>
+      <script>window.dependencyConsumer = true;</script>
+    `);
+
+    const firstScript = document.head.querySelector<HTMLScriptElement>(selector);
+    expect(firstScript).not.toBeNull();
+    expect(document.head.querySelectorAll(selector)).toHaveLength(1);
+
+    firstScript?.dispatchEvent(new Event('load'));
+    await injection;
+
+    expect(document.head.querySelectorAll(selector)).toHaveLength(2);
+  });
+});

--- a/web/src/components/CustomHeadScripts.tsx
+++ b/web/src/components/CustomHeadScripts.tsx
@@ -1,0 +1,52 @@
+import { useSiteStatus } from '@/hooks/useSiteStatus';
+import { useEffect } from 'react';
+
+const CUSTOM_SCRIPT_MARKER = 'data-rote-custom-head-script';
+let hasHandledInitialConfig = false;
+
+function parseScripts(html: string): HTMLScriptElement[] {
+  const documentFragment = new DOMParser().parseFromString(html, 'text/html');
+  return Array.from(documentFragment.querySelectorAll('script')).map((source) => {
+    const script = document.createElement('script');
+    for (const attribute of Array.from(source.attributes)) {
+      script.setAttribute(attribute.name, attribute.value);
+    }
+    script.textContent = source.textContent;
+    script.setAttribute(CUSTOM_SCRIPT_MARKER, 'true');
+    return script;
+  });
+}
+
+export async function injectCustomHeadScripts(html: string): Promise<void> {
+  const scripts = parseScripts(html);
+
+  for (const script of scripts) {
+    const isBlockingExternalScript = Boolean(script.src) && !script.hasAttribute('async');
+    if (!isBlockingExternalScript) {
+      document.head.appendChild(script);
+      continue;
+    }
+
+    script.async = false;
+    await new Promise<void>((resolve) => {
+      script.addEventListener('load', () => resolve(), { once: true });
+      script.addEventListener('error', () => resolve(), { once: true });
+      document.head.appendChild(script);
+    });
+  }
+}
+
+export default function CustomHeadScripts() {
+  const { data: siteStatus } = useSiteStatus();
+
+  useEffect(() => {
+    if (!siteStatus || hasHandledInitialConfig) return;
+    hasHandledInitialConfig = true;
+
+    if (siteStatus.site.customHeadScripts) {
+      void injectCustomHeadScripts(siteStatus.site.customHeadScripts);
+    }
+  }, [siteStatus]);
+
+  return null;
+}

--- a/web/src/hooks/useSiteStatus.ts
+++ b/web/src/hooks/useSiteStatus.ts
@@ -30,6 +30,7 @@ interface SiteStatusData {
       content: string;
       link?: string;
     };
+    customHeadScripts?: string;
   };
   system: {
     version: string;

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1231,6 +1231,13 @@
         "frontendUrlDescription": "Frontend access URL, used to generate note links in RSS feeds",
         "icpRecord": "ICP Record Number",
         "icpRecordDescription": "Website ICP record number, e.g., 京ICP备12345678号",
+        "customHeadScripts": {
+          "title": "Custom Head Scripts",
+          "description": "Supports one or more script tags. Refresh the page after saving to apply changes.",
+          "warning": "Warning: these scripts can read page data and login state. Only paste code you fully trust, and never enter server-side secrets.",
+          "placeholder": "<script defer src=\"https://your-umami-domain.com/script.js\" data-website-id=\"YOUR_WEBSITE_ID\"></script>",
+          "tooLarge": "Custom head scripts must not exceed 64 KiB"
+        },
         "announcement": {
           "title": "Site Announcement",
           "description": "Announcement displayed at the top of the Explore page.",

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -1235,6 +1235,13 @@
         "frontendUrlDescription": "フロントエンドアクセスURL、RSSフィードでノートリンクを生成するために使用",
         "icpRecord": "ICP記録番号",
         "icpRecordDescription": "ウェブサイトICP記録番号、例：京ICP备12345678号",
+        "customHeadScripts": {
+          "title": "カスタム Head スクリプト",
+          "description": "1つ以上の script タグを設定できます。保存後、ページを再読み込みすると反映されます。",
+          "warning": "警告：これらのスクリプトはページデータとログイン状態を読み取れます。完全に信頼できるコードのみを貼り付け、サーバー側の秘密情報は入力しないでください。",
+          "placeholder": "<script defer src=\"https://your-umami-domain.com/script.js\" data-website-id=\"YOUR_WEBSITE_ID\"></script>",
+          "tooLarge": "カスタム Head スクリプトは 64 KiB 以下にしてください"
+        },
         "announcement": {
           "title": "サイトのお知らせ",
           "description": "探索ページの上部に表示されるお知らせ",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1221,6 +1221,13 @@
         "frontendUrlDescription": "前端访问地址，用于生成 RSS Feed 中的笔记链接",
         "icpRecord": "ICP 备案号",
         "icpRecordDescription": "网站备案号，如：京ICP备12345678号",
+        "customHeadScripts": {
+          "title": "自定义 Head 脚本",
+          "description": "支持一个或多个 script 标签，保存后刷新页面生效。",
+          "warning": "警告：这些脚本可读取页面数据和登录状态。仅粘贴你完全信任的代码，且不要填写服务端密钥。",
+          "placeholder": "<script defer src=\"https://your-umami-domain.com/script.js\" data-website-id=\"YOUR_WEBSITE_ID\"></script>",
+          "tooLarge": "自定义 Head 脚本不能超过 64 KiB"
+        },
         "announcement": {
           "title": "站点公告",
           "description": "在探索页面顶部显示的站点公告",

--- a/web/src/pages/admin/components/SiteConfigTab.tsx
+++ b/web/src/pages/admin/components/SiteConfigTab.tsx
@@ -11,12 +11,15 @@ import { toast } from 'sonner';
 import { useSWRConfig } from 'swr';
 import type { SystemConfig } from '../types';
 
+const CUSTOM_HEAD_SCRIPTS_MAX_BYTES = 64 * 1024;
+
 interface SiteConfigTabProps {
   siteConfig: SystemConfig['site'] | undefined;
   setSiteConfig: (config: SystemConfig['site'] | undefined) => void;
   isSaving: boolean;
   setIsSaving: (saving: boolean) => void;
   onMutate: () => void;
+  isSuperAdmin: boolean;
 }
 
 export default function SiteConfigTab({
@@ -25,6 +28,7 @@ export default function SiteConfigTab({
   isSaving,
   setIsSaving,
   onMutate,
+  isSuperAdmin,
 }: SiteConfigTabProps) {
   const { t } = useTranslation('translation', { keyPrefix: 'pages.admin' });
   const { mutate: globalMutate } = useSWRConfig();
@@ -32,6 +36,13 @@ export default function SiteConfigTab({
   const handleSave = async () => {
     if (!siteConfig || !siteConfig.name || !siteConfig.frontendUrl) {
       toast.error(t('saveFailed', { error: 'Site name and frontend URL are required' }));
+      return;
+    }
+    if (
+      new TextEncoder().encode(siteConfig.customHeadScripts || '').byteLength >
+      CUSTOM_HEAD_SCRIPTS_MAX_BYTES
+    ) {
+      toast.error(t('site.customHeadScripts.tooLarge'));
       return;
     }
     setIsSaving(true);
@@ -201,6 +212,36 @@ export default function SiteConfigTab({
           />
           <p className="text-muted-foreground text-xs">{t('site.icpRecordDescription')}</p>
         </div>
+
+        {isSuperAdmin && (
+          <div className="space-y-2">
+            <Label htmlFor="customHeadScripts">{t('site.customHeadScripts.title')}</Label>
+            <p className="text-destructive text-sm">{t('site.customHeadScripts.warning')}</p>
+            <Textarea
+              id="customHeadScripts"
+              value={siteConfig?.customHeadScripts || ''}
+              onChange={(e) =>
+                setSiteConfig({
+                  ...(siteConfig || {}),
+                  name: siteConfig?.name || '',
+                  frontendUrl: siteConfig?.frontendUrl || '',
+                  customHeadScripts: e.target.value,
+                })
+              }
+              placeholder={t('site.customHeadScripts.placeholder')}
+              rows={9}
+              className="font-mono text-xs"
+              spellCheck={false}
+            />
+            <div className="text-muted-foreground flex justify-between text-xs">
+              <span>{t('site.customHeadScripts.description')}</span>
+              <span>
+                {new TextEncoder().encode(siteConfig?.customHeadScripts || '').byteLength} /{' '}
+                {CUSTOM_HEAD_SCRIPTS_MAX_BYTES}
+              </span>
+            </div>
+          </div>
+        )}
 
         <Button onClick={handleSave} disabled={isSaving} className="w-full">
           {isSaving ? t('saving') : t('save')}

--- a/web/src/pages/admin/index.tsx
+++ b/web/src/pages/admin/index.tsx
@@ -218,6 +218,7 @@ export default function AdminDashboard() {
             isSaving={isSaving}
             setIsSaving={setIsSaving}
             onMutate={mutate}
+            isSuperAdmin={profile.role === 'super_admin'}
           />
         )}
 

--- a/web/src/pages/admin/types.ts
+++ b/web/src/pages/admin/types.ts
@@ -11,6 +11,7 @@ export interface SystemConfig {
       content: string;
       link?: string;
     };
+    customHeadScripts?: string;
   };
   storage?: {
     endpoint: string;


### PR DESCRIPTION
## Summary

- add a super-admin-only custom Head Script setting with localized warnings and an Umami example
- validate and persist script-only HTML in the existing site configuration, then expose it through the public site status
- asynchronously inject configured scripts after React starts while preserving external script ordering and avoiding duplicate execution
- remove the hardcoded Umami script from `web/index.html`

## Impact

Self-hosted administrators can configure analytics or other trusted browser scripts without rebuilding the frontend. React rendering is never blocked by the configuration request.

## Validation

- `server`: `bun test utils/customHeadScripts.test.ts`
- `server`: `bun run lint`
- `server`: `bun run build`
- `web`: `bun run test -- src/components/CustomHeadScripts.test.ts`
- `web`: `bun run lint`
- `web`: `bun run build`