### PR TITLE
Enable audio for Live Photo previews

### DIFF
--- a/web/src/components/rote/LivePhotoAttachmentPreview.test.tsx
+++ b/web/src/components/rote/LivePhotoAttachmentPreview.test.tsx
@@ -92,6 +92,28 @@ describe('LivePhotoAttachmentPreview', () => {
     expect(video).toHaveAttribute('preload', 'metadata');
   });
 
+  it('starts audible playback directly from the press gesture and stops on release', () => {
+    const { container } = render(
+      <LivePhotoAttachmentPreview
+        attachment={makeLivePhotoAttachment()}
+        previewSrc="https://cdn.example.com/users/u/compressed/live.webp"
+        thumbnailSrc="https://cdn.example.com/users/u/compressed/live.webp"
+      />
+    );
+
+    const frame = screen.getByLabelText('videoLabel');
+    const video = container.querySelector('video');
+
+    fireEvent.mouseDown(frame, { button: 0 });
+
+    expect(HTMLMediaElement.prototype.play).toHaveBeenCalledTimes(1);
+    expect(video).toHaveClass('opacity-100');
+
+    fireEvent.mouseUp(frame);
+
+    expect(video).toHaveClass('opacity-0');
+  });
+
   it('bounds the registered preview dimensions while preserving the still aspect ratio', () => {
     const { container } = render(
       <LivePhotoAttachmentPreview

--- a/web/src/components/rote/LivePhotoAttachmentPreview.test.tsx
+++ b/web/src/components/rote/LivePhotoAttachmentPreview.test.tsx
@@ -88,6 +88,7 @@ describe('LivePhotoAttachmentPreview', () => {
     expect(video).toHaveClass('object-contain');
     expect(video).not.toHaveAttribute('autoplay');
     expect(video).not.toHaveAttribute('loop');
+    expect(video).not.toHaveAttribute('muted');
     expect(video).toHaveAttribute('preload', 'metadata');
   });
 

--- a/web/src/components/rote/LivePhotoViewer.tsx
+++ b/web/src/components/rote/LivePhotoViewer.tsx
@@ -19,7 +19,6 @@ const DEFAULT_VIEWPORT_SIZE = {
 };
 const VIEWER_HORIZONTAL_PADDING = 32;
 const VIEWER_VERTICAL_PADDING = 64;
-const LIVE_PHOTO_PRESS_DELAY_MS = 180;
 
 export function getLivePhotoPreviewSize(
   width: number,
@@ -87,15 +86,8 @@ export function LivePhotoMotionViewer({
   onVideoError: () => void;
 }) {
   const videoRef = useRef<HTMLVideoElement | null>(null);
-  const pressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [isPlaying, setIsPlaying] = useState(false);
   const { className, style, frameAttrs } = getPhotoViewFrameProps(attrs);
-
-  const clearPressTimer = useCallback(() => {
-    if (!pressTimerRef.current) return;
-    clearTimeout(pressTimerRef.current);
-    pressTimerRef.current = null;
-  }, []);
 
   const resetVideo = useCallback(() => {
     const video = videoRef.current;
@@ -108,10 +100,9 @@ export function LivePhotoMotionViewer({
   }, []);
 
   const stopMotion = useCallback(() => {
-    clearPressTimer();
     resetVideo();
     setIsPlaying(false);
-  }, [clearPressTimer, resetVideo]);
+  }, [resetVideo]);
 
   const startMotion = useCallback(() => {
     const video = videoRef.current;
@@ -124,22 +115,11 @@ export function LivePhotoMotionViewer({
     });
   }, []);
 
-  const queueMotionStart = useCallback(() => {
-    clearPressTimer();
-    pressTimerRef.current = setTimeout(startMotion, LIVE_PHOTO_PRESS_DELAY_MS);
-  }, [clearPressTimer, startMotion]);
-
   useEffect(() => {
     stopMotion();
   }, [playbackSrc, previewSrc, stopMotion]);
 
-  useEffect(
-    () => () => {
-      clearPressTimer();
-      resetVideo();
-    },
-    [clearPressTimer, resetVideo]
-  );
+  useEffect(() => () => resetVideo(), [resetVideo]);
 
   useEffect(() => {
     const handleRelease = () => stopMotion();
@@ -167,7 +147,7 @@ export function LivePhotoMotionViewer({
   const handleMouseDown = (event: MouseEvent<HTMLElement>) => {
     frameAttrs.onMouseDown?.(event);
     if (event.defaultPrevented || event.button !== 0) return;
-    queueMotionStart();
+    startMotion();
   };
 
   const handleMouseUp = (event: MouseEvent<HTMLElement>) => {
@@ -183,7 +163,7 @@ export function LivePhotoMotionViewer({
   const handleTouchStart = (event: TouchEvent<HTMLElement>) => {
     frameAttrs.onTouchStart?.(event);
     if (event.defaultPrevented || event.touches.length !== 1) return;
-    queueMotionStart();
+    startMotion();
   };
 
   const handleTouchEnd = (event: TouchEvent<HTMLElement>) => {

--- a/web/src/components/rote/LivePhotoViewer.tsx
+++ b/web/src/components/rote/LivePhotoViewer.tsx
@@ -223,7 +223,6 @@ export function LivePhotoMotionViewer({
         )}
         src={playbackSrc}
         poster={previewSrc || undefined}
-        muted
         playsInline
         preload="metadata"
         aria-hidden={!isPlaying}


### PR DESCRIPTION
## Summary

- play the paired Live Photo video with its original audio during long-press preview
- cover the audible playback configuration in the component test

## Why

The preview video was explicitly rendered with the `muted` attribute, so its audio track could never be heard even when the source MOV contained sound.

## Validation

- `bun run test --run src/components/rote/LivePhotoAttachmentPreview.test.tsx`
- `bun run lint`
- `bun run build`