### PR TITLE
Notify admins when notes become public

### DIFF
--- a/server/utils/dbMethods/index.ts
+++ b/server/utils/dbMethods/index.ts
@@ -9,7 +9,7 @@ export * from './change';
 export * from './common';
 export * from './linkPreview';
 export * from './note';
-export { createRote } from './noteHooks';
+export { createRote, editRote } from './noteHooks';
 export * from './oauthMcpAuthorization';
 export * from './oauthMcpClients';
 export * from './oauthMcpGrants';

--- a/server/utils/dbMethods/note.ts
+++ b/server/utils/dbMethods/note.ts
@@ -220,7 +220,13 @@ export async function findRotesByIds(ids: string[]): Promise<any[]> {
   }
 }
 
-export async function editRote(data: any): Promise<any> {
+export interface EditRoteWithStateResult {
+  nextState: string;
+  note: any;
+  previousState: string;
+}
+
+export async function editRoteWithState(data: any): Promise<EditRoteWithStateResult> {
   try {
     const {
       id: _id,
@@ -236,15 +242,36 @@ export async function editRote(data: any): Promise<any> {
     // 确保 updatedAt 是 Date 对象，且由服务器端控制
     cleanData.updatedAt = new Date();
 
-    const [rote] = await db
-      .update(rotes)
-      .set(cleanData)
-      .where(and(eq(rotes.id, data.id), eq(rotes.authorid, data.authorid)))
-      .returning();
+    const result = await db.transaction(async (tx) => {
+      const [previousRote] = await tx
+        .select({ state: rotes.state })
+        .from(rotes)
+        .where(and(eq(rotes.id, data.id), eq(rotes.authorid, data.authorid)))
+        .for('update');
+
+      if (!previousRote) {
+        throw new Error('Failed to update note: no matching note found');
+      }
+
+      const [rote] = await tx
+        .update(rotes)
+        .set(cleanData)
+        .where(and(eq(rotes.id, data.id), eq(rotes.authorid, data.authorid)))
+        .returning();
+
+      if (!rote) {
+        throw new Error('Failed to update note: no data returned');
+      }
+
+      return {
+        previousState: previousRote.state,
+        rote,
+      };
+    });
 
     // 使用 relational query API 获取关联数据
     const roteWithRelations = await db.query.rotes.findFirst({
-      where: (rotes, { eq }) => eq(rotes.id, rote.id),
+      where: (rotes, { eq }) => eq(rotes.id, result.rote.id),
       with: {
         author: AUTHOR_QUERY,
         attachments: {
@@ -271,19 +298,28 @@ export async function editRote(data: any): Promise<any> {
     // 记录变更历史
     try {
       await createRoteChange({
-        originid: rote.id,
-        roteid: rote.id,
+        originid: result.rote.id,
+        roteid: result.rote.id,
         action: 'UPDATE',
-        userid: rote.authorid,
+        userid: result.rote.authorid,
       });
     } catch (_error) {
       // 记录变更失败不影响更新操作，静默处理
     }
 
-    return roteWithRelations;
+    return {
+      nextState: result.rote.state,
+      note: roteWithRelations || result.rote,
+      previousState: result.previousState,
+    };
   } catch (error) {
     throw new DatabaseError(`Failed to update rote: ${data.id}`, error);
   }
+}
+
+export async function editRote(data: any): Promise<any> {
+  const result = await editRoteWithState(data);
+  return result.note;
 }
 
 export async function deleteRote(data: any): Promise<any> {

--- a/server/utils/dbMethods/noteHooks.test.ts
+++ b/server/utils/dbMethods/noteHooks.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { becamePublic } from './noteHooks';
+import { becamePublic, editRoteWithPublicTransition } from './noteHooks';
 
 describe('public note notification transitions', () => {
   test('triggers when a private note becomes public', () => {
@@ -17,5 +17,35 @@ describe('public note notification transitions', () => {
   test('does not trigger for transitions that end as non-public', () => {
     expect(becamePublic('public', 'private')).toBe(false);
     expect(becamePublic('private', 'private')).toBe(false);
+  });
+
+  test('allows only one concurrent edit to claim the public transition', async () => {
+    let currentState = 'private';
+    let previousEdit = Promise.resolve();
+    const edit = async (data: { id: string; state: string }) => {
+      const waitForPreviousEdit = previousEdit;
+      let finishEdit: () => void = () => {};
+      previousEdit = new Promise<void>((resolve) => {
+        finishEdit = resolve;
+      });
+
+      await waitForPreviousEdit;
+      const previousState = currentState;
+      currentState = data.state;
+      finishEdit();
+      return {
+        nextState: currentState,
+        note: { ...data, state: currentState },
+        previousState,
+      };
+    };
+
+    const results = await Promise.all([
+      editRoteWithPublicTransition({ id: 'note-1', state: 'public' }, edit),
+      editRoteWithPublicTransition({ id: 'note-1', state: 'public' }, edit),
+    ]);
+
+    expect(results.filter((result) => result.becamePublic)).toHaveLength(1);
+    expect(results.every((result) => result.note.state === 'public')).toBe(true);
   });
 });

--- a/server/utils/dbMethods/noteHooks.test.ts
+++ b/server/utils/dbMethods/noteHooks.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'bun:test';
+import { becamePublic } from './noteHooks';
+
+describe('public note notification transitions', () => {
+  test('triggers when a private note becomes public', () => {
+    expect(becamePublic('private', 'public')).toBe(true);
+  });
+
+  test('triggers when a new note is created as public', () => {
+    expect(becamePublic(undefined, 'public')).toBe(true);
+  });
+
+  test('does not trigger when a public note stays public', () => {
+    expect(becamePublic('public', 'public')).toBe(false);
+  });
+
+  test('does not trigger for transitions that end as non-public', () => {
+    expect(becamePublic('public', 'private')).toBe(false);
+    expect(becamePublic('private', 'private')).toBe(false);
+  });
+});

--- a/server/utils/dbMethods/noteHooks.ts
+++ b/server/utils/dbMethods/noteHooks.ts
@@ -1,12 +1,31 @@
 import { notifyPublicNoteCreated } from '../adminHooks';
 import { trackBackgroundTask } from '../backgroundTask';
-import { createRote as createBaseRote, findRoteById } from './note';
+import { createRote as createBaseRote, editRote as editBaseRote, findRoteById } from './note';
+
+export function becamePublic(previousState: unknown, nextState: unknown): boolean {
+  return previousState !== 'public' && nextState === 'public';
+}
+
+async function notifyPublicNote(note: any) {
+  const noteWithRelations = (await findRoteById(note.id)) || note;
+  trackBackgroundTask(notifyPublicNoteCreated(noteWithRelations), 'admin_hook_public_note_failed');
+}
 
 export async function createRote(data: any): Promise<any> {
   const rote = await createBaseRote(data);
-  if (rote?.state === 'public') {
-    const note = (await findRoteById(rote.id)) || rote;
-    trackBackgroundTask(notifyPublicNoteCreated(note), 'admin_hook_public_note_failed');
+  if (becamePublic(undefined, rote?.state)) {
+    await notifyPublicNote(rote);
   }
+  return rote;
+}
+
+export async function editRote(data: any): Promise<any> {
+  const previousNote = data?.state === 'public' ? await findRoteById(data.id) : null;
+  const rote = await editBaseRote(data);
+
+  if (becamePublic(previousNote?.state, rote?.state)) {
+    await notifyPublicNote(rote);
+  }
+
   return rote;
 }

--- a/server/utils/dbMethods/noteHooks.ts
+++ b/server/utils/dbMethods/noteHooks.ts
@@ -1,6 +1,18 @@
 import { notifyPublicNoteCreated } from '../adminHooks';
 import { trackBackgroundTask } from '../backgroundTask';
-import { createRote as createBaseRote, editRote as editBaseRote, findRoteById } from './note';
+import {
+  createRote as createBaseRote,
+  editRoteWithState as editBaseRoteWithState,
+  type EditRoteWithStateResult,
+  findRoteById,
+} from './note';
+
+type EditRoteOperation = (data: any) => Promise<EditRoteWithStateResult>;
+
+interface PublicTransitionEditResult {
+  becamePublic: boolean;
+  note: any;
+}
 
 export function becamePublic(previousState: unknown, nextState: unknown): boolean {
   return previousState !== 'public' && nextState === 'public';
@@ -19,13 +31,23 @@ export async function createRote(data: any): Promise<any> {
   return rote;
 }
 
-export async function editRote(data: any): Promise<any> {
-  const previousNote = data?.state === 'public' ? await findRoteById(data.id) : null;
-  const rote = await editBaseRote(data);
+export async function editRoteWithPublicTransition(
+  data: any,
+  edit: EditRoteOperation = editBaseRoteWithState
+): Promise<PublicTransitionEditResult> {
+  const result = await edit(data);
+  return {
+    becamePublic: becamePublic(result.previousState, result.nextState),
+    note: result.note,
+  };
+}
 
-  if (becamePublic(previousNote?.state, rote?.state)) {
-    await notifyPublicNote(rote);
+export async function editRote(data: any): Promise<any> {
+  const result = await editRoteWithPublicTransition(data);
+
+  if (result.becamePublic) {
+    await notifyPublicNote(result.note);
   }
 
-  return rote;
+  return result.note;
 }


### PR DESCRIPTION
## Summary

- trigger the existing `note.public.created` admin hook when a note transitions from a non-public state to `public`
- route `editRote` through the notification-aware database method for authenticated API, OpenKey, and MCP updates
- keep public-to-public edits from sending duplicate notifications
- add regression tests for creation and visibility transitions

## Root cause

Admin notifications were only attached to note creation. Updating an existing private note to public used the base `editRote` method directly, so the publication transition bypassed the admin hook.

## Impact

Administrators now receive the configured notification when an existing note is published. Creating a public note continues to work as before, and ordinary edits to an already-public note do not generate duplicate notifications.

## Validation

- `bun test utils/dbMethods/noteHooks.test.ts`
- `bun run lint`
- `bun run build`