### PR TITLE
docs: update user API guide

### DIFF
--- a/doc/userguide/USER-API.md
+++ b/doc/userguide/USER-API.md
@@ -1,79 +1,108 @@
-## 用户接口使用指南
+# 用户接口使用指南
 
-本指南面向对接方，说明如何使用用户相关的接口进行用户信息查询、个人资料管理、统计数据获取等操作。仅包含使用方法与示例，不涉及实现细节。
+本文档说明当前用户接口的请求方式、主要字段和响应结构。接口实现以
+`server/route/v2/user.ts`、`server/utils/dbMethods/user*.ts` 和 `server/imports/` 为准。
 
-### 基础信息
+## 基础信息
 
-- **基础路径**: `/v2/api/users`
-- **统一响应**: `{ code: number, message: string, data: any }`（`code=0` 表示成功）
-- **认证方式**: 在需要鉴权的接口，加请求头 `Authorization: Bearer <accessToken>`
+- 基础路径：`/v2/api/users`
+- 鉴权方式：需要登录的接口使用 `Authorization: Bearer <accessToken>`
+- JSON 请求需使用 `Content-Type: application/json`
+- 除数据导出接口外，成功响应统一为：
 
----
-
-### 1) 获取用户信息（通过用户名）
-
-- **方法**: GET
-- **URL**: `/v2/api/users/:username`
-- **Headers**: 无需认证
-- **路径参数**:
-  - `username`: string（用户名）
-
-请求示例（cURL）:
-
-```bash
-curl -X GET 'https://your-domain.com/v2/api/users/demo'
+```json
+{
+  "code": 0,
+  "message": "success",
+  "data": {}
+}
 ```
 
-成功响应示例（200）：
+- 错误响应通常为：
+
+```json
+{
+  "code": 1,
+  "message": "错误信息",
+  "data": null
+}
+```
+
+## 接口一览
+
+| 方法 | 路径 | 鉴权 | 用途 |
+| --- | --- | --- | --- |
+| `GET` | `/v2/api/users/:username` | 否 | 获取公开用户信息 |
+| `GET` | `/v2/api/users/me/profile` | 是 | 获取当前用户资料和登录方式 |
+| `PUT` | `/v2/api/users/me/profile` | 是 | 更新当前用户资料 |
+| `GET` | `/v2/api/users/me/settings` | 是 | 获取当前用户设置 |
+| `PUT` | `/v2/api/users/me/settings` | 是 | 更新当前用户设置 |
+| `GET` | `/v2/api/users/me/tags` | 是 | 获取当前用户标签统计 |
+| `GET` | `/v2/api/users/me/heatmap` | 是 | 获取当前用户笔记热力图 |
+| `GET` | `/v2/api/users/me/statistics` | 是 | 获取当前用户内容统计 |
+| `GET` | `/v2/api/users/me/export` | 是 | 导出用户数据 |
+| `POST` | `/v2/api/users/me/import/plan` | 是 | 预检需要导入的笔记 |
+| `POST` | `/v2/api/users/me/import` | 是 | 导入用户数据 |
+| `DELETE` | `/v2/api/users/me` | 是 | 删除当前用户账户 |
+
+## 1. 获取公开用户信息
+
+`GET /v2/api/users/:username`
+
+路径参数：
+
+- `username`：用户名。
+
+请求示例：
+
+```bash
+curl 'https://your-domain.com/v2/api/users/demo'
+```
+
+成功响应：
 
 ```json
 {
   "code": 0,
   "message": "success",
   "data": {
-    "id": "uuid",
+    "id": "550e8400-e29b-41d4-a716-446655440000",
     "username": "demo",
     "nickname": "Demo",
     "avatar": "https://example.com/avatar.jpg",
     "cover": "https://example.com/cover.jpg",
     "description": "用户简介",
-    "createdAt": "2024-01-01T00:00:00.000Z",
+    "createdAt": "2026-01-01T00:00:00.000Z",
     "certified": true
   }
 }
 ```
 
-字段说明：
-
-- `certified`: boolean - 用户是否已认证（供前端显示认证状态使用）
+`nickname`、`avatar`、`cover` 和 `description` 可能为 `null`。`certified` 表示用户是否已认证。
 
 可能的错误：
 
-- 404 用户不存在
+- `404`：用户不存在。
 
----
+## 2. 获取当前用户资料
 
-### 2) 获取当前用户个人资料
+`GET /v2/api/users/me/profile`
 
-- **方法**: GET
-- **URL**: `/v2/api/users/me/profile`
-- **Headers**: `Authorization: Bearer <accessToken>`（必填）
-
-请求示例（cURL）:
+请求示例：
 
 ```bash
-curl -X GET 'https://your-domain.com/v2/api/users/me/profile' \
+curl 'https://your-domain.com/v2/api/users/me/profile' \
   -H 'Authorization: Bearer <ACCESS_TOKEN>'
 ```
 
-成功响应示例（200）：
+成功响应：
 
 ```json
 {
   "code": 0,
   "message": "success",
   "data": {
-    "id": "uuid",
+    "id": "550e8400-e29b-41d4-a716-446655440000",
     "certified": true,
     "email": "demo@example.com",
     "username": "demo",
@@ -82,109 +111,105 @@ curl -X GET 'https://your-domain.com/v2/api/users/me/profile' \
     "avatar": "https://example.com/avatar.jpg",
     "cover": "https://example.com/cover.jpg",
     "role": "user",
-    "createdAt": "2024-01-01T00:00:00.000Z",
-    "updatedAt": "2024-01-01T00:00:00.000Z",
+    "createdAt": "2026-01-01T00:00:00.000Z",
+    "updatedAt": "2026-07-23T00:00:00.000Z",
     "allowExplore": true,
-    "authProvider": "local",
-    "authProviderId": null
+    "hasPassword": true,
+    "oauthBindings": [
+      {
+        "provider": "github",
+        "providerId": "12345678",
+        "providerUsername": "demo"
+      }
+    ]
   }
 }
 ```
 
-字段补充说明：
+字段说明：
 
-- `certified`: boolean - 当前用户是否已认证（供前端提示与安全策略使用）
-- `allowExplore`: boolean - 是否允许该用户的公开笔记出现在「探索」页（见下文用户设置接口）
-- `authProvider`: string - 认证提供商，可能的值：
-  - `'local'`: 本地账户（通过用户名密码注册/登录）
-  - `'github'`: GitHub OAuth 账户（纯 OAuth 用户，无密码）
-  - `'apple'`: Apple OAuth 账户（纯 OAuth 用户，无密码）
-  - 其他 OAuth 提供商名称（根据配置动态支持）
-- `authProviderId`: string | null - OAuth 提供商的用户 ID（例如 GitHub 用户 ID），如果未绑定则为 `null`
+- `certified`：用户是否已认证。
+- `allowExplore`：是否允许公开笔记出现在探索页。
+- `hasPassword`：当前账户是否已设置本地密码。
+- `oauthBindings`：账户绑定的 OAuth 登录方式；可以为空数组，也可以包含多个提供商。
+- `oauthBindings[].providerUsername`：提供商用户名，可能为 `null`。
+
+旧版的 `authProvider` 和 `authProviderId` 字段已移除。客户端应使用 `hasPassword` 和
+`oauthBindings` 判断可用登录方式。
 
 可能的错误：
 
-- 401 未认证（需要登录）
-- 404 用户不存在
+- `401`：未认证或令牌无效。
+- `404`：用户不存在。
 
----
+## 3. 更新当前用户资料
 
-### 3) 更新当前用户个人资料
+`PUT /v2/api/users/me/profile`
 
-- **方法**: PUT
-- **URL**: `/v2/api/users/me/profile`
-- **Headers**:
-  - `Authorization: Bearer <accessToken>`（必填）
-  - `Content-Type: application/json`
-- **Body**:
-  - `username`: string（可选，用户名）
-    - 长度：1-20 字符
-    - 格式：只能包含字母、数字、下划线（`_`）和连字符（`-`）
-    - 唯一性：不能与其他用户重复
-    - 保留字：不能与系统路由冲突
-  - `nickname`: string（可选，昵称）
-  - `description`: string（可选，个人简介）
-  - `avatar`: string（可选，头像 URL）
-  - `cover`: string（可选，封面 URL）
+请求体字段均为可选：
 
-请求示例（cURL）:
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `username` | `string` | 1–20 个字符，只能包含字母、数字、下划线和连字符，且不能使用保留路由或已存在的用户名 |
+| `nickname` | `string \| null` | 昵称；空字符串或 `null` 会清空字段 |
+| `description` | `string \| null` | 个人简介；空字符串或 `null` 会清空字段 |
+| `avatar` | `string \| null` | 头像 URL；空字符串或 `null` 会清空字段 |
+| `cover` | `string \| null` | 封面 URL；空字符串或 `null` 会清空字段 |
+
+请求示例：
 
 ```bash
 curl -X PUT 'https://your-domain.com/v2/api/users/me/profile' \
   -H 'Authorization: Bearer <ACCESS_TOKEN>' \
   -H 'Content-Type: application/json' \
   -d '{
-    "username": "newusername",
+    "username": "new-username",
     "nickname": "新昵称",
     "description": "新的个人简介",
     "avatar": "https://example.com/new-avatar.jpg",
-    "cover": "https://example.com/new-cover.jpg"
+    "cover": null
   }'
 ```
 
-成功响应示例（200）：
+成功响应中的 `data` 为更新后的基础资料：
 
 ```json
 {
   "code": 0,
   "message": "success",
   "data": {
-    "id": "uuid",
+    "id": "550e8400-e29b-41d4-a716-446655440000",
     "email": "demo@example.com",
-    "username": "newusername",
+    "username": "new-username",
     "nickname": "新昵称",
     "description": "新的个人简介",
     "avatar": "https://example.com/new-avatar.jpg",
-    "cover": "https://example.com/new-cover.jpg",
+    "cover": null,
     "role": "user",
-    "createdAt": "2024-01-01T00:00:00.000Z",
-    "updatedAt": "2024-01-01T00:00:00.000Z"
+    "createdAt": "2026-01-01T00:00:00.000Z",
+    "updatedAt": "2026-07-23T00:00:00.000Z"
   }
 }
 ```
 
 可能的错误：
 
-- 401 未认证（需要登录）
-- 400 字段格式错误（例如：用户名格式不正确、长度超出限制、与系统路由冲突）
-- 400 用户名已被使用（唯一性冲突）
+- `400`：用户名格式、长度或保留字校验失败。
+- `401`：未认证或令牌无效。
+- `409`：用户名已被使用。
 
----
+## 4. 获取当前用户设置
 
-### 3) 获取当前用户设置（探索页可见性等）
+`GET /v2/api/users/me/settings`
 
-- **方法**: GET
-- **URL**: `/v2/api/users/me/settings`
-- **Headers**: `Authorization: Bearer <accessToken>`（必填）
-
-请求示例（cURL）:
+请求示例：
 
 ```bash
-curl -X GET 'https://your-domain.com/v2/api/users/me/settings' \
+curl 'https://your-domain.com/v2/api/users/me/settings' \
   -H 'Authorization: Bearer <ACCESS_TOKEN>'
 ```
 
-成功响应示例（200）：
+成功响应：
 
 ```json
 {
@@ -196,77 +221,43 @@ curl -X GET 'https://your-domain.com/v2/api/users/me/settings' \
 }
 ```
 
-字段说明：
+`allowExplore` 默认为 `true`。设为 `false` 后，公开笔记仍可通过直接链接访问，但不会被纳入探索页。
 
-- `allowExplore`: boolean
-  - 为 `true`（默认）时：用户的公开笔记可以被纳入「探索」页推荐列表。
-  - 为 `false` 时：用户的公开笔记**仍然可以通过直接链接访问**，但不会出现在探索页中。
+## 5. 更新当前用户设置
 
-可能的错误：
+`PUT /v2/api/users/me/settings`
 
-- 401 未认证（需要登录）
+请求体：
 
----
+```json
+{
+  "allowExplore": false
+}
+```
 
-### 4) 更新当前用户设置（探索页可见性等）
-
-- **方法**: PUT
-- **URL**: `/v2/api/users/me/settings`
-- **Headers**:
-  - `Authorization: Bearer <accessToken>`（必填）
-  - `Content-Type: application/json`
-- **Body**:
-  - `allowExplore`: boolean（可选，是否允许公开笔记出现在探索页）
-
-请求示例（cURL）:
+请求示例：
 
 ```bash
 curl -X PUT 'https://your-domain.com/v2/api/users/me/settings' \
   -H 'Authorization: Bearer <ACCESS_TOKEN>' \
   -H 'Content-Type: application/json' \
-  -d '{
-    "allowExplore": false
-  }'
+  -d '{"allowExplore": false}'
 ```
 
-成功响应示例（200）：
+成功响应中的 `data` 为更新后的完整设置。若没有传入可更新字段，接口不会修改数据，而是返回当前设置。
 
-```json
-{
-  "code": 0,
-  "message": "success",
-  "data": {
-    "allowExplore": false
-  }
-}
-```
+## 6. 获取用户标签统计
 
-说明：
+`GET /v2/api/users/me/tags`
 
-- 此接口仅支持更新当前登录用户自己的设置；
-- 如果请求体中未包含任何可更新字段（如没有 `allowExplore`），将返回当前设置，不做修改。
-
-可能的错误：
-
-- 401 未认证（需要登录）
-- 400 请求体格式错误
-
----
-
-### 5) 获取用户标签
-
-- **方法**: GET
-- **URL**: `/v2/api/users/me/tags`
-- **Headers**: `Authorization: Bearer <accessToken>`（必填）
-
-请求示例（cURL）:
+请求示例：
 
 ```bash
-curl -X GET 'https://your-domain.com/v2/api/users/me/tags' \
+curl 'https://your-domain.com/v2/api/users/me/tags' \
   -H 'Authorization: Bearer <ACCESS_TOKEN>'
 ```
 
-成功响应示例（200）：
+成功响应：
 
 ```json
 {
@@ -285,155 +276,131 @@ curl -X GET 'https://your-domain.com/v2/api/users/me/tags' \
 }
 ```
 
-可能的错误：
+结果按使用次数从高到低排列。
 
-- 401 未认证（需要登录）
+## 7. 获取用户热力图
 
----
+`GET /v2/api/users/me/heatmap`
 
-### 6) 获取用户热力图数据
+查询参数：
 
-- **方法**: GET
-- **URL**: `/v2/api/users/me/heatmap`
-- **Headers**: `Authorization: Bearer <accessToken>`（必填）
-- **Query 参数**:
-  - `startDate`: string（必填，开始日期，格式：YYYY-MM-DD）
-  - `endDate`: string（必填，结束日期，格式：YYYY-MM-DD）
+- `startDate`：必填，开始日期，建议使用 `YYYY-MM-DD`。
+- `endDate`：必填，结束日期，建议使用 `YYYY-MM-DD`。
 
-请求示例（cURL）:
+请求示例：
 
 ```bash
-curl -X GET 'https://your-domain.com/v2/api/users/me/heatmap?startDate=2024-01-01&endDate=2024-12-31' \
+curl 'https://your-domain.com/v2/api/users/me/heatmap?startDate=2026-01-01&endDate=2026-12-31' \
   -H 'Authorization: Bearer <ACCESS_TOKEN>'
 ```
 
-成功响应示例（200）：
+成功响应：
 
 ```json
 {
   "code": 0,
   "message": "success",
   "data": {
-    "2024-01-01": 3,
-    "2024-01-02": 1,
-    "2024-01-05": 5,
-    "2024-01-10": 2
+    "2026-01-01": 3,
+    "2026-01-02": 1
   }
 }
 ```
 
-说明：返回对象中，键为日期（YYYY-MM-DD 格式），值为该日期创建的笔记数量。如果某个日期没有笔记，则不会出现在返回结果中。
+键为 UTC 日期，值为当天创建的笔记数量。没有笔记的日期不会出现在结果中；整个区间没有数据时返回空对象。
 
 可能的错误：
 
-- 401 未认证（需要登录）
-- 400 日期参数缺失或格式错误
+- `400`：缺少 `startDate` 或 `endDate`。
+- `401`：未认证或令牌无效。
 
----
+## 8. 获取用户统计信息
 
-### 7) 获取用户统计信息
+`GET /v2/api/users/me/statistics`
 
-- **方法**: GET
-- **URL**: `/v2/api/users/me/statistics`
-- **Headers**: `Authorization: Bearer <accessToken>`（必填）
-
-请求示例（cURL）:
+请求示例：
 
 ```bash
-curl -X GET 'https://your-domain.com/v2/api/users/me/statistics' \
+curl 'https://your-domain.com/v2/api/users/me/statistics' \
   -H 'Authorization: Bearer <ACCESS_TOKEN>'
 ```
 
-成功响应示例（200）：
+成功响应：
 
 ```json
 {
   "code": 0,
   "message": "success",
   "data": {
-    "noteCount": 100,
-    "attachmentsCount": 25
+    "roteCount": 100,
+    "attachmentCount": 25,
+    "articleCount": 8
   }
 }
 ```
 
-说明：
+旧版字段 `noteCount` 和 `attachmentsCount` 已不再返回。
 
-- `noteCount`: 用户创建的笔记总数
-- `attachmentsCount`: 用户上传的附件总数
+## 9. 导出用户数据
 
-可能的错误：
+`GET /v2/api/users/me/export`
 
-- 401 未认证（需要登录）
-
----
-
-### 8) 导出用户数据
-
-- **方法**: GET
-- **URL**: `/v2/api/users/me/export`
-- **Headers**: `Authorization: Bearer <accessToken>`（必填）
-
-请求示例（cURL）:
+请求示例：
 
 ```bash
-curl -X GET 'https://your-domain.com/v2/api/users/me/export' \
+curl 'https://your-domain.com/v2/api/users/me/export' \
   -H 'Authorization: Bearer <ACCESS_TOKEN>' \
   -o user-data.json
 ```
 
-成功响应示例（200）：
+此接口不使用统一响应包装，而是直接返回 JSON 文件：
 
-响应头：
-
-```
+```text
 Content-Type: application/json
-Content-Disposition: attachment; filename=demo-2024-01-01-12-00-00.json
+Content-Disposition: attachment; filename=demo-2026-07-23-12-00-00.json
 ```
 
-响应体（JSON 格式）：
+导出文件结构：
 
 ```json
 {
-  "articles": [
-    {
-      "id": "article-uuid",
-      "content": "# 文章标题\n\n文章正文",
-      "authorId": "user-uuid",
-      "createdAt": "2024-01-01T00:00:00.000Z",
-      "updatedAt": "2024-01-01T00:00:00.000Z"
-    }
-  ],
+  "formatVersion": 2,
   "notes": [
     {
-      "id": "uuid",
+      "id": "550e8400-e29b-41d4-a716-446655440000",
       "title": "笔记标题",
       "type": "Rote",
       "tags": ["标签1"],
       "content": "笔记内容",
-      "state": "public",
+      "state": "private",
       "archived": false,
-      "authorid": "user-uuid",
+      "authorid": "10000000-0000-4000-8000-000000000001",
+      "articleId": null,
       "pin": false,
       "editor": "normal",
-      "createdAt": "2024-01-01T00:00:00.000Z",
-      "updatedAt": "2024-01-01T00:00:00.000Z",
-      "articleId": "article-uuid",
-      "article": {
-        "id": "article-uuid",
-        "content": "# 文章标题\n\n文章正文",
-        "authorId": "user-uuid",
-        "createdAt": "2024-01-01T00:00:00.000Z",
-        "updatedAt": "2024-01-01T00:00:00.000Z"
-      },
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z",
       "author": {
         "username": "demo",
         "nickname": "Demo",
-        "avatar": "https://example.com/avatar.jpg",
-        "certified": true
+        "avatar": "https://example.com/avatar.jpg"
       },
       "attachments": [],
-      "reactions": []
+      "reactions": [],
+      "source": {
+        "provider": "memos",
+        "accountId": "account-1",
+        "externalId": "memo-1"
+      }
+    }
+  ],
+  "articles": [
+    {
+      "id": "660e8400-e29b-41d4-a716-446655440000",
+      "content": "# 文章标题\n\n文章正文",
+      "authorId": "10000000-0000-4000-8000-000000000001",
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
     }
   ]
 }
@@ -441,38 +408,204 @@ Content-Disposition: attachment; filename=demo-2024-01-01-12-00-00.json
 
 说明：
 
-- 返回 JSON 文件下载，文件名格式：`{username}-{YYYY-MM-DD-HH-mm-ss}.json`
-- 包含用户的所有文章与笔记数据，以及每条笔记的附件、反应和文章关联信息
-- `articles` 为用户文章全集；`notes[*].article` 为该笔记关联文章的内联副本，便于导入时完整恢复
+- `formatVersion` 当前为 `2`。
+- `source` 只会出现在具有外部导入来源的笔记或附件上。
+- 每条笔记还可能包含内联的 `article`、附件详情和反应详情。
+- 导出的 v2 文件可直接作为导入接口的请求体。
+
+## 10. 预检用户数据导入
+
+`POST /v2/api/users/me/import/plan`
+
+请求体与执行导入接口相同。该接口只做校验和查询，不写入笔记、文章或附件。
+
+请求示例：
+
+```bash
+curl -X POST 'https://your-domain.com/v2/api/users/me/import/plan' \
+  -H 'Authorization: Bearer <ACCESS_TOKEN>' \
+  -H 'Content-Type: application/json' \
+  --data-binary @user-data.json
+```
+
+成功响应：
+
+```json
+{
+  "code": 0,
+  "message": "success",
+  "data": {
+    "noteIndexes": [0, 2, 3]
+  }
+}
+```
+
+`noteIndexes` 是请求体 `notes` 数组中需要执行导入的零基索引：
+
+- `existingStrategy: "skip"` 时，已存在的笔记不会出现在列表中。
+- `existingStrategy: "overwrite"` 时，所有笔记索引都会返回。
+- 带 `source` 的笔记按 `provider + accountId + externalId` 判断是否存在；不带 `source` 的旧格式笔记按 `id` 判断。
+
+## 11. 执行用户数据导入
+
+`POST /v2/api/users/me/import`
+
+### 11.1 顶层请求结构
+
+```json
+{
+  "formatVersion": 2,
+  "notes": [],
+  "articles": [],
+  "importOptions": {
+    "existingStrategy": "skip",
+    "visibilityStrategy": "preserve"
+  }
+}
+```
+
+| 字段 | 是否必填 | 说明 |
+| --- | --- | --- |
+| `formatVersion` | 推荐 | 当前版本为 `2`；省略时按兼容的旧格式处理 |
+| `notes` | 是 | 笔记数组，最多 20,000 条 |
+| `articles` | 否 | 文章数组，最多 5,000 条，默认为空数组 |
+| `importOptions.existingStrategy` | 否 | `skip` 或 `overwrite`，默认 `skip` |
+| `importOptions.visibilityStrategy` | 否 | `preserve` 或 `private`，默认 `preserve` |
+
+`skip` 会保留已存在的笔记并把它们计入 `unchanged`；`overwrite` 会用请求数据更新已存在的笔记。
+`private` 会强制导入笔记为私有，`preserve` 会保留请求中的 `state`，缺省时仍为私有。
+`existingStrategy` 只控制笔记；同 ID 的已有文章会更新为本次请求中的内容。
+
+### 11.2 笔记、文章和附件结构
+
+最小笔记：
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "content": "笔记内容"
+}
+```
+
+笔记支持以下字段：
+
+- 必填：`id`（UUID）、`content`（string）。
+- 可选：`title`、`type`、`tags`、`state`、`archived`、`articleId`、`pin`、`editor`、`createdAt`、`updatedAt`、`attachments`、`source`。
+- 单条笔记最多包含 100 个标签和 500 个附件。
+- `createdAt`、`updatedAt` 和 `source.sourceUpdatedAt` 使用 ISO 8601 日期时间字符串。
+
+最小文章：
+
+```json
+{
+  "id": "660e8400-e29b-41d4-a716-446655440000",
+  "content": "# 文章内容"
+}
+```
+
+文章还可包含 `createdAt` 和 `updatedAt`。笔记的 `articleId` 只有在文章属于当前用户时才会建立关联。
+
+最小附件：
+
+```json
+{
+  "url": "attachments/image.png",
+  "storage": "R2",
+  "details": {
+    "key": "attachments/image.png",
+    "size": 1024,
+    "mimetype": "image/png"
+  }
+}
+```
+
+附件还可包含 `id`、`compressUrl`、`posterUrl`、`createdAt`、`updatedAt`、`sortIndex` 和 `source`。
+`details` 必须是对象，并需符合对应存储类型的附件校验规则。
+
+来源标识结构：
+
+```json
+{
+  "provider": "memos",
+  "accountId": "account-1",
+  "externalId": "memo-1",
+  "sourceUpdatedAt": "2026-07-23T00:00:00.000Z"
+}
+```
+
+同一请求中不能包含重复的笔记来源标识，也不能在同一笔记内包含重复的附件来源标识。
+
+### 11.3 请求与响应示例
+
+```bash
+curl -X POST 'https://your-domain.com/v2/api/users/me/import' \
+  -H 'Authorization: Bearer <ACCESS_TOKEN>' \
+  -H 'Content-Type: application/json' \
+  --data-binary @user-data.json
+```
+
+成功响应：
+
+```json
+{
+  "code": 0,
+  "message": "success",
+  "data": {
+    "count": 2,
+    "created": 1,
+    "updated": 0,
+    "unchanged": 1,
+    "notes": {
+      "total": 2,
+      "created": 1,
+      "updated": 0,
+      "unchanged": 1
+    },
+    "articles": {
+      "total": 1,
+      "created": 1,
+      "updated": 0
+    },
+    "attachments": {
+      "total": 1,
+      "created": 1,
+      "updated": 0,
+      "deleted": 0
+    },
+    "formatVersion": 2
+  }
+}
+```
 
 可能的错误：
 
-- 401 未认证（需要登录）
+- `400`：请求格式不符合导入协议。
+- `401`：未认证或令牌无效。
+- 导入内容引用了其他用户拥有的笔记、文章或附件时，请求会失败，不会取得其所有权。
 
----
+## 12. 删除当前用户账户
 
-### 9) 删除用户账户
+`DELETE /v2/api/users/me`
 
-- **方法**: DELETE
-- **URL**: `/v2/api/users/me`
-- **Headers**:
-  - `Authorization: Bearer <accessToken>`（必填）
-  - `Content-Type: application/json`
-- **Body**:
-  - `password`: string（必填，用户密码，用于确认删除操作）
-
-请求示例（cURL）:
+本地密码账户必须提交当前密码：
 
 ```bash
 curl -X DELETE 'https://your-domain.com/v2/api/users/me' \
   -H 'Authorization: Bearer <ACCESS_TOKEN>' \
   -H 'Content-Type: application/json' \
-  -d '{
-    "password": "your-password"
-  }'
+  -d '{"password": "your-password"}'
 ```
 
-成功响应示例（200）：
+未设置本地密码的账户不校验密码，但仍应发送一个 JSON 对象：
+
+```bash
+curl -X DELETE 'https://your-domain.com/v2/api/users/me' \
+  -H 'Authorization: Bearer <ACCESS_TOKEN>' \
+  -H 'Content-Type: application/json' \
+  -d '{}'
+```
+
+成功响应：
 
 ```json
 {
@@ -484,32 +617,19 @@ curl -X DELETE 'https://your-domain.com/v2/api/users/me' \
 }
 ```
 
-说明：
-
-- 此操作会**永久删除**用户账户及其所有相关数据，**无法恢复**
-- 删除范围包括：
-  - 用户账户信息（用户名、邮箱、个人资料等）
-  - 用户设置（探索页可见性等）
-  - 用户的所有笔记（rotes）
-  - 用户的所有附件文件（包括 R2/S3 存储中的文件）
-  - 用户的 API 密钥（open keys）
-  - 用户的推送订阅（service worker subscriptions）
-  - 用户对其他笔记的反应记录会被保留，但 `userid` 会被设为 `null`
-- 删除操作需要密码确认，确保是用户本人操作
-- 建议在执行删除操作前，先使用导出接口备份数据
+此操作不可恢复。账户及其笔记、文章、设置、登录绑定、API 密钥、推送订阅和导入来源映射会被删除；
+附件存储对象会安排删除，用户在其他笔记上的反应会保留但不再关联该用户。建议先调用导出接口备份数据。
 
 可能的错误：
 
-- 400 密码参数缺失
-- 401 未认证（需要登录）
-- 400 密码错误
+- `400`：本地密码账户未提供密码。
+- `401`：未认证或令牌无效。
+- 密码不正确时删除失败。
 
----
+## 客户端使用建议
 
-### 客户端使用建议
-
-- **权限控制**: 获取和更新个人资料、标签、统计数据等接口需要认证，且只能操作当前登录用户的数据
-- **用户信息查询**: 通过用户名查询用户信息无需认证，但返回的信息有限（不包含邮箱等敏感信息）
-- **热力图数据**: 日期格式必须为 `YYYY-MM-DD`，建议在客户端进行格式验证
-- **数据导出**: 导出接口返回文件下载，注意处理响应头中的 `Content-Disposition` 字段以获取正确的文件名
-- **账户删除**: 删除账户是不可逆操作，建议在删除前提示用户确认，并建议用户先导出数据备份
+- 不要从旧字段 `authProvider` 推断登录方式，使用 `hasPassword` 和 `oauthBindings`。
+- 导入前先调用 `/me/import/plan`，再迁移所需附件并分批调用 `/me/import`。
+- 使用 `source` 标识外部数据，才能在重复导入时稳定识别同一条笔记或附件。
+- 导出接口返回原始文件，其他接口返回统一响应对象，客户端解析时需区分。
+- 删除账户不可恢复，应在客户端二次确认，并优先提示用户导出备份。

--- a/doc/userguide/USER-API.md
+++ b/doc/userguide/USER-API.md
@@ -5,7 +5,8 @@
 
 ## 基础信息
 
-- 基础路径：`/v2/api/users`
+- 用户接口基础路径：`/v2/api/users`
+- 远程附件迁移使用相关接口：`/v2/api/imports/attachments/migrate`
 - 鉴权方式：需要登录的接口使用 `Authorization: Bearer <accessToken>`
 - JSON 请求需使用 `Content-Type: application/json`
 - 除数据导出接口外，成功响应统一为：
@@ -42,6 +43,7 @@
 | `GET` | `/v2/api/users/me/statistics` | 是 | 获取当前用户内容统计 |
 | `GET` | `/v2/api/users/me/export` | 是 | 导出用户数据 |
 | `POST` | `/v2/api/users/me/import/plan` | 是 | 预检需要导入的笔记 |
+| `POST` | `/v2/api/imports/attachments/migrate` | 是 | 将一个远程附件迁移到当前用户的对象存储 |
 | `POST` | `/v2/api/users/me/import` | 是 | 导入用户数据 |
 | `DELETE` | `/v2/api/users/me` | 是 | 删除当前用户账户 |
 
@@ -411,7 +413,10 @@ Content-Disposition: attachment; filename=demo-2026-07-23-12-00-00.json
 - `formatVersion` 当前为 `2`。
 - `source` 只会出现在具有外部导入来源的笔记或附件上。
 - 每条笔记还可能包含内联的 `article`、附件详情和反应详情。
-- 导出的 v2 文件可直接作为导入接口的请求体。
+- 导出文件的顶层结构与 v2 导入请求兼容，但只有恢复到原账户、且其中的附件 ID 仍归当前用户所有时，
+  才能原样作为导入请求。对同一实例中的其他账户执行恢复，或在原账户已删除后恢复时，不得复用导出的
+  附件 ID；应先将附件迁移或上传到目标账户，并用目标账户拥有的附件记录替换导出数据中的附件。
+- 导入接口不会仅凭导出文件中的附件 URL 复制对象存储内容。
 
 ## 10. 预检用户数据导入
 
@@ -446,11 +451,95 @@ curl -X POST 'https://your-domain.com/v2/api/users/me/import/plan' \
 - `existingStrategy: "overwrite"` 时，所有笔记索引都会返回。
 - 带 `source` 的笔记按 `provider + accountId + externalId` 判断是否存在；不带 `source` 的旧格式笔记按 `id` 判断。
 
-## 11. 执行用户数据导入
+## 11. 迁移远程附件
+
+`POST /v2/api/imports/attachments/migrate`
+
+此相关接口用于把一个 HTTP/HTTPS 远程附件下载到当前用户的对象存储，并创建一条尚未绑定笔记的附件记录。
+直接将远程 URL 提交给 `/users/me/import` 只会保存该 URL，不会下载或迁移文件。
+
+请求体：
+
+| 字段 | 是否必填 | 说明 |
+| --- | --- | --- |
+| `attachment` | 是 | 一个符合下文附件结构的对象；`url` 必须是可访问的 HTTP/HTTPS URL |
+| `migrationAuth` | 否 | 目前仅支持 `{ "provider": "memos", "baseUrl": "https://memos.example.com" }` |
+
+迁移公开远程附件时可省略 `migrationAuth`。迁移需要认证的 Memos 附件时，还必须通过
+`x-memos-access-token` 请求头传递 Memos 访问令牌；服务端只会向与 `baseUrl` 同源的地址发送该令牌。
+
+Memos 请求示例：
+
+```bash
+curl -X POST 'https://your-domain.com/v2/api/imports/attachments/migrate' \
+  -H 'Authorization: Bearer <ACCESS_TOKEN>' \
+  -H 'Content-Type: application/json' \
+  -H 'x-memos-access-token: <MEMOS_ACCESS_TOKEN>' \
+  -d '{
+    "attachment": {
+      "url": "https://memos.example.com/file/attachments/a/photo.png",
+      "storage": "REMOTE",
+      "details": {
+        "mimetype": "image/png",
+        "originalname": "photo.png"
+      }
+    },
+    "migrationAuth": {
+      "provider": "memos",
+      "baseUrl": "https://memos.example.com"
+    }
+  }'
+```
+
+成功时返回 `201`，`data` 是由当前用户拥有的新附件记录：
+
+```json
+{
+  "code": 0,
+  "message": "success",
+  "data": {
+    "id": "770e8400-e29b-41d4-a716-446655440000",
+    "url": "https://storage.example.com/users/10000000-0000-4000-8000-000000000001/uploads/attachment.png",
+    "compressUrl": "",
+    "posterUrl": "",
+    "userid": "10000000-0000-4000-8000-000000000001",
+    "roteid": null,
+    "storage": "R2",
+    "details": {
+      "key": "users/10000000-0000-4000-8000-000000000001/uploads/attachment.png",
+      "size": 1024,
+      "mimetype": "image/png",
+      "mediaKind": "image",
+      "mtime": "2026-07-23T00:00:00.000Z"
+    },
+    "createdAt": "2026-07-23T00:00:00.000Z",
+    "updatedAt": "2026-07-23T00:00:00.000Z",
+    "sortIndex": 0
+  }
+}
+```
+
+客户端应使用返回的 `data` 替换原远程附件，然后再调用 `/users/me/import`。推荐顺序为：
+
+1. 调用 `/users/me/import/plan` 找出需要处理的笔记。
+2. 对这些笔记中的每个远程附件调用本接口，并替换为返回的附件记录。
+3. 将迁移后的笔记分批提交给 `/users/me/import`。
+
+可能的错误包括：
+
+- `401`：Rote 登录令牌无效。
+- `403 remote_attachment_forbidden`：当前用户不允许上传附件。
+- `413 remote_attachment_too_large`：远程附件超过大小限制。
+- `422 remote_attachment_invalid` 或 `remote_attachment_unsupported`：请求或媒体类型无效。
+- `429 remote_attachment_busy`：服务器迁移队列已满。
+- `502 remote_attachment_download_failed`：无法下载远程附件。
+- `503 remote_attachment_storage_unavailable`：对象存储不可用。
+
+## 12. 执行用户数据导入
 
 `POST /v2/api/users/me/import`
 
-### 11.1 顶层请求结构
+### 12.1 顶层请求结构
 
 ```json
 {
@@ -476,7 +565,7 @@ curl -X POST 'https://your-domain.com/v2/api/users/me/import/plan' \
 `private` 会强制导入笔记为私有，`preserve` 会保留请求中的 `state`，缺省时仍为私有。
 `existingStrategy` 只控制笔记；同 ID 的已有文章会更新为本次请求中的内容。
 
-### 11.2 笔记、文章和附件结构
+### 12.2 笔记、文章和附件结构
 
 最小笔记：
 
@@ -492,7 +581,8 @@ curl -X POST 'https://your-domain.com/v2/api/users/me/import/plan' \
 - 必填：`id`（UUID）、`content`（string）。
 - 可选：`title`、`type`、`tags`、`state`、`archived`、`articleId`、`pin`、`editor`、`createdAt`、`updatedAt`、`attachments`、`source`。
 - 单条笔记最多包含 100 个标签和 500 个附件。
-- `createdAt`、`updatedAt` 和 `source.sourceUpdatedAt` 使用 ISO 8601 日期时间字符串。
+- `createdAt`、`updatedAt` 和 `source.sourceUpdatedAt` 使用 ISO 8601 日期时间字符串。笔记的 `createdAt`
+  会保留；`updatedAt` 会被忽略并写为本次导入时间；`sourceUpdatedAt` 当前只参与格式校验，不会持久化或用于冲突判断。
 
 最小文章：
 
@@ -520,7 +610,8 @@ curl -X POST 'https://your-domain.com/v2/api/users/me/import/plan' \
 ```
 
 附件还可包含 `id`、`compressUrl`、`posterUrl`、`createdAt`、`updatedAt`、`sortIndex` 和 `source`。
-`details` 必须是对象，并需符合对应存储类型的附件校验规则。
+附件的 `createdAt` 会保留，`updatedAt` 会被忽略并写为本次导入时间。`details` 必须是对象，并需符合对应
+存储类型的附件校验规则。
 
 来源标识结构：
 
@@ -533,9 +624,11 @@ curl -X POST 'https://your-domain.com/v2/api/users/me/import/plan' \
 }
 ```
 
-同一请求中不能包含重复的笔记来源标识，也不能在同一笔记内包含重复的附件来源标识。
+同一请求中不能包含重复的笔记来源标识，也不能在同一笔记内包含重复的附件来源标识。附件来源映射只会在
+父笔记也包含 `source` 时持久化并用于后续幂等导入；只有 `attachments[].source` 而没有 `note.source` 时，
+重复执行 `overwrite` 导入可能创建新的附件记录。
 
-### 11.3 请求与响应示例
+### 12.3 请求与响应示例
 
 ```bash
 curl -X POST 'https://your-domain.com/v2/api/users/me/import' \
@@ -583,7 +676,7 @@ curl -X POST 'https://your-domain.com/v2/api/users/me/import' \
 - `401`：未认证或令牌无效。
 - 导入内容引用了其他用户拥有的笔记、文章或附件时，请求会失败，不会取得其所有权。
 
-## 12. 删除当前用户账户
+## 13. 删除当前用户账户
 
 `DELETE /v2/api/users/me`
 
@@ -629,7 +722,8 @@ curl -X DELETE 'https://your-domain.com/v2/api/users/me' \
 ## 客户端使用建议
 
 - 不要从旧字段 `authProvider` 推断登录方式，使用 `hasPassword` 和 `oauthBindings`。
-- 导入前先调用 `/me/import/plan`，再迁移所需附件并分批调用 `/me/import`。
-- 使用 `source` 标识外部数据，才能在重复导入时稳定识别同一条笔记或附件。
+- 导入前先调用 `/me/import/plan`，通过 `/v2/api/imports/attachments/migrate` 迁移所需远程附件，再分批调用
+  `/me/import`。
+- 使用 `source` 标识外部数据；附件要获得稳定的重复导入身份，其父笔记也必须包含 `source`。
 - 导出接口返回原始文件，其他接口返回统一响应对象，客户端解析时需区分。
 - 删除账户不可恢复，应在客户端二次确认，并优先提示用户导出备份。


### PR DESCRIPTION
## Summary

- align the user API guide with all current `/v2/api/users` routes
- replace removed profile and statistics fields with the current response contract
- document export format v2 and the two-stage import protocol
- clarify validation errors and passwordless account deletion

## Why

`USER-API.md` had drifted from the backend after the OAuth profile model, statistics response, and import/export protocol changed. Integrators could otherwise rely on removed fields or miss supported endpoints.

## Impact

Documentation only. Runtime behavior is unchanged; API consumers now have examples and field definitions matching the current implementation.

## Validation

- parsed all 19 JSON examples successfully with Bun
- `git diff --check`
- frontend/backend lint and build not run because no application code changed