### PR TITLE
Fix admin hook notification links and localized titles

### DIFF
--- a/server/tests/adminHooks.test.ts
+++ b/server/tests/adminHooks.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'bun:test';
+import { titleForEnvelope, urlForEnvelope } from '../utils/adminHooks/envelope';
+import type { AdminHookEnvelope } from '../utils/adminHooks/types';
+
+function createUserRegisteredEnvelope(
+  overrides: Partial<AdminHookEnvelope['site']> = {}
+): AdminHookEnvelope {
+  return {
+    actor: {
+      id: 'user-id',
+      type: 'user',
+      username: 'alice',
+    },
+    event: 'user.registered',
+    occurredAt: '2026-07-25T00:00:00.000Z',
+    site: {
+      frontendUrl: 'https://rote.ink/',
+      name: 'Rote',
+      ...overrides,
+    },
+    user: {
+      id: 'user-id',
+      username: 'alice',
+    },
+  };
+}
+
+describe('admin hook envelope URLs', () => {
+  it('links user registration events to the registered user profile', () => {
+    const envelope = createUserRegisteredEnvelope();
+
+    expect(urlForEnvelope(envelope)).toBe('https://rote.ink/alice');
+  });
+
+  it('encodes the username when building a user profile URL', () => {
+    const envelope = createUserRegisteredEnvelope({
+      frontendUrl: 'https://rote.ink',
+    });
+    envelope.user!.username = 'alice/test';
+
+    expect(urlForEnvelope(envelope)).toBe('https://rote.ink/alice%2Ftest');
+  });
+});
+
+describe('admin hook envelope localization', () => {
+  it('uses the localized event label in the notification title', () => {
+    expect(titleForEnvelope(createUserRegisteredEnvelope({ defaultLanguage: 'zh-CN' }))).toBe(
+      'Rote: 新用户注册'
+    );
+    expect(titleForEnvelope(createUserRegisteredEnvelope({ defaultLanguage: 'en' }))).toBe(
+      'Rote: New User Registration'
+    );
+    expect(titleForEnvelope(createUserRegisteredEnvelope({ defaultLanguage: 'ja-JP' }))).toBe(
+      'Rote: 新規ユーザー登録'
+    );
+  });
+});

--- a/server/tests/adminHooks.test.ts
+++ b/server/tests/adminHooks.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { titleForEnvelope, urlForEnvelope } from '../utils/adminHooks/envelope';
+import { titleForEnvelope, urlForEnvelope } from '../utils/adminHooks/presentation';
 import type { AdminHookEnvelope } from '../utils/adminHooks/types';
 
 function createUserRegisteredEnvelope(

--- a/server/utils/adminHooks/delivery.ts
+++ b/server/utils/adminHooks/delivery.ts
@@ -3,8 +3,8 @@ import { getGlobalConfig } from '../config';
 import db from '../drizzle';
 import { updateSubScription } from '../dbMethods/subscription';
 import webpush from '../webpush';
-import { bodyForEnvelope, titleForEnvelope, urlForEnvelope } from './envelope';
 import { assertSafeOutboundUrl, normalizeUrlBase } from './network';
+import { bodyForEnvelope, titleForEnvelope, urlForEnvelope } from './presentation';
 import {
   DEFAULT_BARK_SERVER_URL,
   REQUEST_TIMEOUT_MS,

--- a/server/utils/adminHooks/envelope.ts
+++ b/server/utils/adminHooks/envelope.ts
@@ -1,7 +1,6 @@
 import type { User } from '../../drizzle/schema';
 import type { SiteConfig } from '../../types/config';
 import { getGlobalConfig } from '../config';
-import { labelForAdminHookEvent } from './localization';
 import type { AdminHookActor, AdminHookEnvelope } from './types';
 
 function getSiteInfo() {
@@ -33,42 +32,6 @@ function toActor(user: Partial<User> | null | undefined): AdminHookActor {
 function previewText(value: string, maxLength = 160) {
   const normalized = value.replace(/\s+/g, ' ').trim();
   return normalized.length > maxLength ? `${normalized.slice(0, maxLength)}...` : normalized;
-}
-
-export function titleForEnvelope(envelope: AdminHookEnvelope) {
-  return `${envelope.site.name}: ${labelForAdminHookEvent(
-    envelope.event,
-    envelope.site.defaultLanguage
-  )}`;
-}
-
-export function bodyForEnvelope(envelope: AdminHookEnvelope) {
-  if (envelope.event === 'user.registered') {
-    return [envelope.user?.username, envelope.user?.nickname].filter(Boolean).join(' / ');
-  }
-  return [
-    envelope.note?.author?.username || envelope.actor.username,
-    envelope.note?.title,
-    envelope.note?.contentPreview,
-  ]
-    .filter(Boolean)
-    .join(' / ');
-}
-
-export function urlForEnvelope(envelope: AdminHookEnvelope) {
-  if (envelope.note?.url) return envelope.note.url;
-
-  if (
-    envelope.event === 'user.registered' &&
-    envelope.user?.username &&
-    envelope.site.frontendUrl
-  ) {
-    return `${envelope.site.frontendUrl.replace(/\/+$/, '')}/${encodeURIComponent(
-      envelope.user.username
-    )}`;
-  }
-
-  return envelope.site.frontendUrl;
 }
 
 export function buildUserRegisteredEnvelope(user: Partial<User>): AdminHookEnvelope {

--- a/server/utils/adminHooks/envelope.ts
+++ b/server/utils/adminHooks/envelope.ts
@@ -1,11 +1,13 @@
 import type { User } from '../../drizzle/schema';
 import type { SiteConfig } from '../../types/config';
 import { getGlobalConfig } from '../config';
+import { labelForAdminHookEvent } from './localization';
 import type { AdminHookActor, AdminHookEnvelope } from './types';
 
 function getSiteInfo() {
   const siteConfig = getGlobalConfig<SiteConfig>('site');
   return {
+    defaultLanguage: siteConfig?.defaultLanguage,
     frontendUrl: siteConfig?.frontendUrl,
     name: siteConfig?.name || 'Rote',
   };
@@ -34,7 +36,10 @@ function previewText(value: string, maxLength = 160) {
 }
 
 export function titleForEnvelope(envelope: AdminHookEnvelope) {
-  return `${envelope.site.name}: ${envelope.event}`;
+  return `${envelope.site.name}: ${labelForAdminHookEvent(
+    envelope.event,
+    envelope.site.defaultLanguage
+  )}`;
 }
 
 export function bodyForEnvelope(envelope: AdminHookEnvelope) {
@@ -51,7 +56,19 @@ export function bodyForEnvelope(envelope: AdminHookEnvelope) {
 }
 
 export function urlForEnvelope(envelope: AdminHookEnvelope) {
-  return envelope.note?.url || envelope.site.frontendUrl;
+  if (envelope.note?.url) return envelope.note.url;
+
+  if (
+    envelope.event === 'user.registered' &&
+    envelope.user?.username &&
+    envelope.site.frontendUrl
+  ) {
+    return `${envelope.site.frontendUrl.replace(/\/+$/, '')}/${encodeURIComponent(
+      envelope.user.username
+    )}`;
+  }
+
+  return envelope.site.frontendUrl;
 }
 
 export function buildUserRegisteredEnvelope(user: Partial<User>): AdminHookEnvelope {

--- a/server/utils/adminHooks/locales/en.json
+++ b/server/utils/adminHooks/locales/en.json
@@ -1,0 +1,6 @@
+{
+  "events": {
+    "user.registered": "New User Registration",
+    "note.public.created": "Public Note Created"
+  }
+}

--- a/server/utils/adminHooks/locales/ja.json
+++ b/server/utils/adminHooks/locales/ja.json
@@ -1,0 +1,6 @@
+{
+  "events": {
+    "user.registered": "新規ユーザー登録",
+    "note.public.created": "公開ノート作成"
+  }
+}

--- a/server/utils/adminHooks/locales/zh.json
+++ b/server/utils/adminHooks/locales/zh.json
@@ -1,0 +1,6 @@
+{
+  "events": {
+    "user.registered": "新用户注册",
+    "note.public.created": "创建公开笔记"
+  }
+}

--- a/server/utils/adminHooks/localization.ts
+++ b/server/utils/adminHooks/localization.ts
@@ -1,0 +1,22 @@
+import type { AdminHookEvent } from '../../types/config';
+import en from './locales/en.json';
+import ja from './locales/ja.json';
+import zh from './locales/zh.json';
+
+type AdminHookLocale = 'en' | 'ja' | 'zh';
+
+const eventLabels: Record<AdminHookLocale, Record<AdminHookEvent, string>> = {
+  en: en.events,
+  ja: ja.events,
+  zh: zh.events,
+};
+
+function resolveLocale(language?: string): AdminHookLocale {
+  const languageCode = language?.trim().toLowerCase().split(/[-_]/)[0];
+  if (languageCode === 'en' || languageCode === 'ja') return languageCode;
+  return 'zh';
+}
+
+export function labelForAdminHookEvent(event: AdminHookEvent, language?: string) {
+  return eventLabels[resolveLocale(language)][event];
+}

--- a/server/utils/adminHooks/presentation.ts
+++ b/server/utils/adminHooks/presentation.ts
@@ -1,0 +1,38 @@
+import { labelForAdminHookEvent } from './localization';
+import type { AdminHookEnvelope } from './types';
+
+export function titleForEnvelope(envelope: AdminHookEnvelope) {
+  return `${envelope.site.name}: ${labelForAdminHookEvent(
+    envelope.event,
+    envelope.site.defaultLanguage
+  )}`;
+}
+
+export function bodyForEnvelope(envelope: AdminHookEnvelope) {
+  if (envelope.event === 'user.registered') {
+    return [envelope.user?.username, envelope.user?.nickname].filter(Boolean).join(' / ');
+  }
+  return [
+    envelope.note?.author?.username || envelope.actor.username,
+    envelope.note?.title,
+    envelope.note?.contentPreview,
+  ]
+    .filter(Boolean)
+    .join(' / ');
+}
+
+export function urlForEnvelope(envelope: AdminHookEnvelope) {
+  if (envelope.note?.url) return envelope.note.url;
+
+  if (
+    envelope.event === 'user.registered' &&
+    envelope.user?.username &&
+    envelope.site.frontendUrl
+  ) {
+    return `${envelope.site.frontendUrl.replace(/\/+$/, '')}/${encodeURIComponent(
+      envelope.user.username
+    )}`;
+  }
+
+  return envelope.site.frontendUrl;
+}

--- a/server/utils/adminHooks/types.ts
+++ b/server/utils/adminHooks/types.ts
@@ -29,6 +29,7 @@ export interface AdminHookEnvelope {
   };
   occurredAt: string;
   site: {
+    defaultLanguage?: string;
     frontendUrl?: string;
     name: string;
   };


### PR DESCRIPTION
## Summary

- link user registration notifications to the registered user's public profile
- localize admin hook event titles in Chinese, English, and Japanese using the site's `defaultLanguage`
- add regression tests for profile URL generation, username encoding, and localized titles

## Root cause

`urlForEnvelope` fell back to the site homepage for registration events even though the envelope contained `user.username`. Notification titles also interpolated the raw event identifier, such as `user.registered`, instead of resolving a localized label.

## Impact

Bark and administrator PWA registration notifications now open the relevant user profile and display a reader-facing event title rather than an internal event key.

## Validation

- `bun test tests/adminHooks.test.ts`
- `bun run lint`
- `bun run build`