### PR TITLE
Add server-backed user blocking

### DIFF
--- a/doc/userguide/API-ENDPOINTS.md
+++ b/doc/userguide/API-ENDPOINTS.md
@@ -38,18 +38,21 @@
 
 ### 3) 用户
 
-| 路径                   | 方法   | 认证 | 描述         |
-| ---------------------- | ------ | ---- | ------------ |
-| `/users/:username`     | GET    | 无   | 获取用户信息 |
-| `/users/me/profile`    | GET    | 登录 | 获取我的资料 |
-| `/users/me/profile`    | PUT    | 登录 | 更新我的资料 |
-| `/users/me/settings`   | GET    | 登录 | 获取我的设置 |
-| `/users/me/settings`   | PUT    | 登录 | 更新我的设置 |
-| `/users/me/tags`       | GET    | 登录 | 获取我的标签 |
-| `/users/me/heatmap`    | GET    | 登录 | 活跃热力图   |
-| `/users/me/statistics` | GET    | 登录 | 统计信息     |
-| `/users/me/export`     | GET    | 登录 | 导出数据     |
-| `/users/me`            | DELETE | 登录 | 删除账户     |
+| 路径                                    | 方法   | 认证 | 描述                     |
+| --------------------------------------- | ------ | ---- | ------------------------ |
+| `/users/:username`                      | GET    | 可选 | viewer-aware 用户信息    |
+| `/users/me/profile`                     | GET    | 登录 | 获取我的资料             |
+| `/users/me/profile`                     | PUT    | 登录 | 更新我的资料             |
+| `/users/me/settings`                    | GET    | 登录 | 获取我的设置             |
+| `/users/me/settings`                    | PUT    | 登录 | 更新我的设置             |
+| `/users/me/tags`                        | GET    | 登录 | 获取我的标签             |
+| `/users/me/heatmap`                     | GET    | 登录 | 活跃热力图               |
+| `/users/me/statistics`                  | GET    | 登录 | 统计信息                 |
+| `/users/me/export`                      | GET    | 登录 | 导出数据                 |
+| `/users/me/blocks`                      | GET    | 登录 | 获取完整屏蔽列表         |
+| `/users/me/blocks/:targetUserId`        | PUT    | 登录 | 幂等屏蔽用户             |
+| `/users/me/blocks/:targetUserId`        | DELETE | 登录 | 幂等解除屏蔽             |
+| `/users/me`                             | DELETE | 登录 | 删除账户                 |
 
 ### 4) RSS
 

--- a/doc/userguide/USER-API.md
+++ b/doc/userguide/USER-API.md
@@ -33,7 +33,7 @@
 
 | 方法 | 路径 | 鉴权 | 用途 |
 | --- | --- | --- | --- |
-| `GET` | `/v2/api/users/:username` | 否 | 获取公开用户信息 |
+| `GET` | `/v2/api/users/:username` | 可选 | 获取 viewer-aware 的公开用户信息 |
 | `GET` | `/v2/api/users/me/profile` | 是 | 获取当前用户资料和登录方式 |
 | `PUT` | `/v2/api/users/me/profile` | 是 | 更新当前用户资料 |
 | `GET` | `/v2/api/users/me/settings` | 是 | 获取当前用户设置 |
@@ -42,6 +42,9 @@
 | `GET` | `/v2/api/users/me/heatmap` | 是 | 获取当前用户笔记热力图 |
 | `GET` | `/v2/api/users/me/statistics` | 是 | 获取当前用户内容统计 |
 | `GET` | `/v2/api/users/me/export` | 是 | 导出用户数据 |
+| `GET` | `/v2/api/users/me/blocks` | 是 | 获取当前账户的完整屏蔽列表 |
+| `PUT` | `/v2/api/users/me/blocks/:targetUserId` | 是 | 幂等屏蔽目标账户 |
+| `DELETE` | `/v2/api/users/me/blocks/:targetUserId` | 是 | 幂等解除屏蔽 |
 | `POST` | `/v2/api/users/me/import/plan` | 是 | 预检需要导入的笔记 |
 | `POST` | `/v2/api/imports/attachments/migrate` | 是 | 将一个远程附件迁移到当前用户的对象存储 |
 | `POST` | `/v2/api/users/me/import` | 是 | 导入用户数据 |
@@ -75,12 +78,16 @@ curl 'https://your-domain.com/v2/api/users/demo'
     "cover": "https://example.com/cover.jpg",
     "description": "用户简介",
     "createdAt": "2026-01-01T00:00:00.000Z",
-    "certified": true
+    "certified": true,
+    "viewerHasBlocked": false
   }
 }
 ```
 
 `nickname`、`avatar`、`cover` 和 `description` 可能为 `null`。`certified` 表示用户是否已认证。
+登录请求还会返回 `viewerHasBlocked`：当前 viewer 屏蔽该用户时为 `true`，以便资料页提供解除操作；
+如果目标用户屏蔽了 viewer，则统一返回 `404`，不会泄露屏蔽关系。匿名请求的
+`viewerHasBlocked` 始终为 `false`。
 
 可能的错误：
 
@@ -676,7 +683,67 @@ curl -X POST 'https://your-domain.com/v2/api/users/me/import' \
 - `401`：未认证或令牌无效。
 - 导入内容引用了其他用户拥有的笔记、文章或附件时，请求会失败，不会取得其所有权。
 
-## 13. 删除当前用户账户
+## 13. 管理已屏蔽用户
+
+屏蔽关系由 Server 按账户持久化，跨 Web、iOS、重装和多设备保持一致。
+
+### 获取完整屏蔽列表
+
+`GET /v2/api/users/me/blocks`
+
+```json
+{
+  "code": 0,
+  "message": "success",
+  "data": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440000",
+      "username": "blocked-user",
+      "nickname": "Blocked User",
+      "avatar": null,
+      "description": null,
+      "certified": false,
+      "blockedAt": "2026-07-28T08:00:00.000Z"
+    }
+  ]
+}
+```
+
+列表按 `blockedAt` 降序、目标用户 ID 升序稳定排列。
+
+### 屏蔽与解除
+
+```bash
+curl -X PUT \
+  'https://your-domain.com/v2/api/users/me/blocks/550e8400-e29b-41d4-a716-446655440000' \
+  -H 'Authorization: Bearer <ACCESS_TOKEN>'
+
+curl -X DELETE \
+  'https://your-domain.com/v2/api/users/me/blocks/550e8400-e29b-41d4-a716-446655440000' \
+  -H 'Authorization: Bearer <ACCESS_TOKEN>'
+```
+
+成功数据分别为：
+
+```json
+{ "blocked": true, "targetUserId": "550e8400-e29b-41d4-a716-446655440000" }
+```
+
+```json
+{ "blocked": false, "targetUserId": "550e8400-e29b-41d4-a716-446655440000" }
+```
+
+重复调用是幂等的。不能屏蔽自己；屏蔽不存在的目标返回 `404`。解除不存在的关系仍成功返回
+`blocked: false`。
+
+登录用户的公开列表、搜索、随机、详情、batch、用户公开笔记和文章查询会在数据库分页前排除
+双方任一方向存在屏蔽的作者；具名 reaction 也对相关 viewer 隐藏。双方不能新增 reaction。
+RSS、sitemap 和真正匿名请求保持公开语义。
+
+屏蔽不是内容隐私或访问控制保证：公开 Rote 和 Article 仍是公开资源，退出登录后 Server
+无法把匿名请求与账户屏蔽关系绑定。客户端不得把屏蔽描述成“将公开内容设为私密”。
+
+## 14. 删除当前用户账户
 
 `DELETE /v2/api/users/me`
 

--- a/server/drizzle/migrations/0021_friendly_dazzler.sql
+++ b/server/drizzle/migrations/0021_friendly_dazzler.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "user_blocks" (
+	"blockerId" uuid NOT NULL,
+	"blockedId" uuid NOT NULL,
+	"createdAt" timestamp (6) with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "user_blocks_blocker_blocked_pk" PRIMARY KEY("blockerId","blockedId"),
+	CONSTRAINT "user_blocks_no_self_block" CHECK ("user_blocks"."blockerId" <> "user_blocks"."blockedId")
+);
+--> statement-breakpoint
+ALTER TABLE "user_blocks" ADD CONSTRAINT "user_blocks_blocker_id_users_id_fk" FOREIGN KEY ("blockerId") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
+ALTER TABLE "user_blocks" ADD CONSTRAINT "user_blocks_blocked_id_users_id_fk" FOREIGN KEY ("blockedId") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
+CREATE INDEX "user_blocks_blocker_id_idx" ON "user_blocks" USING btree ("blockerId");--> statement-breakpoint
+CREATE INDEX "user_blocks_blocked_id_idx" ON "user_blocks" USING btree ("blockedId");

--- a/server/drizzle/migrations/meta/0021_snapshot.json
+++ b/server/drizzle/migrations/meta/0021_snapshot.json
@@ -1,0 +1,3468 @@
+{
+  "id": "9372fadf-8c49-416a-a4e5-1dadccb38850",
+  "prevId": "1907943f-a7b1-481d-afe4-26fa9eb8bc34",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ai_token_usage_logs": {
+      "name": "ai_token_usage_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "promptTokens": {
+          "name": "promptTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "completionTokens": {
+          "name": "completionTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalTokens": {
+          "name": "totalTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_token_usage_logs_userid_idx": {
+          "name": "ai_token_usage_logs_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_token_usage_logs_createdAt_idx": {
+          "name": "ai_token_usage_logs_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_token_usage_logs_userid_users_id_fk": {
+          "name": "ai_token_usage_logs_userid_users_id_fk",
+          "tableFrom": "ai_token_usage_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.articles": {
+      "name": "articles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorId": {
+          "name": "authorId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "articles_authorId_idx": {
+          "name": "articles_authorId_idx",
+          "columns": [
+            {
+              "expression": "authorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "articles_authorId_users_id_fk": {
+          "name": "articles_authorId_users_id_fk",
+          "tableFrom": "articles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "authorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attachments": {
+      "name": "attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compressUrl": {
+          "name": "compressUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "posterUrl": {
+          "name": "posterUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roteid": {
+          "name": "roteid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage": {
+          "name": "storage",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sortIndex": {
+          "name": "sortIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "attachments_userid_idx": {
+          "name": "attachments_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attachments_roteid_idx": {
+          "name": "attachments_roteid_idx",
+          "columns": [
+            {
+              "expression": "roteid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attachments_roteid_sortIndex_idx": {
+          "name": "attachments_roteid_sortIndex_idx",
+          "columns": [
+            {
+              "expression": "roteid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sortIndex",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attachments_userid_users_id_fk": {
+          "name": "attachments_userid_users_id_fk",
+          "tableFrom": "attachments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "attachments_roteid_rotes_id_fk": {
+          "name": "attachments_roteid_rotes_id_fk",
+          "tableFrom": "attachments",
+          "tableTo": "rotes",
+          "columnsFrom": [
+            "roteid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_embeddings": {
+      "name": "document_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceType": {
+          "name": "sourceType",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceId": {
+          "name": "sourceId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunkIndex": {
+          "name": "chunkIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contentHash": {
+          "name": "contentHash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embeddingModel": {
+          "name": "embeddingModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embeddingDimensions": {
+          "name": "embeddingDimensions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_embeddings_ownerId_idx": {
+          "name": "document_embeddings_ownerId_idx",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_embeddings_source_idx": {
+          "name": "document_embeddings_source_idx",
+          "columns": [
+            {
+              "expression": "sourceType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sourceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_embeddings_owner_source_idx": {
+          "name": "document_embeddings_owner_source_idx",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sourceType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_embeddings_model_dimensions_idx": {
+          "name": "document_embeddings_model_dimensions_idx",
+          "columns": [
+            {
+              "expression": "embeddingModel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "embeddingDimensions",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_embeddings_ownerId_users_id_fk": {
+          "name": "document_embeddings_ownerId_users_id_fk",
+          "tableFrom": "document_embeddings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "document_embeddings_source_chunk_unique": {
+          "name": "document_embeddings_source_chunk_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sourceType",
+            "sourceId",
+            "chunkIndex"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.embedding_jobs": {
+      "name": "embedding_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceType": {
+          "name": "sourceType",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceId": {
+          "name": "sourceId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'upsert'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lockedAt": {
+          "name": "lockedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "embedding_jobs_status_idx": {
+          "name": "embedding_jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "embedding_jobs_source_idx": {
+          "name": "embedding_jobs_source_idx",
+          "columns": [
+            {
+              "expression": "sourceType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sourceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "embedding_jobs_ownerId_idx": {
+          "name": "embedding_jobs_ownerId_idx",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "embedding_jobs_ownerId_users_id_fk": {
+          "name": "embedding_jobs_ownerId_users_id_fk",
+          "tableFrom": "embedding_jobs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.note_import_sources": {
+      "name": "note_import_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roteId": {
+          "name": "roteId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachmentMap": {
+          "name": "attachmentMap",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "note_import_sources_owner_idx": {
+          "name": "note_import_sources_owner_idx",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "note_import_sources_ownerId_users_id_fk": {
+          "name": "note_import_sources_ownerId_users_id_fk",
+          "tableFrom": "note_import_sources",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "note_import_sources_roteId_rotes_id_fk": {
+          "name": "note_import_sources_roteId_rotes_id_fk",
+          "tableFrom": "note_import_sources",
+          "tableTo": "rotes",
+          "columnsFrom": [
+            "roteId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "note_import_sources_rote_id_unique": {
+          "name": "note_import_sources_rote_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "roteId"
+          ]
+        },
+        "note_import_sources_owner_source_unique": {
+          "name": "note_import_sources_owner_source_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "ownerId",
+            "provider",
+            "accountId",
+            "externalId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.open_key_usage_logs": {
+      "name": "open_key_usage_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "openKeyId": {
+          "name": "openKeyId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientIp": {
+          "name": "clientIp",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statusCode": {
+          "name": "statusCode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responseTime": {
+          "name": "responseTime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "open_key_usage_logs_openKeyId_idx": {
+          "name": "open_key_usage_logs_openKeyId_idx",
+          "columns": [
+            {
+              "expression": "openKeyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "open_key_usage_logs_createdAt_idx": {
+          "name": "open_key_usage_logs_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "open_key_usage_logs_openKeyId_user_open_keys_id_fk": {
+          "name": "open_key_usage_logs_openKeyId_user_open_keys_id_fk",
+          "tableFrom": "open_key_usage_logs",
+          "tableTo": "user_open_keys",
+          "columnsFrom": [
+            "openKeyId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reactions": {
+      "name": "reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visitorId": {
+          "name": "visitorId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visitorInfo": {
+          "name": "visitorInfo",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roteid": {
+          "name": "roteid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reactions_roteid_type_idx": {
+          "name": "reactions_roteid_type_idx",
+          "columns": [
+            {
+              "expression": "roteid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reactions_userid_idx": {
+          "name": "reactions_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reactions_visitorId_idx": {
+          "name": "reactions_visitorId_idx",
+          "columns": [
+            {
+              "expression": "visitorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reactions_roteid_rotes_id_fk": {
+          "name": "reactions_roteid_rotes_id_fk",
+          "tableFrom": "reactions",
+          "tableTo": "rotes",
+          "columnsFrom": [
+            "roteid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "reactions_userid_users_id_fk": {
+          "name": "reactions_userid_users_id_fk",
+          "tableFrom": "reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_reaction": {
+          "name": "unique_reaction",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userid",
+            "visitorId",
+            "roteid",
+            "type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_permission_policies": {
+      "name": "role_permission_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effect": {
+          "name": "effect",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "role_permission_policies_role_idx": {
+          "name": "role_permission_policies_role_idx",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_role_permission": {
+          "name": "unique_role_permission",
+          "nullsNotDistinct": false,
+          "columns": [
+            "role",
+            "permission"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rote_changes": {
+      "name": "rote_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "originid": {
+          "name": "originid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roteid": {
+          "name": "roteid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CREATE'"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rote_changes_originid_createdAt_idx": {
+          "name": "rote_changes_originid_createdAt_idx",
+          "columns": [
+            {
+              "expression": "originid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rote_changes_originid_action_idx": {
+          "name": "rote_changes_originid_action_idx",
+          "columns": [
+            {
+              "expression": "originid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rote_changes_roteid_createdAt_idx": {
+          "name": "rote_changes_roteid_createdAt_idx",
+          "columns": [
+            {
+              "expression": "roteid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rote_changes_userid_idx": {
+          "name": "rote_changes_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rote_changes_roteid_action_idx": {
+          "name": "rote_changes_roteid_action_idx",
+          "columns": [
+            {
+              "expression": "roteid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rote_changes_roteid_rotes_id_fk": {
+          "name": "rote_changes_roteid_rotes_id_fk",
+          "tableFrom": "rote_changes",
+          "tableTo": "rotes",
+          "columnsFrom": [
+            "roteid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rote_link_previews": {
+      "name": "rote_link_previews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "roteid": {
+          "name": "roteid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "siteName": {
+          "name": "siteName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentExcerpt": {
+          "name": "contentExcerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rote_link_previews_roteid_idx": {
+          "name": "rote_link_previews_roteid_idx",
+          "columns": [
+            {
+              "expression": "roteid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rote_link_previews_roteid_rotes_id_fk": {
+          "name": "rote_link_previews_roteid_rotes_id_fk",
+          "tableFrom": "rote_link_previews",
+          "tableTo": "rotes",
+          "columnsFrom": [
+            "roteid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "rote_link_previews_roteid_url_unique": {
+          "name": "rote_link_previews_roteid_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "roteid",
+            "url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rotes": {
+      "name": "rotes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Rote'"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "authorid": {
+          "name": "authorid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "articleId": {
+          "name": "articleId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pin": {
+          "name": "pin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "editor": {
+          "name": "editor",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'normal'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rotes_authorid_state_idx": {
+          "name": "rotes_authorid_state_idx",
+          "columns": [
+            {
+              "expression": "authorid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rotes_authorid_archived_idx": {
+          "name": "rotes_authorid_archived_idx",
+          "columns": [
+            {
+              "expression": "authorid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rotes_authorid_created_at_idx": {
+          "name": "rotes_authorid_created_at_idx",
+          "columns": [
+            {
+              "expression": "authorid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rotes_tags_idx": {
+          "name": "rotes_tags_idx",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "rotes_articleId_idx": {
+          "name": "rotes_articleId_idx",
+          "columns": [
+            {
+              "expression": "articleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rotes_authorid_users_id_fk": {
+          "name": "rotes_authorid_users_id_fk",
+          "tableFrom": "rotes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "authorid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "rotes_articleId_articles_id_fk": {
+          "name": "rotes_articleId_articles_id_fk",
+          "tableFrom": "rotes",
+          "tableTo": "articles",
+          "columnsFrom": [
+            "articleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group": {
+          "name": "group",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isRequired": {
+          "name": "isRequired",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isInitialized": {
+          "name": "isInitialized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isSystem": {
+          "name": "isSystem",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "settings_isRequired_idx": {
+          "name": "settings_isRequired_idx",
+          "columns": [
+            {
+              "expression": "isRequired",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "settings_isInitialized_idx": {
+          "name": "settings_isInitialized_idx",
+          "columns": [
+            {
+              "expression": "isInitialized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "settings_isSystem_idx": {
+          "name": "settings_isSystem_idx",
+          "columns": [
+            {
+              "expression": "isSystem",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "settings_group_unique": {
+          "name": "settings_group_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_blocks": {
+      "name": "user_blocks",
+      "schema": "",
+      "columns": {
+        "blockerId": {
+          "name": "blockerId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blockedId": {
+          "name": "blockedId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_blocks_blocker_id_idx": {
+          "name": "user_blocks_blocker_id_idx",
+          "columns": [
+            {
+              "expression": "blockerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_blocks_blocked_id_idx": {
+          "name": "user_blocks_blocked_id_idx",
+          "columns": [
+            {
+              "expression": "blockedId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_blocks_blocker_id_users_id_fk": {
+          "name": "user_blocks_blocker_id_users_id_fk",
+          "tableFrom": "user_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blockerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "user_blocks_blocked_id_users_id_fk": {
+          "name": "user_blocks_blocked_id_users_id_fk",
+          "tableFrom": "user_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blockedId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_blocks_blocker_blocked_pk": {
+          "name": "user_blocks_blocker_blocked_pk",
+          "columns": [
+            "blockerId",
+            "blockedId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_blocks_no_self_block": {
+          "name": "user_blocks_no_self_block",
+          "value": "\"user_blocks\".\"blockerId\" <> \"user_blocks\".\"blockedId\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_oauth_bindings": {
+      "name": "user_oauth_bindings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerUsername": {
+          "name": "providerUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_oauth_bindings_userid_idx": {
+          "name": "user_oauth_bindings_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_oauth_bindings_provider_idx": {
+          "name": "user_oauth_bindings_provider_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_oauth_bindings_providerId_idx": {
+          "name": "user_oauth_bindings_providerId_idx",
+          "columns": [
+            {
+              "expression": "providerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_oauth_bindings_userid_users_id_fk": {
+          "name": "user_oauth_bindings_userid_users_id_fk",
+          "tableFrom": "user_oauth_bindings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_provider": {
+          "name": "unique_user_provider",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userid",
+            "provider"
+          ]
+        },
+        "unique_provider_id": {
+          "name": "unique_provider_id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider",
+            "providerId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_open_keys": {
+      "name": "user_open_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"SENDROTE\"}'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_open_keys_userid_idx": {
+          "name": "user_open_keys_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_open_keys_userid_users_id_fk": {
+          "name": "user_open_keys_userid_users_id_fk",
+          "tableFrom": "user_open_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_passkeys": {
+      "name": "user_passkeys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentialId": {
+          "name": "credentialId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "transports": {
+          "name": "transports",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deviceName": {
+          "name": "deviceName",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "deviceType": {
+          "name": "deviceType",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_passkeys_userid_idx": {
+          "name": "user_passkeys_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_passkeys_credentialId_idx": {
+          "name": "user_passkeys_credentialId_idx",
+          "columns": [
+            {
+              "expression": "credentialId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_passkeys_userid_users_id_fk": {
+          "name": "user_passkeys_userid_users_id_fk",
+          "tableFrom": "user_passkeys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_passkeys_credentialId_unique": {
+          "name": "user_passkeys_credentialId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credentialId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_permission_overrides": {
+      "name": "user_permission_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effect": {
+          "name": "effect",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_permission_overrides_userid_idx": {
+          "name": "user_permission_overrides_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_permission_overrides_userid_users_id_fk": {
+          "name": "user_permission_overrides_userid_users_id_fk",
+          "tableFrom": "user_permission_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "user_permission_overrides_updatedBy_users_id_fk": {
+          "name": "user_permission_overrides_updatedBy_users_id_fk",
+          "tableFrom": "user_permission_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updatedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_permission": {
+          "name": "unique_user_permission",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userid",
+            "permission"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "darkmode": {
+          "name": "darkmode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "allowExplore": {
+          "name": "allowExplore",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_settings_userid_idx": {
+          "name": "user_settings_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_settings_userid_users_id_fk": {
+          "name": "user_settings_userid_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_settings_userid_unique": {
+          "name": "user_settings_userid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_sw_subscriptions": {
+      "name": "user_sw_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "expirationTime": {
+          "name": "expirationTime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keys": {
+          "name": "keys",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_sw_subscriptions_userid_idx": {
+          "name": "user_sw_subscriptions_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_sw_subscriptions_endpoint_idx": {
+          "name": "user_sw_subscriptions_endpoint_idx",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_sw_subscriptions_userid_users_id_fk": {
+          "name": "user_sw_subscriptions_userid_users_id_fk",
+          "tableFrom": "user_sw_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_sw_subscriptions_endpoint_unique": {
+          "name": "user_sw_subscriptions_endpoint_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "endpoint"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "passwordhash": {
+          "name": "passwordhash",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salt": {
+          "name": "salt",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover": {
+          "name": "cover",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_username_idx": {
+          "name": "users_username_idx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_authorization_codes": {
+      "name": "oauth_authorization_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "codeHash": {
+          "name": "codeHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requestId": {
+          "name": "requestId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirectUri": {
+          "name": "redirectUri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codeChallenge": {
+          "name": "codeChallenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codeChallengeMethod": {
+          "name": "codeChallengeMethod",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumedAt": {
+          "name": "consumedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_authorization_codes_codeHash_idx": {
+          "name": "oauth_authorization_codes_codeHash_idx",
+          "columns": [
+            {
+              "expression": "codeHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_authorization_codes_requestId_idx": {
+          "name": "oauth_authorization_codes_requestId_idx",
+          "columns": [
+            {
+              "expression": "requestId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_authorization_codes_clientId_oauth_clients_clientId_fk": {
+          "name": "oauth_authorization_codes_clientId_oauth_clients_clientId_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "clientId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "oauth_authorization_codes_requestId_oauth_authorization_requests_id_fk": {
+          "name": "oauth_authorization_codes_requestId_oauth_authorization_requests_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "oauth_authorization_requests",
+          "columnsFrom": [
+            "requestId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "oauth_authorization_codes_userid_users_id_fk": {
+          "name": "oauth_authorization_codes_userid_users_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_authorization_codes_codeHash_unique": {
+          "name": "oauth_authorization_codes_codeHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "codeHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_authorization_requests": {
+      "name": "oauth_authorization_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirectUri": {
+          "name": "redirectUri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codeChallenge": {
+          "name": "codeChallenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codeChallengeMethod": {
+          "name": "codeChallengeMethod",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_authorization_requests_clientId_idx": {
+          "name": "oauth_authorization_requests_clientId_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_authorization_requests_expiresAt_idx": {
+          "name": "oauth_authorization_requests_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_authorization_requests_clientId_oauth_clients_clientId_fk": {
+          "name": "oauth_authorization_requests_clientId_oauth_clients_clientId_fk",
+          "tableFrom": "oauth_authorization_requests",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "clientId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "oauth_authorization_requests_userid_users_id_fk": {
+          "name": "oauth_authorization_requests_userid_users_id_fk",
+          "tableFrom": "oauth_authorization_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_clients": {
+      "name": "oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientName": {
+          "name": "clientName",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientUri": {
+          "name": "clientUri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logoUri": {
+          "name": "logoUri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirectUris": {
+          "name": "redirectUris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "grantTypes": {
+          "name": "grantTypes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"authorization_code\",\"refresh_token\"}'"
+        },
+        "responseTypes": {
+          "name": "responseTypes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"code\"}'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_clients_clientId_idx": {
+          "name": "oauth_clients_clientId_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_clients_clientId_unique": {
+          "name": "oauth_clients_clientId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clientId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_grants": {
+      "name": "oauth_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_grants_userid_idx": {
+          "name": "oauth_grants_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_grants_clientId_oauth_clients_clientId_fk": {
+          "name": "oauth_grants_clientId_oauth_clients_clientId_fk",
+          "tableFrom": "oauth_grants",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "clientId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "oauth_grants_userid_users_id_fk": {
+          "name": "oauth_grants_userid_users_id_fk",
+          "tableFrom": "oauth_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_oauth_grant_user_client_resource": {
+          "name": "unique_oauth_grant_user_client_resource",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userid",
+            "clientId",
+            "resource"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_tokens": {
+      "name": "oauth_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replacedByTokenId": {
+          "name": "replacedByTokenId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_refresh_tokens_tokenHash_idx": {
+          "name": "oauth_refresh_tokens_tokenHash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_tokens_client_user_idx": {
+          "name": "oauth_refresh_tokens_client_user_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_tokens_clientId_oauth_clients_clientId_fk": {
+          "name": "oauth_refresh_tokens_clientId_oauth_clients_clientId_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "clientId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "oauth_refresh_tokens_userid_users_id_fk": {
+          "name": "oauth_refresh_tokens_userid_users_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_refresh_tokens_tokenHash_unique": {
+          "name": "oauth_refresh_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/drizzle/migrations/meta/_journal.json
+++ b/server/drizzle/migrations/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1784981710926,
       "tag": "0020_extend_jwt_expiry",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1785222667914,
+      "tag": "0021_friendly_dazzler",
+      "breakpoints": true
     }
   ]
 }

--- a/server/drizzle/schema.ts
+++ b/server/drizzle/schema.ts
@@ -1,12 +1,14 @@
-import { relations } from 'drizzle-orm';
+import { relations, sql } from 'drizzle-orm';
 import {
   boolean,
+  check,
   customType,
   foreignKey,
   index,
   integer,
   jsonb,
   pgTable,
+  primaryKey,
   text,
   timestamp,
   unique,
@@ -48,6 +50,39 @@ export const users = pgTable(
     emailIdx: index('users_email_idx').on(table.email),
     usernameIdx: index('users_username_idx').on(table.username),
     // 注意：authProvider 相关索引已移除，OAuth 绑定信息存储在 user_oauth_bindings 表中
+  })
+);
+
+// Account-level user block relationships.
+export const userBlocks = pgTable(
+  'user_blocks',
+  {
+    blockerId: uuid('blockerId').notNull(),
+    blockedId: uuid('blockedId').notNull(),
+    createdAt: timestamp('createdAt', { withTimezone: true, precision: 6 }).notNull().defaultNow(),
+  },
+  (table) => ({
+    primaryKey: primaryKey({
+      columns: [table.blockerId, table.blockedId],
+      name: 'user_blocks_blocker_blocked_pk',
+    }),
+    blockerIdx: index('user_blocks_blocker_id_idx').on(table.blockerId),
+    blockedIdx: index('user_blocks_blocked_id_idx').on(table.blockedId),
+    blockerFk: foreignKey({
+      columns: [table.blockerId],
+      foreignColumns: [users.id],
+      name: 'user_blocks_blocker_id_users_id_fk',
+    })
+      .onDelete('cascade')
+      .onUpdate('cascade'),
+    blockedFk: foreignKey({
+      columns: [table.blockedId],
+      foreignColumns: [users.id],
+      name: 'user_blocks_blocked_id_users_id_fk',
+    })
+      .onDelete('cascade')
+      .onUpdate('cascade'),
+    noSelfBlock: check('user_blocks_no_self_block', sql`${table.blockerId} <> ${table.blockedId}`),
   })
 );
 
@@ -609,6 +644,8 @@ export const usersRelations = relations(users, ({ one, many }) => ({
   userreaction: many(reactions),
   rotes: many(rotes),
   articles: many(articles),
+  blocksCreated: many(userBlocks, { relationName: 'blocker' }),
+  blocksReceived: many(userBlocks, { relationName: 'blocked' }),
   openkey: many(userOpenKeys),
   usersetting: one(userSettings, {
     fields: [users.id],
@@ -620,6 +657,19 @@ export const usersRelations = relations(users, ({ one, many }) => ({
   permissionOverrides: many(userPermissionOverrides),
   documentEmbeddings: many(documentEmbeddings),
   embeddingJobs: many(embeddingJobs),
+}));
+
+export const userBlocksRelations = relations(userBlocks, ({ one }) => ({
+  blocker: one(users, {
+    fields: [userBlocks.blockerId],
+    references: [users.id],
+    relationName: 'blocker',
+  }),
+  blocked: one(users, {
+    fields: [userBlocks.blockedId],
+    references: [users.id],
+    relationName: 'blocked',
+  }),
 }));
 
 export const userSettingsRelations = relations(userSettings, ({ one }) => ({
@@ -759,6 +809,8 @@ export const aiTokenUsageLogsRelations = relations(aiTokenUsageLogs, ({ one }) =
 // 导出类型
 export type User = typeof users.$inferSelect;
 export type NewUser = typeof users.$inferInsert;
+export type UserBlock = typeof userBlocks.$inferSelect;
+export type NewUserBlock = typeof userBlocks.$inferInsert;
 export type UserSetting = typeof userSettings.$inferSelect;
 export type NewUserSetting = typeof userSettings.$inferInsert;
 export type UserOpenKey = typeof userOpenKeys.$inferSelect;

--- a/server/mcp/articles.ts
+++ b/server/mcp/articles.ts
@@ -31,21 +31,21 @@ export const articleTools: McpTool[] = [
   defineMcpTool('articles_get', async (c, args) => {
     const auth = requireAuth(c);
     const id = assertUuid(args.id, 'article_id');
-    const article = await findArticleById(id);
+    const article = await findArticleById(id, auth.userId);
     if (!article) throw new Error(mcpErrors.articleNotFound);
-    const note = await getNoteByArticleId(id);
+    const note = await getNoteByArticleId(id, auth.userId);
     if (article.authorId === auth.userId || note?.state === 'public') return { ...article, note };
     throw new Error(mcpErrors.articleAccessDenied);
   }),
   defineMcpTool('articles_get_by_note', async (c, args) => {
     const auth = requireAuth(c);
     const noteId = assertUuid(args.noteId, 'note_id');
-    const note = await findRoteById(noteId);
+    const note = await findRoteById(noteId, auth.userId);
     if (!note) throw new Error(mcpErrors.noteNotFound);
     if (note.state !== 'public' && note.authorid !== auth.userId) {
       throw new Error(mcpErrors.notePrivate);
     }
-    return await getNoteArticleCard(noteId);
+    return await getNoteArticleCard(noteId, auth.userId);
   }),
   defineMcpTool('articles_update', async (c, args) => {
     const auth = requireAuth(c);

--- a/server/mcp/notes.ts
+++ b/server/mcp/notes.ts
@@ -67,7 +67,7 @@ export const noteTools: McpTool[] = [
   defineMcpTool('notes_get', async (c, args) => {
     const auth = requireAuth(c);
     const id = assertUuid(args.id, 'note_id');
-    const note = await findRoteById(id);
+    const note = await findRoteById(id, auth.userId);
     if (!note) throw new Error(mcpErrors.noteNotFound);
     if (note.state === 'public' || note.authorid === auth.userId) return note;
     throw new Error(mcpErrors.notePrivate);
@@ -78,7 +78,7 @@ export const noteTools: McpTool[] = [
     if (!Array.isArray(ids) || ids.length === 0) throw new Error(mcpErrors.idsRequired);
     if (ids.length > MAX_BATCH_SIZE) throw new Error(mcpErrors.batchLimitExceeded);
     ids.forEach((id) => assertUuid(id, 'note_id'));
-    const notes = await findRotesByIds(ids);
+    const notes = await findRotesByIds(ids, auth.userId);
     return notes.filter((note) => note.state === 'public' || note.authorid === auth.userId);
   }),
   defineMcpTool('notes_update', updateNote),

--- a/server/mcp/reactions.ts
+++ b/server/mcp/reactions.ts
@@ -1,4 +1,5 @@
 import { addReaction, findRoteById, removeReaction } from '../utils/dbMethods';
+import { assertUsersMayInteract } from '../userBlocks/service';
 import { ReactionCreateZod } from '../utils/zod';
 import mcpErrors from './errorCodes.json';
 import { defineMcpTool } from './registry';
@@ -11,6 +12,7 @@ export const reactionTools: McpTool[] = [
     ReactionCreateZod.parse({ type: args.type, roteid: args.roteid, metadata: args.metadata });
     const note = await findRoteById(args.roteid);
     if (!note) throw new Error(mcpErrors.roteNotFound);
+    await assertUsersMayInteract(auth.userId, note.authorid);
     return await addReaction({
       type: args.type,
       roteid: args.roteid,

--- a/server/notes/actions.ts
+++ b/server/notes/actions.ts
@@ -83,7 +83,7 @@ export async function updateUserNote(userId: string, id: string, input: UpdateUs
     await setNoteArticleId(id, articleIdToSet, userId);
   }
 
-  const data = await findRoteById(id);
+  const data = await findRoteById(id, userId);
   const hasArticle = Boolean(data?.articleId || data?.article);
   const contentProvided = Object.prototype.hasOwnProperty.call(input, 'content');
   const contentForPreview = contentProvided ? input.content : data?.content;

--- a/server/route/v2/ai.ts
+++ b/server/route/v2/ai.ts
@@ -226,6 +226,7 @@ aiRouter.post('/search', authenticateJWT, bodyTypeCheck, async (c: HonoContext) 
   const { sources: results } = await searchMemory({
     query,
     ownerId: body?.scope === 'public' ? undefined : user.id,
+    viewerId: user.id,
     scope: body?.scope === 'public' ? 'public' : 'mine',
     sourceTypes: body?.sourceTypes,
     timeRange: body?.timeRange,

--- a/server/route/v2/article.ts
+++ b/server/route/v2/article.ts
@@ -105,12 +105,15 @@ articlesRouter.get('/by-note/:noteId', optionalJWT, async (c: HonoContext) => {
     throw new Error('Invalid or missing noteId');
   }
 
-  const note = await findRoteById(noteId);
+  const note = await findRoteById(noteId, user?.id);
+  if (!note) {
+    throw new Error('Note not found');
+  }
   if (!isNoteAccessible(note, user)) {
     throw new Error('Access denied: note is private');
   }
 
-  const article = await getNoteArticleCard(noteId);
+  const article = await getNoteArticleCard(noteId, user?.id);
   return c.json(createResponse(article), 200);
 });
 
@@ -123,13 +126,13 @@ articlesRouter.get('/:id', optionalJWT, async (c: HonoContext) => {
     throw new Error('Invalid or missing ID');
   }
 
-  const article = await findArticleById(id);
+  const article = await findArticleById(id, user?.id);
 
   if (!article) {
     throw new Error('Article not found');
   }
 
-  const note = await getNoteByArticleId(id);
+  const note = await getNoteByArticleId(id, user?.id);
 
   // 作者可直接访问，返回文章和其关联的笔记（如有）
   if (user && article.authorId === user.id) {

--- a/server/route/v2/note.ts
+++ b/server/route/v2/note.ts
@@ -91,7 +91,7 @@ notesRouter.post('/', authenticateJWT, bodyTypeCheck, async (c: HonoContext) => 
   }
 
   // 重新查询以获取最新关联数据（附件/文章等）
-  const fullRote = await findRoteById(rote.id);
+  const fullRote = await findRoteById(rote.id, user.id);
   void enqueueEmbeddingJob('rote', rote.id, user.id).catch((error) => {
     console.error('Failed to enqueue rote embedding job:', error);
   });
@@ -172,7 +172,8 @@ notesRouter.get('/search', authenticateJWT, async (c: HonoContext) => {
 });
 
 // 搜索公开笔记
-notesRouter.get('/search/public', async (c: HonoContext) => {
+notesRouter.get('/search/public', optionalJWT, async (c: HonoContext) => {
+  const viewer = c.get('user') as User | undefined;
   const keyword = c.req.query('keyword');
   const skip = c.req.query('skip');
   const limit = c.req.query('limit');
@@ -216,13 +217,14 @@ notesRouter.get('/search/public', async (c: HonoContext) => {
   const parsedSkip = typeof skip === 'string' ? parseInt(skip) : undefined;
   const parsedLimit = typeof limit === 'string' ? parseInt(limit) : undefined;
 
-  const rotes = await searchPublicRotes(keyword, parsedSkip, parsedLimit, filter);
+  const rotes = await searchPublicRotes(keyword, parsedSkip, parsedLimit, filter, viewer?.id);
 
   return c.json(createResponse(rotes), 200);
 });
 
 // 搜索指定用户的公开笔记
-notesRouter.get('/search/users/:username', async (c: HonoContext) => {
+notesRouter.get('/search/users/:username', optionalJWT, async (c: HonoContext) => {
+  const viewer = c.get('user') as User | undefined;
   const username = c.req.param('username');
   const keyword = c.req.query('keyword');
   const skip = c.req.query('skip');
@@ -283,7 +285,8 @@ notesRouter.get('/search/users/:username', async (c: HonoContext) => {
     parsedSkip,
     parsedLimit,
     filter,
-    archived ? (archived === 'true' ? true : false) : undefined
+    archived ? (archived === 'true' ? true : false) : undefined,
+    viewer?.id
   );
 
   return c.json(createResponse(rotes), 200);
@@ -340,7 +343,8 @@ notesRouter.get('/', authenticateJWT, async (c: HonoContext) => {
 });
 
 // 获取用户公开笔记
-notesRouter.get('/users/:username', async (c: HonoContext) => {
+notesRouter.get('/users/:username', optionalJWT, async (c: HonoContext) => {
+  const viewer = c.get('user') as User | undefined;
   const username = c.req.param('username');
   const skip = c.req.query('skip');
   const limit = c.req.query('limit');
@@ -393,14 +397,16 @@ notesRouter.get('/users/:username', async (c: HonoContext) => {
     parsedSkip,
     parsedLimit,
     filter,
-    archived ? (archived === 'true' ? true : false) : undefined
+    archived ? (archived === 'true' ? true : false) : undefined,
+    viewer?.id
   );
 
   return c.json(createResponse(rote), 200);
 });
 
 // 获取所有公开笔记
-notesRouter.get('/public', async (c: HonoContext) => {
+notesRouter.get('/public', optionalJWT, async (c: HonoContext) => {
+  const viewer = c.get('user') as User | undefined;
   const skip = c.req.query('skip');
   const limit = c.req.query('limit');
 
@@ -428,7 +434,7 @@ notesRouter.get('/public', async (c: HonoContext) => {
   const parsedSkip = typeof skip === 'string' ? parseInt(skip) : undefined;
   const parsedLimit = typeof limit === 'string' ? parseInt(limit) : undefined;
 
-  const rote = await findPublicRote(parsedSkip, parsedLimit, filter);
+  const rote = await findPublicRote(parsedSkip, parsedLimit, filter, viewer?.id);
 
   return c.json(createResponse(rote), 200);
 });
@@ -457,7 +463,7 @@ notesRouter.post('/batch', optionalJWT, bodyTypeCheck, async (c: HonoContext) =>
   }
 
   // 批量获取笔记
-  const rotes = await findRotesByIds(uniqueIds);
+  const rotes = await findRotesByIds(uniqueIds, user?.id);
 
   // 权限过滤：只返回用户有权限访问的笔记
   const accessibleRotes = rotes.filter((rote) => {
@@ -492,7 +498,7 @@ notesRouter.get('/:id', optionalJWT, async (c: HonoContext) => {
     throw new Error('Invalid or missing ID');
   }
 
-  const rote = await findRoteById(id);
+  const rote = await findRoteById(id, user?.id);
   if (!rote) {
     throw new Error('Note not found');
   }
@@ -539,7 +545,7 @@ notesRouter.put('/:id', authenticateJWT, bodyTypeCheck, async (c: HonoContext) =
   }
 
   // 重新获取最新数据（包含更新后的 article）
-  const data = await findRoteById(id);
+  const data = await findRoteById(id, user.id);
   void enqueueEmbeddingJob('rote', id, user.id).catch((error) => {
     console.error('Failed to enqueue rote embedding job:', error);
   });

--- a/server/route/v2/openKeyRouter.ts
+++ b/server/route/v2/openKeyRouter.ts
@@ -20,6 +20,7 @@ import { requireStorageConfig } from '../../middleware/configCheck';
 import type { StorageConfig } from '../../types/config';
 import type { HonoContext, HonoVariables } from '../../types/hono';
 import type { UploadResult } from '../../types/main';
+import { assertUsersMayInteract } from '../../userBlocks/service';
 import { getGlobalConfig } from '../../utils/config';
 import {
   addReaction,
@@ -209,7 +210,7 @@ router.get('/articles/by-note/:noteId', isOpenKeyOk, async (c: HonoContext) => {
   }
 
   // Check if user has access to the note
-  const note = await findRoteById(noteId);
+  const note = await findRoteById(noteId, openKey.userid);
   if (!note) {
     throw new Error('Note not found');
   }
@@ -219,7 +220,7 @@ router.get('/articles/by-note/:noteId', isOpenKeyOk, async (c: HonoContext) => {
     throw new Error('Access denied: note is private');
   }
 
-  const article = await getNoteArticleCard(noteId);
+  const article = await getNoteArticleCard(noteId, openKey.userid);
   if (!article) {
     return c.json(createResponse(null), 200);
   }
@@ -236,13 +237,13 @@ router.get('/articles/:id', isOpenKeyOk, async (c: HonoContext) => {
     throw new Error('Invalid or missing ID');
   }
 
-  const article = await findArticleById(id);
+  const article = await findArticleById(id, openKey.userid);
 
   if (!article) {
     throw new Error('Article not found');
   }
 
-  const note = await getNoteByArticleId(id);
+  const note = await getNoteByArticleId(id, openKey.userid);
 
   if (article.authorId === openKey.userid) {
     return c.json(createResponse({ ...article, note }), 200);
@@ -609,7 +610,7 @@ router.post('/notes/batch', isOpenKeyOk, requireOpenKeyPerm('GETROTE'), async (c
     }
   }
 
-  const notes = await findRotesByIds(ids);
+  const notes = await findRotesByIds(ids, openKey.userid);
 
   // Filter notes: only return public notes or notes owned by the user
   const accessibleNotes = notes.filter(
@@ -628,7 +629,7 @@ router.get('/notes/:id', isOpenKeyOk, requireOpenKeyPerm('GETROTE'), async (c: H
     throw new Error('Invalid or missing ID');
   }
 
-  const rote = await findRoteById(id);
+  const rote = await findRoteById(id, openKey.userid);
   if (!rote) {
     throw new Error('Note not found');
   }
@@ -670,7 +671,7 @@ router.put('/notes/:id', isOpenKeyOk, requireOpenKeyPerm('EDITROTE'), async (c: 
     await setNoteArticleId(id, articleIdToSet, openKey.userid);
   }
 
-  const data = await findRoteById(id);
+  const data = await findRoteById(id, openKey.userid);
   const hasArticle = Boolean(data?.articleId || data?.article);
   const contentProvided = Object.prototype.hasOwnProperty.call(body, 'content');
   const contentForPreview = contentProvided ? (body as any).content : data?.content;
@@ -760,6 +761,7 @@ router.post(
     }
 
     const openKey = c.get('openKey')!;
+    await assertUsersMayInteract(openKey.userid, rote.authorid);
 
     // Build reaction data with OpenKey user
     const reactionData = {
@@ -985,7 +987,7 @@ router.put(
     }
 
     // Verify the note belongs to the user
-    const note = await findRoteById(noteId);
+    const note = await findRoteById(noteId, openKey.userid);
     if (!note) {
       throw new Error('Note not found');
     }

--- a/server/route/v2/reaction.ts
+++ b/server/route/v2/reaction.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import type { User } from '../../drizzle/schema';
 import { optionalJWT } from '../../middleware/jwtAuth';
 import type { HonoContext, HonoVariables } from '../../types/hono';
+import { assertUsersMayInteract } from '../../userBlocks/service';
 import { addReaction, findRoteById, removeReaction } from '../../utils/dbMethods';
 import { createResponse, isValidUUID } from '../../utils/main';
 import { ReactionCreateZod } from '../../utils/zod';
@@ -35,6 +36,9 @@ reactionsRouter.post('/', async (c: HonoContext) => {
   const rote = await findRoteById(roteid);
   if (!rote) {
     throw new Error('Rote not found');
+  }
+  if (user) {
+    await assertUsersMayInteract(user.id, rote.authorid);
   }
 
   // 构建反应数据

--- a/server/route/v2/user.ts
+++ b/server/route/v2/user.ts
@@ -1,8 +1,14 @@
 import { Hono } from 'hono';
 import moment from 'moment';
 import type { User } from '../../drizzle/schema';
-import { authenticateJWT } from '../../middleware/jwtAuth';
+import { authenticateJWT, optionalJWT } from '../../middleware/jwtAuth';
 import type { HonoContext, HonoVariables } from '../../types/hono';
+import {
+  blockUser,
+  getBlockedUsers,
+  getViewerAwarePublicUserProfile,
+  unblockUser,
+} from '../../userBlocks/service';
 import {
   deleteUserAccount,
   editMyProfile,
@@ -11,29 +17,17 @@ import {
   getMyProfile,
   getMySettings,
   getMyTags,
-  getUserInfoByUsername,
   importData,
   oneUser,
   planImportData,
   statistics,
   updateMySettings,
 } from '../../utils/dbMethods';
-import { createResponse } from '../../utils/main';
+import { createResponse, isValidUUID } from '../../utils/main';
 import { UsernameUpdateZod } from '../../utils/zod';
 
 // 用户相关路由
 const usersRouter = new Hono<{ Variables: HonoVariables }>();
-
-// 获取用户信息
-usersRouter.get('/:username', async (c: HonoContext) => {
-  const username = c.req.param('username');
-  if (!username) {
-    throw new Error('Username is required');
-  }
-
-  const data = await getUserInfoByUsername(username);
-  return c.json(createResponse(data), 200);
-});
 
 // 获取当前用户个人资料
 usersRouter.get('/me/profile', authenticateJWT, async (c: HonoContext) => {
@@ -122,6 +116,34 @@ usersRouter.get('/me/export', authenticateJWT, async (c: HonoContext) => {
   return c.text(jsonData);
 });
 
+usersRouter.get('/me/blocks', authenticateJWT, async (c: HonoContext) => {
+  const user = c.get('user') as User;
+  const blocks = await getBlockedUsers(user.id);
+  return c.json(createResponse(blocks), 200);
+});
+
+usersRouter.put('/me/blocks/:targetUserId', authenticateJWT, async (c: HonoContext) => {
+  const user = c.get('user') as User;
+  const targetUserId = c.req.param('targetUserId');
+  if (!targetUserId || !isValidUUID(targetUserId)) {
+    throw new Error('Invalid target user ID');
+  }
+
+  const result = await blockUser(user.id, targetUserId);
+  return c.json(createResponse(result), 200);
+});
+
+usersRouter.delete('/me/blocks/:targetUserId', authenticateJWT, async (c: HonoContext) => {
+  const user = c.get('user') as User;
+  const targetUserId = c.req.param('targetUserId');
+  if (!targetUserId || !isValidUUID(targetUserId)) {
+    throw new Error('Invalid target user ID');
+  }
+
+  const result = await unblockUser(user.id, targetUserId);
+  return c.json(createResponse(result), 200);
+});
+
 // 导入用户数据
 usersRouter.post('/me/import', authenticateJWT, async (c: HonoContext) => {
   const user = c.get('user') as User;
@@ -159,6 +181,18 @@ usersRouter.delete('/me', authenticateJWT, async (c: HonoContext) => {
   const passwordToVerify = password || 'oauth_user_placeholder';
 
   const data = await deleteUserAccount(user.id, passwordToVerify);
+  return c.json(createResponse(data), 200);
+});
+
+// 获取公开用户信息。屏蔽者仍可看到目标资料以便解除屏蔽；反向屏蔽不泄露。
+usersRouter.get('/:username', optionalJWT, async (c: HonoContext) => {
+  const username = c.req.param('username');
+  if (!username) {
+    throw new Error('Username is required');
+  }
+
+  const viewer = c.get('user') as User | undefined;
+  const data = await getViewerAwarePublicUserProfile(username, viewer?.id);
   return c.json(createResponse(data), 200);
 });
 

--- a/server/userBlocks/service.ts
+++ b/server/userBlocks/service.ts
@@ -1,0 +1,62 @@
+import { oneUser } from '../utils/dbMethods/user';
+import { getUserInfoByUsername } from '../utils/dbMethods/userProfile';
+import {
+  createUserBlock,
+  deleteUserBlock,
+  getUserBlockRelationship,
+  hasBlockInEitherDirection,
+  hasUserBlocked,
+  listUserBlocks,
+} from '../utils/dbMethods/userBlock';
+
+export async function blockUser(blockerId: string, targetUserId: string) {
+  if (blockerId === targetUserId) {
+    throw new Error('Invalid block target: you cannot block yourself');
+  }
+
+  const target = await oneUser(targetUserId);
+  if (!target) {
+    throw new Error('User not found');
+  }
+
+  await createUserBlock(blockerId, targetUserId);
+  return { blocked: true, targetUserId };
+}
+
+export async function unblockUser(blockerId: string, targetUserId: string) {
+  if (blockerId === targetUserId) {
+    throw new Error('Invalid block target: you cannot unblock yourself');
+  }
+
+  await deleteUserBlock(blockerId, targetUserId);
+  return { blocked: false, targetUserId };
+}
+
+export async function getBlockedUsers(blockerId: string) {
+  return listUserBlocks(blockerId);
+}
+
+export async function getViewerAwarePublicUserProfile(username: string, viewerId?: string) {
+  const profile = await getUserInfoByUsername(username);
+  if (!viewerId || viewerId === profile.id) {
+    return { ...profile, viewerHasBlocked: false };
+  }
+
+  const relationship = await getUserBlockRelationship(viewerId, profile.id);
+  if (relationship.targetHasBlocked) {
+    throw new Error('User not found');
+  }
+
+  return {
+    ...profile,
+    viewerHasBlocked: relationship.viewerHasBlocked,
+  };
+}
+
+export async function assertUsersMayInteract(actorId: string, contentOwnerId: string) {
+  if (actorId !== contentOwnerId && (await hasBlockInEitherDirection(actorId, contentOwnerId))) {
+    throw new Error('Rote not found');
+  }
+}
+
+export { getUserBlockRelationship, hasBlockInEitherDirection, hasUserBlocked };

--- a/server/userBlocks/userBlock.integration.test.ts
+++ b/server/userBlocks/userBlock.integration.test.ts
@@ -1,0 +1,293 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { and, eq, inArray } from 'drizzle-orm';
+
+process.env.POSTGRESQL_URL ||= 'postgres://rote:rote_password_123@localhost:5433/rote';
+
+const { articles, reactions, rotes, userBlocks, users } = await import('../drizzle/schema');
+const { default: db, closeDatabase } = await import('../utils/drizzle');
+const {
+  findArticleById,
+  findPublicRote,
+  findRandomPublicRote,
+  findRoteById,
+  findRotesByIds,
+  findUserPublicRote,
+  getNoteByArticleId,
+  searchPublicRotes,
+  searchUserPublicRotes,
+} = await import('../utils/dbMethods');
+const {
+  assertUsersMayInteract,
+  blockUser,
+  getBlockedUsers,
+  getUserBlockRelationship,
+  getViewerAwarePublicUserProfile,
+  hasUserBlocked,
+  unblockUser,
+} = await import('./service');
+
+const ids = {
+  viewer: '10000000-0000-4000-8000-000000000001',
+  blocked: '10000000-0000-4000-8000-000000000002',
+  visibleOne: '10000000-0000-4000-8000-000000000003',
+  visibleTwo: '10000000-0000-4000-8000-000000000004',
+  cascade: '10000000-0000-4000-8000-000000000005',
+  blockedNote: '20000000-0000-4000-8000-000000000001',
+  visibleNoteOne: '20000000-0000-4000-8000-000000000002',
+  visibleNoteTwo: '20000000-0000-4000-8000-000000000003',
+  viewerNote: '20000000-0000-4000-8000-000000000004',
+  blockedArticle: '30000000-0000-4000-8000-000000000001',
+  visibleArticle: '30000000-0000-4000-8000-000000000002',
+};
+
+const allUserIds = [ids.viewer, ids.blocked, ids.visibleOne, ids.visibleTwo, ids.cascade];
+
+describe.serial('server-authoritative user blocks', () => {
+  beforeAll(async () => {
+    await db.delete(users).where(inArray(users.id, allUserIds));
+
+    await db.insert(users).values([
+      {
+        id: ids.viewer,
+        email: 'block-viewer@example.test',
+        username: 'block-viewer',
+      },
+      {
+        id: ids.blocked,
+        email: 'block-target@example.test',
+        username: 'block-target',
+        nickname: 'Blocked target',
+        description: 'Target description',
+        emailVerified: true,
+      },
+      {
+        id: ids.visibleOne,
+        email: 'block-visible-one@example.test',
+        username: 'block-visible-one',
+      },
+      {
+        id: ids.visibleTwo,
+        email: 'block-visible-two@example.test',
+        username: 'block-visible-two',
+      },
+    ]);
+
+    await db.insert(articles).values([
+      {
+        id: ids.blockedArticle,
+        authorId: ids.blocked,
+        content: '# Blocked article',
+      },
+      {
+        id: ids.visibleArticle,
+        authorId: ids.visibleOne,
+        content: '# Visible article',
+      },
+    ]);
+
+    await db.insert(rotes).values([
+      {
+        id: ids.blockedNote,
+        authorid: ids.blocked,
+        content: 'shared visibility keyword blocked',
+        state: 'public',
+        articleId: ids.blockedArticle,
+        createdAt: new Date('2026-07-28T05:00:00Z'),
+        updatedAt: new Date('2026-07-28T05:00:00Z'),
+      },
+      {
+        id: ids.visibleNoteOne,
+        authorid: ids.visibleOne,
+        content: 'shared visibility keyword visible one',
+        state: 'public',
+        articleId: ids.visibleArticle,
+        createdAt: new Date('2026-07-28T04:00:00Z'),
+        updatedAt: new Date('2026-07-28T04:00:00Z'),
+      },
+      {
+        id: ids.visibleNoteTwo,
+        authorid: ids.visibleTwo,
+        content: 'shared visibility keyword visible two',
+        state: 'public',
+        createdAt: new Date('2026-07-28T03:00:00Z'),
+        updatedAt: new Date('2026-07-28T03:00:00Z'),
+      },
+      {
+        id: ids.viewerNote,
+        authorid: ids.viewer,
+        content: 'viewer own public note',
+        state: 'public',
+        createdAt: new Date('2026-07-28T02:00:00Z'),
+        updatedAt: new Date('2026-07-28T02:00:00Z'),
+      },
+    ]);
+
+    await db.insert(reactions).values([
+      {
+        type: 'blocked-user',
+        userid: ids.blocked,
+        roteid: ids.visibleNoteOne,
+      },
+      {
+        type: 'visible-user',
+        userid: ids.visibleTwo,
+        roteid: ids.visibleNoteOne,
+      },
+      {
+        type: 'anonymous',
+        visitorId: 'block-test-visitor',
+        roteid: ids.visibleNoteOne,
+      },
+    ]);
+  });
+
+  afterAll(async () => {
+    await db.delete(users).where(inArray(users.id, allUserIds));
+    await closeDatabase();
+  });
+
+  it('rejects self-blocking at both the service and database boundaries', async () => {
+    await expect(blockUser(ids.viewer, ids.viewer)).rejects.toThrow('cannot block yourself');
+    await expect(
+      db.insert(userBlocks).values({ blockerId: ids.viewer, blockedId: ids.viewer }).execute()
+    ).rejects.toThrow();
+  });
+
+  it('rejects a missing target and keeps unblock idempotent for missing relationships', async () => {
+    const missing = '10000000-0000-4000-8000-000000000099';
+    await expect(blockUser(ids.viewer, missing)).rejects.toThrow('User not found');
+    await expect(unblockUser(ids.viewer, missing)).resolves.toEqual({
+      blocked: false,
+      targetUserId: missing,
+    });
+  });
+
+  it('blocks idempotently and lists complete public summaries in stable order', async () => {
+    await expect(blockUser(ids.viewer, ids.blocked)).resolves.toEqual({
+      blocked: true,
+      targetUserId: ids.blocked,
+    });
+    await expect(blockUser(ids.viewer, ids.blocked)).resolves.toEqual({
+      blocked: true,
+      targetUserId: ids.blocked,
+    });
+
+    const list = await getBlockedUsers(ids.viewer);
+    expect(list).toHaveLength(1);
+    expect(list[0]).toMatchObject({
+      id: ids.blocked,
+      username: 'block-target',
+      nickname: 'Blocked target',
+      description: 'Target description',
+      certified: true,
+    });
+    expect(list[0].blockedAt).toBeInstanceOf(Date);
+  });
+
+  it('returns a blocked profile only to its blocker and hides the reverse direction', async () => {
+    await expect(
+      getViewerAwarePublicUserProfile('block-target', ids.viewer)
+    ).resolves.toMatchObject({
+      id: ids.blocked,
+      viewerHasBlocked: true,
+    });
+    await expect(getViewerAwarePublicUserProfile('block-viewer', ids.blocked)).rejects.toThrow(
+      'User not found'
+    );
+  });
+
+  it('filters public list and search before pagination', async () => {
+    const page = await findPublicRote(0, 2, {}, ids.viewer);
+    expect(page.map((note: any) => note.id)).toEqual([ids.visibleNoteOne, ids.visibleNoteTwo]);
+
+    const search = await searchPublicRotes('visibility keyword', 0, 2, {}, ids.viewer);
+    expect(search.map((note: any) => note.id)).toEqual([ids.visibleNoteOne, ids.visibleNoteTwo]);
+  });
+
+  it('hides blocked authors from user lists, detail, batch, and random queries', async () => {
+    await expect(findRoteById(ids.blockedNote, ids.viewer)).resolves.toBeNull();
+    await expect(
+      findRotesByIds([ids.blockedNote, ids.visibleNoteOne], ids.viewer)
+    ).resolves.toMatchObject([{ id: ids.visibleNoteOne }]);
+    await expect(findUserPublicRote(ids.blocked, 0, 20, {}, false, ids.viewer)).resolves.toEqual(
+      []
+    );
+    await expect(
+      searchUserPublicRotes(ids.blocked, 'keyword', 0, 20, {}, false, ids.viewer)
+    ).resolves.toEqual([]);
+
+    for (let attempt = 0; attempt < 12; attempt++) {
+      const random = await findRandomPublicRote(ids.viewer);
+      expect(random.authorid).not.toBe(ids.blocked);
+    }
+  });
+
+  it('hides named reactions from blocked accounts while preserving anonymous reactions', async () => {
+    const note = await findRoteById(ids.visibleNoteOne, ids.viewer);
+    expect(note.reactions.map((reaction: any) => reaction.type).sort()).toEqual([
+      'anonymous',
+      'visible-user',
+    ]);
+  });
+
+  it('hides blocked article and note detail in article context', async () => {
+    await expect(findArticleById(ids.blockedArticle, ids.viewer)).resolves.toBeNull();
+    await expect(getNoteByArticleId(ids.blockedArticle, ids.viewer)).resolves.toBeNull();
+    await expect(findArticleById(ids.visibleArticle, ids.viewer)).resolves.toMatchObject({
+      id: ids.visibleArticle,
+    });
+  });
+
+  it('enforces interaction rejection and both relationship directions', async () => {
+    await expect(assertUsersMayInteract(ids.viewer, ids.blocked)).rejects.toThrow('Rote not found');
+
+    expect(await getUserBlockRelationship(ids.viewer, ids.blocked)).toEqual({
+      viewerHasBlocked: true,
+      targetHasBlocked: false,
+    });
+
+    await blockUser(ids.visibleTwo, ids.viewer);
+    expect(await getUserBlockRelationship(ids.viewer, ids.visibleTwo)).toEqual({
+      viewerHasBlocked: false,
+      targetHasBlocked: true,
+    });
+    await expect(findRoteById(ids.visibleNoteTwo, ids.viewer)).resolves.toBeNull();
+    await expect(assertUsersMayInteract(ids.viewer, ids.visibleTwo)).rejects.toThrow(
+      'Rote not found'
+    );
+    await unblockUser(ids.visibleTwo, ids.viewer);
+  });
+
+  it('unblocks idempotently and immediately restores visibility', async () => {
+    await expect(unblockUser(ids.viewer, ids.blocked)).resolves.toEqual({
+      blocked: false,
+      targetUserId: ids.blocked,
+    });
+    await expect(unblockUser(ids.viewer, ids.blocked)).resolves.toEqual({
+      blocked: false,
+      targetUserId: ids.blocked,
+    });
+    expect(await hasUserBlocked(ids.viewer, ids.blocked)).toBe(false);
+    await expect(findRoteById(ids.blockedNote, ids.viewer)).resolves.toMatchObject({
+      id: ids.blockedNote,
+    });
+  });
+
+  it('cascades block relationships when either user is deleted', async () => {
+    await db.insert(users).values({
+      id: ids.cascade,
+      email: 'block-cascade@example.test',
+      username: 'block-cascade',
+    });
+    await blockUser(ids.viewer, ids.cascade);
+    expect(await hasUserBlocked(ids.viewer, ids.cascade)).toBe(true);
+
+    await db.delete(users).where(eq(users.id, ids.cascade));
+    expect(await hasUserBlocked(ids.viewer, ids.cascade)).toBe(false);
+    const dangling = await db
+      .select()
+      .from(userBlocks)
+      .where(and(eq(userBlocks.blockerId, ids.viewer), eq(userBlocks.blockedId, ids.cascade)));
+    expect(dangling).toEqual([]);
+  });
+});

--- a/server/userBlocks/userBlock.integration.test.ts
+++ b/server/userBlocks/userBlock.integration.test.ts
@@ -41,6 +41,7 @@ const ids = {
 };
 
 const allUserIds = [ids.viewer, ids.blocked, ids.visibleOne, ids.visibleTwo, ids.cascade];
+const visibilityFixtureTag = 'user-block-visibility-fixture';
 
 describe.serial('server-authoritative user blocks', () => {
   beforeAll(async () => {
@@ -91,6 +92,7 @@ describe.serial('server-authoritative user blocks', () => {
         authorid: ids.blocked,
         content: 'shared visibility keyword blocked',
         state: 'public',
+        tags: [visibilityFixtureTag],
         articleId: ids.blockedArticle,
         createdAt: new Date('2026-07-28T05:00:00Z'),
         updatedAt: new Date('2026-07-28T05:00:00Z'),
@@ -100,6 +102,7 @@ describe.serial('server-authoritative user blocks', () => {
         authorid: ids.visibleOne,
         content: 'shared visibility keyword visible one',
         state: 'public',
+        tags: [visibilityFixtureTag],
         articleId: ids.visibleArticle,
         createdAt: new Date('2026-07-28T04:00:00Z'),
         updatedAt: new Date('2026-07-28T04:00:00Z'),
@@ -109,6 +112,7 @@ describe.serial('server-authoritative user blocks', () => {
         authorid: ids.visibleTwo,
         content: 'shared visibility keyword visible two',
         state: 'public',
+        tags: [visibilityFixtureTag],
         createdAt: new Date('2026-07-28T03:00:00Z'),
         updatedAt: new Date('2026-07-28T03:00:00Z'),
       },
@@ -197,10 +201,11 @@ describe.serial('server-authoritative user blocks', () => {
   });
 
   it('filters public list and search before pagination', async () => {
-    const page = await findPublicRote(0, 2, {}, ids.viewer);
+    const filter = { tags: { hasEvery: [visibilityFixtureTag] } };
+    const page = await findPublicRote(0, 2, filter, ids.viewer);
     expect(page.map((note: any) => note.id)).toEqual([ids.visibleNoteOne, ids.visibleNoteTwo]);
 
-    const search = await searchPublicRotes('visibility keyword', 0, 2, {}, ids.viewer);
+    const search = await searchPublicRotes('visibility keyword', 0, 2, filter, ids.viewer);
     expect(search.map((note: any) => note.id)).toEqual([ids.visibleNoteOne, ids.visibleNoteTwo]);
   });
 

--- a/server/utils/dbMethods/ai/semanticSearch.ts
+++ b/server/utils/dbMethods/ai/semanticSearch.ts
@@ -4,6 +4,7 @@ import { createEmbedding, vectorToLiteral } from '../../ai/client';
 import { getGlobalConfig } from '../../config';
 import db from '../../drizzle';
 import { logAiTokenUsage } from '../aiToken';
+import { subjectIsVisibleToViewer } from '../userBlock';
 import { getStoredAiConfig, isVectorUsable } from './config';
 import {
   buildTextArraySql,
@@ -22,6 +23,7 @@ import type {
 export async function semanticSearch(params: {
   query: string;
   ownerId?: string;
+  viewerId?: string;
   scope?: 'mine' | 'public';
   sourceTypes?: AiSourceType[];
   timeRange?: NormalizedTimeRange | null;
@@ -145,6 +147,10 @@ export async function semanticSearch(params: {
       (de."sourceType" = 'article' AND a."id" IS NOT NULL)
     )
   `;
+  const viewerVisibilitySql =
+    params.scope === 'public'
+      ? subjectIsVisibleToViewer(sql`de."ownerId"`, params.viewerId)
+      : undefined;
   const permissionSql =
     params.scope === 'public'
       ? sql`
@@ -152,6 +158,7 @@ export async function semanticSearch(params: {
         AND r."authorid" = de."ownerId"
         AND r."state" = 'public'
         AND r."archived" = false
+        ${viewerVisibilitySql ? sql`AND ${viewerVisibilitySql}` : sql``}
         AND NOT EXISTS (
           SELECT 1 FROM "user_settings" us
           WHERE us."userid" = r."authorid" AND us."allowExplore" = false

--- a/server/utils/dbMethods/ai/textSearch.ts
+++ b/server/utils/dbMethods/ai/textSearch.ts
@@ -127,6 +127,7 @@ function getResultDate(result: SemanticSearchResult, dateField: RetrievalDateFie
 export async function textSearchMemory(params: {
   query: string;
   ownerId?: string;
+  viewerId?: string;
   sourceTypes?: AiSourceType[];
   timeRange?: NormalizedTimeRange | null;
   selection?: RetrievalSelection;
@@ -268,6 +269,7 @@ export async function textSearchMemory(params: {
 export async function searchMemory(params: {
   query: string;
   ownerId?: string;
+  viewerId?: string;
   scope?: 'mine' | 'public';
   sourceTypes?: AiSourceType[];
   timeRange?: NormalizedTimeRange | null;

--- a/server/utils/dbMethods/article.ts
+++ b/server/utils/dbMethods/article.ts
@@ -5,6 +5,7 @@ import { parseMarkdownMeta } from '../markdown';
 import { deleteEmbeddingsForSource, enqueueEmbeddingJob } from './ai';
 import { createRoteChange } from './change';
 import { DatabaseError } from './common';
+import { subjectIsVisibleToViewer } from './userBlock';
 
 export interface ArticleMeta {
   title: string;
@@ -199,10 +200,16 @@ export async function deleteArticle(data: {
 }
 
 // 获取单篇文章（包含作者基础字段）
-export async function findArticleById(id: string): Promise<ArticleWithAuthor | null> {
+export async function findArticleById(
+  id: string,
+  viewerId?: string
+): Promise<ArticleWithAuthor | null> {
   try {
     const article = await db.query.articles.findFirst({
-      where: (tbl, { eq }) => eq(tbl.id, id),
+      where: (tbl, { and, eq }) => {
+        const visible = subjectIsVisibleToViewer(tbl.authorId, viewerId);
+        return visible ? and(eq(tbl.id, id), visible) : eq(tbl.id, id);
+      },
       with: {
         author: {
           columns: {
@@ -278,7 +285,10 @@ export async function replaceNoteArticleRefs(
 }
 
 // 获取某个笔记下的文章引用（简略字段）
-export async function getNoteArticleCard(noteId: string): Promise<ArticleWithAuthor | null> {
+export async function getNoteArticleCard(
+  noteId: string,
+  viewerId?: string
+): Promise<ArticleWithAuthor | null> {
   try {
     const note = await db.query.rotes.findFirst({
       where: (tbl, { eq }) => eq(tbl.id, noteId),
@@ -287,7 +297,12 @@ export async function getNoteArticleCard(noteId: string): Promise<ArticleWithAut
     if (!note?.articleId) return null;
 
     const article = await db.query.articles.findFirst({
-      where: (tbl, { eq }) => eq(tbl.id, note.articleId as any),
+      where: (tbl, { and, eq }) => {
+        const visible = subjectIsVisibleToViewer(tbl.authorId, viewerId);
+        return visible
+          ? and(eq(tbl.id, note.articleId as any), visible)
+          : eq(tbl.id, note.articleId as any);
+      },
       columns: {
         id: true,
         content: true,
@@ -318,7 +333,8 @@ export async function getNoteArticleCard(noteId: string): Promise<ArticleWithAut
 // 获取某个笔记上下文中的文章全文（必须存在引用）
 export async function getArticleInNoteContext(
   articleId: string,
-  noteId: string
+  noteId: string,
+  viewerId?: string
 ): Promise<ArticleWithAuthor | null> {
   try {
     const note = await db.query.rotes.findFirst({
@@ -329,7 +345,10 @@ export async function getArticleInNoteContext(
     if (note.articleId !== articleId) return null;
 
     const article = await db.query.articles.findFirst({
-      where: (tbl, { eq }) => eq(tbl.id, articleId),
+      where: (tbl, { and, eq }) => {
+        const visible = subjectIsVisibleToViewer(tbl.authorId, viewerId);
+        return visible ? and(eq(tbl.id, articleId), visible) : eq(tbl.id, articleId);
+      },
       with: {
         author: {
           columns: {

--- a/server/utils/dbMethods/index.ts
+++ b/server/utils/dbMethods/index.ts
@@ -19,6 +19,7 @@ export * from './site';
 export * from './subscription';
 export * from './user';
 export * from './userAccount';
+export * from './userBlock';
 export * from './userData';
 export * from './userOAuth';
 export * from './userPasskey';

--- a/server/utils/dbMethods/note.ts
+++ b/server/utils/dbMethods/note.ts
@@ -5,6 +5,7 @@ import { getGlobalConfig } from '../config';
 import db from '../drizzle';
 import { createRoteChange } from './change';
 import { DatabaseError } from './common';
+import { reactionIsVisibleToViewer, subjectIsVisibleToViewer } from './userBlock';
 
 // 文章查询配置常量
 const ARTICLE_QUERY = {
@@ -26,6 +27,26 @@ const AUTHOR_QUERY = {
     emailVerified: true,
   },
 };
+
+function reactionsQuery(viewerId?: string) {
+  const query: any = {
+    with: {
+      user: {
+        columns: {
+          username: true,
+          nickname: true,
+          avatar: true,
+        },
+      },
+    },
+  };
+
+  if (viewerId) {
+    query.where = (reactionTable: any) => reactionIsVisibleToViewer(reactionTable.userid, viewerId);
+  }
+
+  return query;
+}
 
 // 笔记相关方法
 export async function createRote(data: any): Promise<any> {
@@ -110,17 +131,7 @@ export async function createRote(data: any): Promise<any> {
           linkPreviews: {
             orderBy: (linkPreviews, { asc }) => [asc(linkPreviews.createdAt)],
           },
-          reactions: {
-            with: {
-              user: {
-                columns: {
-                  username: true,
-                  nickname: true,
-                  avatar: true,
-                },
-              },
-            },
-          },
+          reactions: reactionsQuery(data.authorid),
         },
       });
     } catch (_queryError) {
@@ -146,10 +157,13 @@ export async function createRote(data: any): Promise<any> {
   }
 }
 
-export async function findRoteById(id: string): Promise<any> {
+export async function findRoteById(id: string, viewerId?: string): Promise<any> {
   try {
     const rote = await db.query.rotes.findFirst({
-      where: (rotes, { eq }) => eq(rotes.id, id),
+      where: (roteTable, { and, eq }) => {
+        const visible = subjectIsVisibleToViewer(roteTable.authorid, viewerId);
+        return visible ? and(eq(roteTable.id, id), visible) : eq(roteTable.id, id);
+      },
       with: {
         author: AUTHOR_QUERY,
         attachments: {
@@ -161,17 +175,7 @@ export async function findRoteById(id: string): Promise<any> {
         linkPreviews: {
           orderBy: (linkPreviews, { asc }) => [asc(linkPreviews.createdAt)],
         },
-        reactions: {
-          with: {
-            user: {
-              columns: {
-                username: true,
-                nickname: true,
-                avatar: true,
-              },
-            },
-          },
-        },
+        reactions: reactionsQuery(viewerId),
         article: ARTICLE_QUERY,
       },
     });
@@ -181,14 +185,17 @@ export async function findRoteById(id: string): Promise<any> {
   }
 }
 
-export async function findRotesByIds(ids: string[]): Promise<any[]> {
+export async function findRotesByIds(ids: string[], viewerId?: string): Promise<any[]> {
   try {
     if (!ids || ids.length === 0) {
       return [];
     }
 
     const rotesList = await db.query.rotes.findMany({
-      where: (rotes, { inArray }) => inArray(rotes.id, ids),
+      where: (roteTable, { and, inArray }) => {
+        const visible = subjectIsVisibleToViewer(roteTable.authorid, viewerId);
+        return visible ? and(inArray(roteTable.id, ids), visible) : inArray(roteTable.id, ids);
+      },
       with: {
         author: AUTHOR_QUERY,
         attachments: {
@@ -200,17 +207,7 @@ export async function findRotesByIds(ids: string[]): Promise<any[]> {
         linkPreviews: {
           orderBy: (linkPreviews, { asc }) => [asc(linkPreviews.createdAt)],
         },
-        reactions: {
-          with: {
-            user: {
-              columns: {
-                username: true,
-                nickname: true,
-                avatar: true,
-              },
-            },
-          },
-        },
+        reactions: reactionsQuery(viewerId),
         article: ARTICLE_QUERY,
       },
     });
@@ -280,17 +277,7 @@ export async function editRoteWithState(data: any): Promise<EditRoteWithStateRes
             asc(attachments.createdAt),
           ],
         },
-        reactions: {
-          with: {
-            user: {
-              columns: {
-                username: true,
-                nickname: true,
-                avatar: true,
-              },
-            },
-          },
-        },
+        reactions: reactionsQuery(data.authorid),
         article: ARTICLE_QUERY,
       },
     });
@@ -351,7 +338,8 @@ function buildWhereConditions(
   authorid: string | undefined,
   archived: any,
   state: string | undefined,
-  filter: any
+  filter: any,
+  viewerId?: string
 ) {
   return (rotes: any, { eq, and, sql }: any) => {
     const conditions = [];
@@ -366,6 +354,11 @@ function buildWhereConditions(
 
     if (state) {
       conditions.push(eq(rotes.state, state));
+    }
+
+    const visible = subjectIsVisibleToViewer(rotes.authorid, viewerId);
+    if (visible) {
+      conditions.push(visible);
     }
 
     // 处理额外的过滤条件
@@ -434,17 +427,7 @@ export async function findMyRote(
         linkPreviews: {
           orderBy: (linkPreviews: any, { asc }: any) => [asc(linkPreviews.createdAt)],
         },
-        reactions: {
-          with: {
-            user: {
-              columns: {
-                username: true,
-                nickname: true,
-                avatar: true,
-              },
-            },
-          },
-        },
+        reactions: reactionsQuery(authorid),
         article: ARTICLE_QUERY,
       },
     };
@@ -461,10 +444,11 @@ export async function findUserPublicRote(
   skip: number | undefined,
   limit: number | undefined,
   filter: any,
-  archived: any
+  archived: any,
+  viewerId?: string
 ): Promise<any> {
   try {
-    const whereCondition = buildWhereConditions(userid, archived, 'public', filter);
+    const whereCondition = buildWhereConditions(userid, archived, 'public', filter, viewerId);
 
     const rotesList = await db.query.rotes.findMany({
       where: whereCondition,
@@ -477,17 +461,7 @@ export async function findUserPublicRote(
         linkPreviews: {
           orderBy: (linkPreviews, { asc }) => [asc(linkPreviews.createdAt)],
         },
-        reactions: {
-          with: {
-            user: {
-              columns: {
-                username: true,
-                nickname: true,
-                avatar: true,
-              },
-            },
-          },
-        },
+        reactions: reactionsQuery(viewerId),
         article: ARTICLE_QUERY,
       },
     });
@@ -500,7 +474,8 @@ export async function findUserPublicRote(
 export async function findPublicRote(
   skip: number | undefined,
   limit: number | undefined,
-  filter: any
+  filter: any,
+  viewerId?: string
 ): Promise<any> {
   try {
     const securityConfig = getGlobalConfig<SecurityConfig>('security');
@@ -511,6 +486,10 @@ export async function findPublicRote(
     // 仅公开且未归档的笔记
     conditions.push(eq(rotes.state, 'public'));
     conditions.push(eq(rotes.archived, false));
+    const visible = subjectIsVisibleToViewer(rotes.authorid, viewerId);
+    if (visible) {
+      conditions.push(visible);
+    }
 
     // 处理额外的过滤条件（与 buildWhereConditions 中逻辑保持一致）
     if (filter && typeof filter === 'object') {
@@ -577,7 +556,7 @@ export async function findPublicRote(
     }
 
     const ids = rows.map((row) => row.id);
-    const rotesList = await findRotesByIds(ids);
+    const rotesList = await findRotesByIds(ids, viewerId);
 
     // 按照查询到的 ID 顺序返回结果，保持与分页顺序一致
     const roteMap = new Map<string, any>(rotesList.map((rote) => [rote.id, rote]));
@@ -612,17 +591,7 @@ export async function findMyRandomRote(authorid: string): Promise<any> {
         linkPreviews: {
           orderBy: (linkPreviews, { asc }) => [asc(linkPreviews.createdAt)],
         },
-        reactions: {
-          with: {
-            user: {
-              columns: {
-                username: true,
-                nickname: true,
-                avatar: true,
-              },
-            },
-          },
-        },
+        reactions: reactionsQuery(authorid),
         article: ARTICLE_QUERY,
       },
     });
@@ -633,7 +602,7 @@ export async function findMyRandomRote(authorid: string): Promise<any> {
   }
 }
 
-export async function findRandomPublicRote(): Promise<any> {
+export async function findRandomPublicRote(viewerId?: string): Promise<any> {
   try {
     const securityConfig = getGlobalConfig<SecurityConfig>('security');
     const requireVerifiedEmailForExplore = securityConfig?.requireVerifiedEmailForExplore === true;
@@ -643,6 +612,10 @@ export async function findRandomPublicRote(): Promise<any> {
     // 仅公开且未归档的笔记
     conditions.push(eq(rotes.state, 'public'));
     conditions.push(eq(rotes.archived, false));
+    const visible = subjectIsVisibleToViewer(rotes.authorid, viewerId);
+    if (visible) {
+      conditions.push(visible);
+    }
 
     // 探索页策略：用户设置 + 邮箱验证（与 findPublicRote 保持一致）
     conditions.push(
@@ -677,7 +650,7 @@ export async function findRandomPublicRote(): Promise<any> {
       throw new DatabaseError('No public rotes found');
     }
 
-    const [rote] = await findRotesByIds([row.id]);
+    const [rote] = await findRotesByIds([row.id], viewerId);
     if (!rote) {
       throw new DatabaseError('No public rotes found');
     }
@@ -697,7 +670,8 @@ function buildSearchConditions(
   authorid: string | undefined,
   archived: any,
   state: string | undefined,
-  filter: any
+  filter: any,
+  viewerId?: string
 ) {
   return (rotes: any, { eq, and, or, ilike, sql }: any) => {
     // ilike() 使用参数化查询，会自动处理转义，所以使用原始 keyword
@@ -714,6 +688,8 @@ function buildSearchConditions(
     if (authorid) conditions.push(eq(rotes.authorid, authorid));
     if (archived !== undefined) conditions.push(eq(rotes.archived, archived));
     if (state) conditions.push(eq(rotes.state, state));
+    const visible = subjectIsVisibleToViewer(rotes.authorid, viewerId);
+    if (visible) conditions.push(visible);
 
     // 处理额外的过滤条件
     if (filter && typeof filter === 'object') {
@@ -777,17 +753,7 @@ export async function searchMyRotes(
         linkPreviews: {
           orderBy: (linkPreviews, { asc }) => [asc(linkPreviews.createdAt)],
         },
-        reactions: {
-          with: {
-            user: {
-              columns: {
-                username: true,
-                nickname: true,
-                avatar: true,
-              },
-            },
-          },
-        },
+        reactions: reactionsQuery(authorid),
         article: ARTICLE_QUERY,
       },
     });
@@ -801,10 +767,18 @@ export async function searchPublicRotes(
   keyword: string,
   skip: number | undefined,
   limit: number | undefined,
-  filter: any = {}
+  filter: any = {},
+  viewerId?: string
 ): Promise<any> {
   try {
-    const whereCondition = buildSearchConditions(keyword, undefined, false, 'public', filter);
+    const whereCondition = buildSearchConditions(
+      keyword,
+      undefined,
+      false,
+      'public',
+      filter,
+      viewerId
+    );
 
     const rotesList = await db.query.rotes.findMany({
       where: whereCondition,
@@ -817,17 +791,7 @@ export async function searchPublicRotes(
         linkPreviews: {
           orderBy: (linkPreviews, { asc }) => [asc(linkPreviews.createdAt)],
         },
-        reactions: {
-          with: {
-            user: {
-              columns: {
-                username: true,
-                nickname: true,
-                avatar: true,
-              },
-            },
-          },
-        },
+        reactions: reactionsQuery(viewerId),
         article: ARTICLE_QUERY,
       },
     });
@@ -843,10 +807,18 @@ export async function searchUserPublicRotes(
   skip: number | undefined,
   limit: number | undefined,
   filter: any = {},
-  archived: any = false
+  archived: any = false,
+  viewerId?: string
 ): Promise<any> {
   try {
-    const whereCondition = buildSearchConditions(keyword, userid, archived, 'public', filter);
+    const whereCondition = buildSearchConditions(
+      keyword,
+      userid,
+      archived,
+      'public',
+      filter,
+      viewerId
+    );
 
     const rotesList = await db.query.rotes.findMany({
       where: whereCondition,
@@ -859,17 +831,7 @@ export async function searchUserPublicRotes(
         linkPreviews: {
           orderBy: (linkPreviews, { asc }) => [asc(linkPreviews.createdAt)],
         },
-        reactions: {
-          with: {
-            user: {
-              columns: {
-                username: true,
-                nickname: true,
-                avatar: true,
-              },
-            },
-          },
-        },
+        reactions: reactionsQuery(viewerId),
         article: ARTICLE_QUERY,
       },
     });
@@ -940,12 +902,17 @@ export async function getAllPublicRssData(limit = 20): Promise<{ notes: any[] }>
 }
 
 // 根据文章ID查找关联的笔记（用于文章公开访问权限检查）
-export async function getNoteByArticleId(articleId: string): Promise<any> {
+export async function getNoteByArticleId(articleId: string, viewerId?: string): Promise<any> {
   try {
     if (!articleId) return null;
     // 查找 articleId 匹配的笔记，优先返回公开笔记（不过滤归档状态）
     const note = await db.query.rotes.findFirst({
-      where: (rotes, { eq }) => eq(rotes.articleId, articleId),
+      where: (roteTable, { and, eq }) => {
+        const visible = subjectIsVisibleToViewer(roteTable.authorid, viewerId);
+        return visible
+          ? and(eq(roteTable.articleId, articleId), visible)
+          : eq(roteTable.articleId, articleId);
+      },
       // 优先返回公开笔记，避免私有笔记先被匹配导致误拒访问
       orderBy: (rotes, { desc, sql }) => [
         desc(sql`CASE WHEN ${rotes.state} = 'public' THEN 1 ELSE 0 END`),
@@ -961,17 +928,7 @@ export async function getNoteByArticleId(articleId: string): Promise<any> {
         linkPreviews: {
           orderBy: (linkPreviews, { asc }) => [asc(linkPreviews.createdAt)],
         },
-        reactions: {
-          with: {
-            user: {
-              columns: {
-                username: true,
-                nickname: true,
-                avatar: true,
-              },
-            },
-          },
-        },
+        reactions: reactionsQuery(viewerId),
         article: ARTICLE_QUERY,
       },
     });

--- a/server/utils/dbMethods/userBlock.ts
+++ b/server/utils/dbMethods/userBlock.ts
@@ -1,0 +1,149 @@
+import { and, asc, desc, eq, or, sql, type SQL, type SQLWrapper } from 'drizzle-orm';
+import { userBlocks, users } from '../../drizzle/schema';
+import db from '../drizzle';
+import { DatabaseError } from './common';
+
+export interface UserBlockRelationship {
+  viewerHasBlocked: boolean;
+  targetHasBlocked: boolean;
+}
+
+export interface BlockedUserSummary {
+  id: string;
+  username: string;
+  nickname: string | null;
+  avatar: string | null;
+  description: string | null;
+  certified: boolean;
+  blockedAt: Date;
+}
+
+export async function createUserBlock(blockerId: string, blockedId: string): Promise<void> {
+  try {
+    await db
+      .insert(userBlocks)
+      .values({ blockerId, blockedId })
+      .onConflictDoNothing({
+        target: [userBlocks.blockerId, userBlocks.blockedId],
+      });
+  } catch (error) {
+    throw new DatabaseError('Failed to block user', error);
+  }
+}
+
+export async function deleteUserBlock(blockerId: string, blockedId: string): Promise<void> {
+  try {
+    await db
+      .delete(userBlocks)
+      .where(and(eq(userBlocks.blockerId, blockerId), eq(userBlocks.blockedId, blockedId)));
+  } catch (error) {
+    throw new DatabaseError('Failed to unblock user', error);
+  }
+}
+
+export async function listUserBlocks(blockerId: string): Promise<BlockedUserSummary[]> {
+  try {
+    return await db
+      .select({
+        id: users.id,
+        username: users.username,
+        nickname: users.nickname,
+        avatar: users.avatar,
+        description: users.description,
+        certified: users.emailVerified,
+        blockedAt: userBlocks.createdAt,
+      })
+      .from(userBlocks)
+      .innerJoin(users, eq(users.id, userBlocks.blockedId))
+      .where(eq(userBlocks.blockerId, blockerId))
+      .orderBy(desc(userBlocks.createdAt), asc(userBlocks.blockedId));
+  } catch (error) {
+    throw new DatabaseError('Failed to list blocked users', error);
+  }
+}
+
+export async function hasUserBlocked(blockerId: string, blockedId: string): Promise<boolean> {
+  try {
+    const [relationship] = await db
+      .select({ blockerId: userBlocks.blockerId })
+      .from(userBlocks)
+      .where(and(eq(userBlocks.blockerId, blockerId), eq(userBlocks.blockedId, blockedId)))
+      .limit(1);
+    return Boolean(relationship);
+  } catch (error) {
+    throw new DatabaseError('Failed to check user block relationship', error);
+  }
+}
+
+export async function getUserBlockRelationship(
+  viewerId: string,
+  targetId: string
+): Promise<UserBlockRelationship> {
+  try {
+    const relationships = await db
+      .select({
+        blockerId: userBlocks.blockerId,
+        blockedId: userBlocks.blockedId,
+      })
+      .from(userBlocks)
+      .where(
+        or(
+          and(eq(userBlocks.blockerId, viewerId), eq(userBlocks.blockedId, targetId)),
+          and(eq(userBlocks.blockerId, targetId), eq(userBlocks.blockedId, viewerId))
+        )
+      );
+
+    return {
+      viewerHasBlocked: relationships.some(
+        ({ blockerId, blockedId }) => blockerId === viewerId && blockedId === targetId
+      ),
+      targetHasBlocked: relationships.some(
+        ({ blockerId, blockedId }) => blockerId === targetId && blockedId === viewerId
+      ),
+    };
+  } catch (error) {
+    throw new DatabaseError('Failed to get user block relationship', error);
+  }
+}
+
+export async function hasBlockInEitherDirection(
+  userId: string,
+  targetId: string
+): Promise<boolean> {
+  const relationship = await getUserBlockRelationship(userId, targetId);
+  return relationship.viewerHasBlocked || relationship.targetHasBlocked;
+}
+
+/**
+ * SQL predicate used by viewer-aware content queries. It must be included in
+ * the database WHERE clause before offset/limit are applied.
+ */
+export function subjectIsVisibleToViewer(
+  subjectId: SQLWrapper,
+  viewerId?: string
+): SQL | undefined {
+  if (!viewerId) return undefined;
+
+  return sql`NOT EXISTS (
+    SELECT 1
+    FROM "user_blocks" AS viewer_blocks
+    WHERE (
+      (viewer_blocks."blockerId" = ${viewerId} AND viewer_blocks."blockedId" = ${subjectId})
+      OR
+      (viewer_blocks."blockerId" = ${subjectId} AND viewer_blocks."blockedId" = ${viewerId})
+    )
+  )`;
+}
+
+/**
+ * Anonymous reactions stay public. Named reactions are hidden when the viewer
+ * and reacting account have a block in either direction.
+ */
+export function reactionIsVisibleToViewer(
+  reactionUserId: SQLWrapper,
+  viewerId?: string
+): SQL | undefined {
+  if (!viewerId) return undefined;
+  const userVisible = subjectIsVisibleToViewer(reactionUserId, viewerId);
+  return sql`(${reactionUserId} IS NULL OR ${userVisible})`;
+}

--- a/web/src/components/rote/RoteActionsMenu.test.tsx
+++ b/web/src/components/rote/RoteActionsMenu.test.tsx
@@ -1,0 +1,63 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Rote } from '@/types/main';
+
+import RoteActionsMenu from './RoteActionsMenu';
+
+vi.mock('@/hooks/useNoteExport', () => ({
+  useNoteExport: () => ({
+    exporting: false,
+    handleExportImage: vi.fn(),
+  }),
+}));
+
+const publicNote: Rote = {
+  id: 'note-id',
+  title: 'Public note',
+  tags: [],
+  content: 'Visible content',
+  state: 'public',
+  archived: false,
+  authorid: 'target-id',
+  pin: false,
+  createdAt: '2026-07-28T00:00:00.000Z',
+  updatedAt: '2026-07-28T00:00:00.000Z',
+  author: {
+    username: 'target',
+    nickname: 'Target',
+    avatar: '',
+  },
+  attachments: [],
+  reactions: [],
+};
+
+describe('RoteActionsMenu', () => {
+  it('shows block but not owner actions for another user public note', async () => {
+    render(
+      <MemoryRouter>
+        <RoteActionsMenu
+          rote={publicNote}
+          isOwner={false}
+          blockTarget={{
+            displayName: 'Target',
+            id: 'target-id',
+          }}
+          onEdit={vi.fn()}
+          onShare={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'actions' }), {
+      button: 0,
+      ctrlKey: false,
+    });
+
+    expect(await screen.findByRole('menuitem', { name: 'block' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'details' })).toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: 'edit' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: 'delete' })).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/rote/RoteActionsMenu.tsx
+++ b/web/src/components/rote/RoteActionsMenu.tsx
@@ -10,6 +10,7 @@ import {
   Save,
   Share,
   Trash2,
+  UserRoundX,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
@@ -23,6 +24,8 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import BlockUserConfirmDialog from '@/features/user-blocks/BlockUserConfirmDialog';
+import { useUserBlockAction } from '@/features/user-blocks/useUserBlockAction';
 import { useNoteExport } from '@/hooks/useNoteExport';
 import type { Attachment, Rote, Rotes } from '@/types/main';
 import { del, put } from '@/utils/api';
@@ -35,6 +38,13 @@ interface RoteActionsMenuProps {
   onEdit: () => void;
   onShare: () => void;
   onNoticeCreate?: () => void;
+  isOwner?: boolean;
+  blockTarget?: {
+    blocked?: boolean;
+    displayName: string;
+    id: string;
+  };
+  onBlockChanged?: (blocked: boolean) => void | Promise<void>;
 }
 
 export default function RoteActionsMenu({
@@ -44,11 +54,22 @@ export default function RoteActionsMenu({
   onEdit,
   onShare,
   onNoticeCreate,
+  isOwner = true,
+  blockTarget,
+  onBlockChanged,
 }: RoteActionsMenuProps) {
   const { t } = useTranslation('translation', {
     keyPrefix: 'components.roteItem',
   });
+  const { t: tUserBlocks } = useTranslation('translation', {
+    keyPrefix: 'userBlocks',
+  });
   const { exporting, handleExportImage } = useNoteExport();
+  const blockAction = useUserBlockAction({
+    blocked: blockTarget?.blocked === true,
+    targetUserId: blockTarget?.id || '',
+    onChanged: onBlockChanged,
+  });
 
   /**
    * Rote 操作相关的辅助函数集合
@@ -149,117 +170,148 @@ export default function RoteActionsMenu({
   }
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          size="icon"
-          variant="ghost"
-          aria-label={t('actions', 'Actions')}
-          title={t('actions', 'Actions')}
-          className="hover:bg-background/80 bg-background fixed top-2 right-2 z-10 size-8 rounded-md p-2 duration-300"
-        >
-          <Ellipsis className="size-4" />
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="z-50 min-w-[180px]">
-        <DropdownMenuItem asChild>
-          <Link
-            className="bg-foreground/3 flex cursor-pointer items-center gap-2 rounded-md px-2 py-1 font-semibold"
-            to={`/rote/${rote.id}`}
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            size="icon"
+            variant="ghost"
+            aria-label={t('actions', 'Actions')}
+            title={t('actions', 'Actions')}
+            className="hover:bg-background/80 ml-auto size-8 shrink-0 rounded-md p-2 duration-300"
           >
-            <Layers className="size-4" />
-            {t('details')}
-          </Link>
-        </DropdownMenuItem>
-
-        {onNoticeCreate && (
-          <DropdownMenuItem onSelect={onNoticeCreate}>
-            <Bell className="size-4" />
-            {t('review')}
+            <Ellipsis className="size-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="z-50 min-w-[180px]">
+          <DropdownMenuItem asChild>
+            <Link
+              className="bg-foreground/3 flex cursor-pointer items-center gap-2 rounded-md px-2 py-1 font-semibold"
+              to={`/rote/${rote.id}`}
+            >
+              <Layers className="size-4" />
+              {t('details')}
+            </Link>
           </DropdownMenuItem>
-        )}
 
-        <DropdownMenuItem onSelect={editRotePin}>
-          {rote.pin ? <PinOff className="size-4" /> : <PinIcon className="size-4" />}
-          {rote.pin ? t('unpinned') : t('pinned')}
-        </DropdownMenuItem>
+          {isOwner && (
+            <>
+              {onNoticeCreate && (
+                <DropdownMenuItem onSelect={onNoticeCreate}>
+                  <Bell className="size-4" />
+                  {t('review')}
+                </DropdownMenuItem>
+              )}
 
-        <DropdownMenuItem onSelect={onEdit}>
-          <Edit3 className="size-4" />
-          {t('edit')}
-        </DropdownMenuItem>
+              <DropdownMenuItem onSelect={editRotePin}>
+                {rote.pin ? <PinOff className="size-4" /> : <PinIcon className="size-4" />}
+                {rote.pin ? t('unpinned') : t('pinned')}
+              </DropdownMenuItem>
 
-        <DropdownMenuItem onSelect={editRoteArchived}>
-          <Save className="size-4" />
-          {rote.archived ? t('unarchive') : t('archive')}
-        </DropdownMenuItem>
+              <DropdownMenuItem onSelect={onEdit}>
+                <Edit3 className="size-4" />
+                {t('edit')}
+              </DropdownMenuItem>
 
-        <DropdownMenuItem
-          onSelect={() => {
-            if (rote.state === 'private') {
-              toast(t('messages.privateNoteCannotShare'), {
-                description: t('messages.privateNoteShareDescription'),
-                action: {
-                  label: t('messages.setPublicAndShare'),
-                  onClick: () => {
-                    roteHelpers.executeRoteAction(
-                      () =>
-                        put('/notes/' + rote.id, {
-                          id: rote.id,
-                          authorid: rote.authorid,
-                          state: 'public',
-                        }),
-                      (res) => {
-                        roteHelpers.updateLocalRoteEdit(res.data);
-                        onShare();
+              <DropdownMenuItem onSelect={editRoteArchived}>
+                <Save className="size-4" />
+                {rote.archived ? t('unarchive') : t('archive')}
+              </DropdownMenuItem>
+
+              <DropdownMenuItem
+                onSelect={() => {
+                  if (rote.state === 'private') {
+                    toast(t('messages.privateNoteCannotShare'), {
+                      description: t('messages.privateNoteShareDescription'),
+                      action: {
+                        label: t('messages.setPublicAndShare'),
+                        onClick: () => {
+                          roteHelpers.executeRoteAction(
+                            () =>
+                              put('/notes/' + rote.id, {
+                                id: rote.id,
+                                authorid: rote.authorid,
+                                state: 'public',
+                              }),
+                            (res) => {
+                              roteHelpers.updateLocalRoteEdit(res.data);
+                              onShare();
+                            },
+                            t('messages.editing'),
+                            t('messages.editSuccess'),
+                            t('messages.editFailed')
+                          );
+                        },
                       },
-                      t('messages.editing'),
-                      t('messages.editSuccess'),
-                      t('messages.editFailed')
-                    );
-                  },
-                },
-              });
-              return;
-            }
-            onShare();
-          }}
-        >
-          <Share className="size-4" />
-          {t('share')}
-        </DropdownMenuItem>
+                    });
+                    return;
+                  }
+                  onShare();
+                }}
+              >
+                <Share className="size-4" />
+                {t('share')}
+              </DropdownMenuItem>
 
-        <DropdownMenuItem
-          onSelect={() => {
-            const imageAttachments = rote.attachments
-              ?.filter((a): a is Attachment => !(a instanceof File))
-              .sort((a, b) => (a.sortIndex > b.sortIndex ? 1 : -1));
-            let articleTitle: string | undefined;
-            if (rote.article?.content) {
-              const match = rote.article.content.match(/^\s*#\s+([^\n]+)/);
-              articleTitle = match ? match[1].trim() : undefined;
-            }
-            handleExportImage({
-              title: rote.title,
-              content: rote.content,
-              noteId: rote.id,
-              author: rote.author,
-              tags: rote.tags,
-              attachments: imageAttachments,
-              articleTitle,
-            });
-          }}
-          disabled={exporting}
-        >
-          {exporting ? <Loader className="size-4 animate-spin" /> : <Image className="size-4" />}
-          {exporting ? t('exporting') : t('exportImage')}
-        </DropdownMenuItem>
+              <DropdownMenuItem
+                onSelect={() => {
+                  const imageAttachments = rote.attachments
+                    ?.filter((a): a is Attachment => !(a instanceof File))
+                    .sort((a, b) => (a.sortIndex > b.sortIndex ? 1 : -1));
+                  let articleTitle: string | undefined;
+                  if (rote.article?.content) {
+                    const match = rote.article.content.match(/^\s*#\s+([^\n]+)/);
+                    articleTitle = match ? match[1].trim() : undefined;
+                  }
+                  handleExportImage({
+                    title: rote.title,
+                    content: rote.content,
+                    noteId: rote.id,
+                    author: rote.author,
+                    tags: rote.tags,
+                    attachments: imageAttachments,
+                    articleTitle,
+                  });
+                }}
+                disabled={exporting}
+              >
+                {exporting ? (
+                  <Loader className="size-4 animate-spin" />
+                ) : (
+                  <Image className="size-4" />
+                )}
+                {exporting ? t('exporting') : t('exportImage')}
+              </DropdownMenuItem>
 
-        <DropdownMenuItem onSelect={deleteRoteFn} className="text-red-500 focus:text-red-500">
-          <Trash2 className="size-4 text-red-500" />
-          {t('delete')}
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+              <DropdownMenuItem onSelect={deleteRoteFn} className="text-red-500 focus:text-red-500">
+                <Trash2 className="size-4 text-red-500" />
+                {t('delete')}
+              </DropdownMenuItem>
+            </>
+          )}
+
+          {blockTarget && (
+            <DropdownMenuItem
+              variant="destructive"
+              disabled={blockAction.isMutating}
+              onSelect={blockAction.requestBlock}
+            >
+              <UserRoundX className="size-4" />
+              {tUserBlocks('block')}
+            </DropdownMenuItem>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {blockTarget && (
+        <BlockUserConfirmDialog
+          open={blockAction.confirmOpen}
+          isMutating={blockAction.isMutating}
+          targetDisplayName={blockTarget.displayName}
+          onOpenChange={blockAction.setConfirmOpen}
+          onConfirm={blockAction.confirmBlock}
+        />
+      )}
+    </>
   );
 }

--- a/web/src/components/rote/randomRote.tsx
+++ b/web/src/components/rote/randomRote.tsx
@@ -1,5 +1,6 @@
 import LoadingPlaceholder from '@/components/others/LoadingPlaceholder';
 import RoteItem from '@/components/rote/roteItem';
+import { viewerAwareCacheKey } from '@/features/user-blocks/viewerCacheScope';
 import { profileAtom } from '@/state/profile';
 import { type Rote } from '@/types/main';
 import { get } from '@/utils/api';
@@ -21,7 +22,9 @@ export default function RandomRote() {
     isValidating,
     mutate,
     error,
-  } = useAPIGet<Rote>('randomRote', () => get('/notes/random').then((res) => res.data));
+  } = useAPIGet<Rote>(viewerAwareCacheKey('randomRote', profile?.id), () =>
+    get('/notes/random').then((res) => res.data)
+  );
 
   return isLoading ? (
     <LoadingPlaceholder size={6} className="py-8" error={error} />

--- a/web/src/components/rote/roteItem.tsx
+++ b/web/src/components/rote/roteItem.tsx
@@ -47,6 +47,7 @@ function RoteItem({
   showAvatar = true,
   enableContentCollapse = true,
   showReactions = true,
+  showAuthorActions = false,
 }: {
   rote: Rote;
   mutate?: SWRInfiniteKeyedMutator<Rotes>;
@@ -54,6 +55,7 @@ function RoteItem({
   showAvatar?: boolean;
   enableContentCollapse?: boolean;
   showReactions?: boolean;
+  showAuthorActions?: boolean;
 }) {
   const { t } = useTranslation('translation', {
     keyPrefix: 'components.roteItem',
@@ -65,11 +67,33 @@ function RoteItem({
   const profile = useAtomValue(profileAtom);
 
   const isOwner = profile?.username === rote.author.username;
+  const blockTarget =
+    showAuthorActions && profile?.id && !isOwner && rote.authorid
+      ? {
+          displayName: rote.author.nickname || rote.author.username,
+          id: rote.authorid,
+        }
+      : undefined;
 
   const onEdit = useCallback(() => {
     setRote(rote);
     setModalType('edit');
   }, [rote]);
+
+  const onBlockChanged = useCallback(
+    async (blocked: boolean) => {
+      if (!blocked) return;
+
+      if (mutate) {
+        await mutate();
+      }
+
+      if (mutateSingle) {
+        await mutateSingle();
+      }
+    },
+    [mutate, mutateSingle]
+  );
 
   return (
     <div
@@ -175,11 +199,14 @@ function RoteItem({
             )}
           </span>
 
-          {isOwner && inView && (mutate || mutateSingle) && (
+          {inView && ((isOwner && (mutate || mutateSingle)) || blockTarget) && (
             <RoteActionsMenu
               rote={rote}
               mutate={mutate}
               mutateSingle={mutateSingle}
+              isOwner={isOwner}
+              blockTarget={blockTarget}
+              onBlockChanged={onBlockChanged}
               onEdit={onEdit}
               onShare={() => {
                 const url = `${window.location.origin}/rote/${rote.id}`;

--- a/web/src/components/rote/roteList.tsx
+++ b/web/src/components/rote/roteList.tsx
@@ -17,6 +17,7 @@ function RoteList({
   isItemMuted,
   isValidating,
   itemActions,
+  showAuthorActions = false,
 }: {
   data?: Rotes[];
   loadMore?: () => void;
@@ -25,6 +26,7 @@ function RoteList({
   isItemMuted?: (rote: Rote, index: number) => boolean;
   isValidating?: boolean;
   itemActions?: (rote: Rote, index: number) => ReactNode;
+  showAuthorActions?: boolean;
 }) {
   const { t } = useTranslation('translation', {
     keyPrefix: 'components.roteList',
@@ -91,7 +93,14 @@ function RoteList({
     rotes.map((item: Rote, index) => {
       const actions = itemActions?.(item, index);
       const muted = isItemMuted?.(item, index);
-      const roteItem = <RoteItem rote={item} mutate={mutate} showReactions={!isStaticList} />;
+      const roteItem = (
+        <RoteItem
+          rote={item}
+          mutate={mutate}
+          showReactions={!isStaticList}
+          showAuthorActions={showAuthorActions}
+        />
+      );
 
       if (!actions && !muted) {
         return (
@@ -100,6 +109,7 @@ function RoteList({
             key={item.id || index}
             mutate={mutate}
             showReactions={!isStaticList}
+            showAuthorActions={showAuthorActions}
           />
         );
       }

--- a/web/src/features/user-blocks/BlockUserButton.test.tsx
+++ b/web/src/features/user-blocks/BlockUserButton.test.tsx
@@ -1,0 +1,108 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { toast } from 'sonner';
+import BlockUserButton from './BlockUserButton';
+import { blockUser, unblockUser } from './api';
+import { refreshBlockAffectedCaches } from './cache';
+
+vi.mock('./api', () => ({
+  blockUser: vi.fn(),
+  unblockUser: vi.fn(),
+}));
+
+vi.mock('./cache', async (importOriginal) => {
+  const original = await importOriginal<typeof import('./cache')>();
+  return {
+    ...original,
+    refreshBlockAffectedCaches: vi.fn(),
+  };
+});
+
+describe('BlockUserButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(refreshBlockAffectedCaches).mockResolvedValue();
+  });
+
+  it('requires confirmation before blocking and refreshes affected caches on success', async () => {
+    vi.mocked(blockUser).mockResolvedValue({
+      blocked: true,
+      targetUserId: 'target-id',
+    });
+    const onChanged = vi.fn();
+
+    render(
+      <BlockUserButton
+        blocked={false}
+        targetDisplayName="Target"
+        targetUserId="target-id"
+        onChanged={onChanged}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'blockAria' }));
+    expect(blockUser).not.toHaveBeenCalled();
+    expect(screen.getByText('confirmDescription')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'confirm' }));
+
+    await waitFor(() => expect(blockUser).toHaveBeenCalledWith('target-id'));
+    expect(onChanged).toHaveBeenCalledWith(true);
+    expect(refreshBlockAffectedCaches).toHaveBeenCalledTimes(1);
+    expect(toast.success).toHaveBeenCalledWith('blockSuccess');
+    expect(screen.getByRole('button', { name: 'unblockAria' })).toBeInTheDocument();
+  });
+
+  it('rolls the optimistic state back when the server mutation fails', async () => {
+    vi.mocked(blockUser).mockRejectedValue(new Error('offline'));
+
+    render(<BlockUserButton blocked={false} targetDisplayName="Target" targetUserId="target-id" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'blockAria' }));
+    fireEvent.click(screen.getByRole('button', { name: 'confirm' }));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    expect(screen.getByRole('button', { name: 'blockAria' })).toBeInTheDocument();
+    expect(refreshBlockAffectedCaches).not.toHaveBeenCalled();
+  });
+
+  it('keeps the server-confirmed state when cache refresh fails', async () => {
+    vi.mocked(blockUser).mockResolvedValue({
+      blocked: true,
+      targetUserId: 'target-id',
+    });
+    vi.mocked(refreshBlockAffectedCaches).mockRejectedValue(new Error('cache unavailable'));
+
+    render(<BlockUserButton blocked={false} targetDisplayName="Target" targetUserId="target-id" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'blockAria' }));
+    fireEvent.click(screen.getByRole('button', { name: 'confirm' }));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('refreshFailed'));
+    expect(toast.success).toHaveBeenCalledWith('blockSuccess');
+    expect(screen.getByRole('button', { name: 'unblockAria' })).toBeInTheDocument();
+  });
+
+  it('unblocks without a second confirmation', async () => {
+    vi.mocked(unblockUser).mockResolvedValue({
+      blocked: false,
+      targetUserId: 'target-id',
+    });
+    const onChanged = vi.fn();
+
+    render(
+      <BlockUserButton
+        blocked
+        targetDisplayName="Target"
+        targetUserId="target-id"
+        onChanged={onChanged}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'unblockAria' }));
+
+    await waitFor(() => expect(unblockUser).toHaveBeenCalledWith('target-id'));
+    expect(onChanged).toHaveBeenCalledWith(false);
+    expect(screen.getByRole('button', { name: 'blockAria' })).toBeInTheDocument();
+  });
+});

--- a/web/src/features/user-blocks/BlockUserButton.tsx
+++ b/web/src/features/user-blocks/BlockUserButton.tsx
@@ -1,0 +1,126 @@
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { blockUser, unblockUser } from './api';
+import { refreshBlockAffectedCaches } from './cache';
+import { Loader, UserRoundX } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+
+interface BlockUserButtonProps {
+  blocked: boolean;
+  targetDisplayName: string;
+  targetUserId: string;
+  onChanged?: (blocked: boolean) => void | Promise<void>;
+}
+
+export default function BlockUserButton({
+  blocked,
+  targetDisplayName,
+  targetUserId,
+  onChanged,
+}: BlockUserButtonProps) {
+  const { t } = useTranslation('translation', { keyPrefix: 'userBlocks' });
+  const [effectiveBlocked, setEffectiveBlocked] = useState(blocked);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [isMutating, setIsMutating] = useState(false);
+
+  useEffect(() => {
+    setEffectiveBlocked(blocked);
+  }, [blocked]);
+
+  const performMutation = async (nextBlocked: boolean) => {
+    const previousBlocked = effectiveBlocked;
+    setEffectiveBlocked(nextBlocked);
+    setIsMutating(true);
+
+    try {
+      if (nextBlocked) {
+        await blockUser(targetUserId);
+      } else {
+        await unblockUser(targetUserId);
+      }
+    } catch (error: any) {
+      setEffectiveBlocked(previousBlocked);
+      setConfirmOpen(false);
+      const message = error?.response?.data?.message || error?.message || t('mutationFailed');
+      toast.error(t('mutationFailedWithReason', { error: message }));
+      setIsMutating(false);
+      return;
+    }
+
+    setConfirmOpen(false);
+    toast.success(nextBlocked ? t('blockSuccess') : t('unblockSuccess'));
+
+    const refreshResults = await Promise.allSettled([
+      Promise.resolve().then(() => onChanged?.(nextBlocked)),
+      refreshBlockAffectedCaches(),
+    ]);
+    if (refreshResults.some((result) => result.status === 'rejected')) {
+      toast.error(t('refreshFailed'));
+    }
+    setIsMutating(false);
+  };
+
+  if (effectiveBlocked) {
+    return (
+      <Button
+        variant="outline"
+        size="sm"
+        disabled={isMutating}
+        aria-label={t('unblockAria', { user: targetDisplayName })}
+        onClick={() => void performMutation(false)}
+      >
+        {isMutating && <Loader className="size-4 animate-spin" />}
+        {isMutating ? t('unblocking') : t('unblock')}
+      </Button>
+    );
+  }
+
+  return (
+    <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+      <Button
+        variant="destructive"
+        size="sm"
+        disabled={isMutating}
+        aria-label={t('blockAria', { user: targetDisplayName })}
+        onClick={() => setConfirmOpen(true)}
+      >
+        <UserRoundX className="size-4" />
+        {t('block')}
+      </Button>
+      <DialogContent closeLabel={t('cancel')}>
+        <DialogHeader>
+          <DialogTitle>{t('confirmTitle', { user: targetDisplayName })}</DialogTitle>
+          <DialogDescription>{t('confirmDescription')}</DialogDescription>
+        </DialogHeader>
+        <div className="bg-muted text-muted-foreground rounded-md p-3 text-sm">
+          {t('publicContentNotice')}
+        </div>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="outline" disabled={isMutating}>
+              {t('cancel')}
+            </Button>
+          </DialogClose>
+          <Button
+            variant="destructive"
+            disabled={isMutating}
+            onClick={() => void performMutation(true)}
+          >
+            {isMutating && <Loader className="size-4 animate-spin" />}
+            {isMutating ? t('blocking') : t('confirm')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/features/user-blocks/BlockUserButton.tsx
+++ b/web/src/features/user-blocks/BlockUserButton.tsx
@@ -1,19 +1,8 @@
 import { Button } from '@/components/ui/button';
-import {
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
-import { blockUser, unblockUser } from './api';
-import { refreshBlockAffectedCaches } from './cache';
+import BlockUserConfirmDialog from './BlockUserConfirmDialog';
+import { useUserBlockAction } from './useUserBlockAction';
 import { Loader, UserRoundX } from 'lucide-react';
-import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { toast } from 'sonner';
 
 interface BlockUserButtonProps {
   blocked: boolean;
@@ -29,46 +18,19 @@ export default function BlockUserButton({
   onChanged,
 }: BlockUserButtonProps) {
   const { t } = useTranslation('translation', { keyPrefix: 'userBlocks' });
-  const [effectiveBlocked, setEffectiveBlocked] = useState(blocked);
-  const [confirmOpen, setConfirmOpen] = useState(false);
-  const [isMutating, setIsMutating] = useState(false);
-
-  useEffect(() => {
-    setEffectiveBlocked(blocked);
-  }, [blocked]);
-
-  const performMutation = async (nextBlocked: boolean) => {
-    const previousBlocked = effectiveBlocked;
-    setEffectiveBlocked(nextBlocked);
-    setIsMutating(true);
-
-    try {
-      if (nextBlocked) {
-        await blockUser(targetUserId);
-      } else {
-        await unblockUser(targetUserId);
-      }
-    } catch (error: any) {
-      setEffectiveBlocked(previousBlocked);
-      setConfirmOpen(false);
-      const message = error?.response?.data?.message || error?.message || t('mutationFailed');
-      toast.error(t('mutationFailedWithReason', { error: message }));
-      setIsMutating(false);
-      return;
-    }
-
-    setConfirmOpen(false);
-    toast.success(nextBlocked ? t('blockSuccess') : t('unblockSuccess'));
-
-    const refreshResults = await Promise.allSettled([
-      Promise.resolve().then(() => onChanged?.(nextBlocked)),
-      refreshBlockAffectedCaches(),
-    ]);
-    if (refreshResults.some((result) => result.status === 'rejected')) {
-      toast.error(t('refreshFailed'));
-    }
-    setIsMutating(false);
-  };
+  const {
+    confirmBlock,
+    confirmOpen,
+    effectiveBlocked,
+    isMutating,
+    requestBlock,
+    setConfirmOpen,
+    unblock,
+  } = useUserBlockAction({
+    blocked,
+    targetUserId,
+    onChanged,
+  });
 
   if (effectiveBlocked) {
     return (
@@ -77,7 +39,7 @@ export default function BlockUserButton({
         size="sm"
         disabled={isMutating}
         aria-label={t('unblockAria', { user: targetDisplayName })}
-        onClick={() => void performMutation(false)}
+        onClick={() => void unblock()}
       >
         {isMutating && <Loader className="size-4 animate-spin" />}
         {isMutating ? t('unblocking') : t('unblock')}
@@ -86,41 +48,24 @@ export default function BlockUserButton({
   }
 
   return (
-    <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+    <>
       <Button
         variant="destructive"
         size="sm"
         disabled={isMutating}
         aria-label={t('blockAria', { user: targetDisplayName })}
-        onClick={() => setConfirmOpen(true)}
+        onClick={requestBlock}
       >
         <UserRoundX className="size-4" />
         {t('block')}
       </Button>
-      <DialogContent closeLabel={t('cancel')}>
-        <DialogHeader>
-          <DialogTitle>{t('confirmTitle', { user: targetDisplayName })}</DialogTitle>
-          <DialogDescription>{t('confirmDescription')}</DialogDescription>
-        </DialogHeader>
-        <div className="bg-muted text-muted-foreground rounded-md p-3 text-sm">
-          {t('publicContentNotice')}
-        </div>
-        <DialogFooter>
-          <DialogClose asChild>
-            <Button variant="outline" disabled={isMutating}>
-              {t('cancel')}
-            </Button>
-          </DialogClose>
-          <Button
-            variant="destructive"
-            disabled={isMutating}
-            onClick={() => void performMutation(true)}
-          >
-            {isMutating && <Loader className="size-4 animate-spin" />}
-            {isMutating ? t('blocking') : t('confirm')}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+      <BlockUserConfirmDialog
+        open={confirmOpen}
+        isMutating={isMutating}
+        targetDisplayName={targetDisplayName}
+        onOpenChange={setConfirmOpen}
+        onConfirm={confirmBlock}
+      />
+    </>
   );
 }

--- a/web/src/features/user-blocks/BlockUserConfirmDialog.tsx
+++ b/web/src/features/user-blocks/BlockUserConfirmDialog.tsx
@@ -1,0 +1,53 @@
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Loader } from 'lucide-react';
+
+interface BlockUserConfirmDialogProps {
+  isMutating: boolean;
+  open: boolean;
+  targetDisplayName: string;
+  onConfirm: () => void | Promise<void>;
+  onOpenChange: (open: boolean) => void;
+}
+
+export default function BlockUserConfirmDialog({
+  isMutating,
+  open,
+  targetDisplayName,
+  onConfirm,
+  onOpenChange,
+}: BlockUserConfirmDialogProps) {
+  const { t } = useTranslation('translation', { keyPrefix: 'userBlocks' });
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent closeLabel={t('cancel')}>
+        <DialogHeader>
+          <DialogTitle>{t('confirmTitle', { user: targetDisplayName })}</DialogTitle>
+          <DialogDescription>{t('confirmDescription')}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="outline" disabled={isMutating}>
+              {t('cancel')}
+            </Button>
+          </DialogClose>
+          <Button variant="destructive" disabled={isMutating} onClick={() => void onConfirm()}>
+            {isMutating && <Loader className="size-4 animate-spin" />}
+            {isMutating ? t('blocking') : t('confirm')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/features/user-blocks/BlockedUserNotesState.test.tsx
+++ b/web/src/features/user-blocks/BlockedUserNotesState.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import BlockedUserNotesState from './BlockedUserNotesState';
+
+describe('BlockedUserNotesState', () => {
+  it('explains that notes are hidden instead of showing the generic empty state', () => {
+    render(<BlockedUserNotesState />);
+
+    expect(screen.getByRole('status')).toHaveTextContent('title');
+    expect(screen.getByRole('status')).toHaveTextContent('description');
+    expect(screen.queryByText('empty')).not.toBeInTheDocument();
+  });
+});

--- a/web/src/features/user-blocks/BlockedUserNotesState.tsx
+++ b/web/src/features/user-blocks/BlockedUserNotesState.tsx
@@ -1,0 +1,19 @@
+import { EyeOff } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+export default function BlockedUserNotesState() {
+  const { t } = useTranslation('translation', { keyPrefix: 'userBlocks.notesHidden' });
+
+  return (
+    <div
+      role="status"
+      className="bg-background flex shrink-0 flex-col items-center justify-center gap-3 px-6 py-8 text-center"
+    >
+      <EyeOff className="text-theme/30 size-10" />
+      <div className="space-y-1">
+        <div className="font-medium">{t('title')}</div>
+        <div className="text-info text-sm font-light">{t('description')}</div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/features/user-blocks/UserBlockMenu.test.tsx
+++ b/web/src/features/user-blocks/UserBlockMenu.test.tsx
@@ -1,0 +1,104 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import UserBlockMenu from './UserBlockMenu';
+import { blockUser, unblockUser } from './api';
+import { refreshBlockAffectedCaches } from './cache';
+
+vi.mock('./api', () => ({
+  blockUser: vi.fn(),
+  unblockUser: vi.fn(),
+}));
+
+vi.mock('./cache', async (importOriginal) => {
+  const original = await importOriginal<typeof import('./cache')>();
+  return {
+    ...original,
+    refreshBlockAffectedCaches: vi.fn(),
+  };
+});
+
+describe('UserBlockMenu', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(refreshBlockAffectedCaches).mockResolvedValue();
+  });
+
+  it('keeps blocking inside the actions menu and opens the confirmation dialog', async () => {
+    vi.mocked(blockUser).mockResolvedValue({
+      blocked: true,
+      targetUserId: 'target-id',
+    });
+
+    render(<UserBlockMenu blocked={false} targetDisplayName="Target" targetUserId="target-id" />);
+
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'menuAria' }), {
+      button: 0,
+      ctrlKey: false,
+    });
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'block' }));
+
+    expect(blockUser).not.toHaveBeenCalled();
+    expect(screen.getByText('confirmDescription')).toBeInTheDocument();
+    expect(screen.queryByText('publicContentNotice')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'confirm' }));
+
+    await waitFor(() => expect(blockUser).toHaveBeenCalledWith('target-id'));
+    expect(refreshBlockAffectedCaches).toHaveBeenCalledTimes(1);
+  });
+
+  it('unblocks directly from the actions menu', async () => {
+    vi.mocked(unblockUser).mockResolvedValue({
+      blocked: false,
+      targetUserId: 'target-id',
+    });
+
+    render(<UserBlockMenu blocked targetDisplayName="Target" targetUserId="target-id" />);
+
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'menuAria' }), {
+      button: 0,
+      ctrlKey: false,
+    });
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'unblock' }));
+
+    await waitFor(() => expect(unblockUser).toHaveBeenCalledWith('target-id'));
+    expect(refreshBlockAffectedCaches).toHaveBeenCalledTimes(1);
+  });
+
+  it('waits for the local state transition before refreshing shared caches', async () => {
+    vi.mocked(unblockUser).mockResolvedValue({
+      blocked: false,
+      targetUserId: 'target-id',
+    });
+    let resolveChanged: (() => void) | undefined;
+    const onChanged = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveChanged = resolve;
+        })
+    );
+
+    render(
+      <UserBlockMenu
+        blocked
+        targetDisplayName="Target"
+        targetUserId="target-id"
+        onChanged={onChanged}
+      />
+    );
+
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'menuAria' }), {
+      button: 0,
+      ctrlKey: false,
+    });
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'unblock' }));
+
+    await waitFor(() => expect(onChanged).toHaveBeenCalledWith(false));
+    expect(refreshBlockAffectedCaches).not.toHaveBeenCalled();
+
+    resolveChanged?.();
+
+    await waitFor(() => expect(refreshBlockAffectedCaches).toHaveBeenCalledTimes(1));
+  });
+});

--- a/web/src/features/user-blocks/UserBlockMenu.tsx
+++ b/web/src/features/user-blocks/UserBlockMenu.tsx
@@ -1,0 +1,96 @@
+import { Ellipsis, Loader, UserRoundCheck, UserRoundX } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+
+import BlockUserConfirmDialog from './BlockUserConfirmDialog';
+import { useUserBlockAction } from './useUserBlockAction';
+
+interface UserBlockMenuProps {
+  blocked: boolean;
+  targetDisplayName: string;
+  targetUserId: string;
+  onChanged?: (blocked: boolean) => void | Promise<void>;
+}
+
+export default function UserBlockMenu({
+  blocked,
+  targetDisplayName,
+  targetUserId,
+  onChanged,
+}: UserBlockMenuProps) {
+  const { t } = useTranslation('translation', { keyPrefix: 'userBlocks' });
+  const {
+    confirmBlock,
+    confirmOpen,
+    effectiveBlocked,
+    isMutating,
+    requestBlock,
+    setConfirmOpen,
+    unblock,
+  } = useUserBlockAction({
+    blocked,
+    targetUserId,
+    onChanged,
+  });
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            size="icon"
+            variant="ghost"
+            className="size-8"
+            aria-label={t('menuAria', { user: targetDisplayName })}
+            title={t('menuAria', { user: targetDisplayName })}
+          >
+            <Ellipsis className="size-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem
+            disabled={isMutating}
+            variant={effectiveBlocked ? 'default' : 'destructive'}
+            onSelect={() => {
+              if (effectiveBlocked) {
+                void unblock();
+                return;
+              }
+              requestBlock();
+            }}
+          >
+            {isMutating ? (
+              <Loader className="size-4 animate-spin" />
+            ) : effectiveBlocked ? (
+              <UserRoundCheck className="size-4" />
+            ) : (
+              <UserRoundX className="size-4" />
+            )}
+            {isMutating
+              ? effectiveBlocked
+                ? t('unblocking')
+                : t('blocking')
+              : effectiveBlocked
+                ? t('unblock')
+                : t('block')}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <BlockUserConfirmDialog
+        open={confirmOpen}
+        isMutating={isMutating}
+        targetDisplayName={targetDisplayName}
+        onOpenChange={setConfirmOpen}
+        onConfirm={confirmBlock}
+      />
+    </>
+  );
+}

--- a/web/src/features/user-blocks/api.ts
+++ b/web/src/features/user-blocks/api.ts
@@ -1,0 +1,28 @@
+import type { BlockedUserSummary } from '@/types/main';
+import { del, get, put } from '@/utils/api';
+
+type ApiEnvelope<T> = {
+  code: number;
+  message: string;
+  data: T;
+};
+
+export type UserBlockMutation = {
+  blocked: boolean;
+  targetUserId: string;
+};
+
+export async function listBlockedUsers(): Promise<BlockedUserSummary[]> {
+  const response = await get<ApiEnvelope<BlockedUserSummary[]>>('/users/me/blocks');
+  return response.data;
+}
+
+export async function blockUser(targetUserId: string): Promise<UserBlockMutation> {
+  const response = await put<ApiEnvelope<UserBlockMutation>>(`/users/me/blocks/${targetUserId}`);
+  return response.data;
+}
+
+export async function unblockUser(targetUserId: string): Promise<UserBlockMutation> {
+  const response = await del<ApiEnvelope<UserBlockMutation>>(`/users/me/blocks/${targetUserId}`);
+  return response.data;
+}

--- a/web/src/features/user-blocks/cache.test.ts
+++ b/web/src/features/user-blocks/cache.test.ts
@@ -1,0 +1,37 @@
+import type { Rotes } from '@/types/main';
+import { describe, expect, it } from 'vitest';
+import { isBlockAffectedCacheKey, removeUserContentFromPages } from './cache';
+
+describe('user block cache helpers', () => {
+  it('removes a blocked author from every cached page without mutating other entries', () => {
+    const pages = [
+      [
+        { id: 'one', authorid: 'blocked', author: { username: 'blocked-user' } },
+        { id: 'two', authorid: 'visible', author: { username: 'visible-user' } },
+      ],
+      [{ id: 'three', authorid: 'blocked', author: { username: 'blocked-user' } }],
+    ] as unknown as Rotes[];
+
+    expect(
+      removeUserContentFromPages(pages, { id: 'blocked', username: 'blocked-user' })?.map((page) =>
+        page.map((rote) => rote.id)
+      )
+    ).toEqual([['two'], []]);
+    expect(pages[0]).toHaveLength(2);
+  });
+
+  it('targets user-content and infinite public cache keys', () => {
+    expect(isBlockAffectedCacheKey('/notes/public')).toBe(true);
+    expect(isBlockAffectedCacheKey('/users/me/blocks')).toBe(true);
+    expect(isBlockAffectedCacheKey({ apiType: 'public' })).toBe(true);
+    expect(
+      isBlockAffectedCacheKey([
+        'viewer-aware',
+        'https://rote.example|account-id',
+        '/articles/article-id',
+      ])
+    ).toBe(true);
+    expect(isBlockAffectedCacheKey({ apiType: 'mine' })).toBe(false);
+    expect(isBlockAffectedCacheKey('https://api.github.com/repo')).toBe(false);
+  });
+});

--- a/web/src/features/user-blocks/cache.test.ts
+++ b/web/src/features/user-blocks/cache.test.ts
@@ -24,6 +24,7 @@ describe('user block cache helpers', () => {
     expect(isBlockAffectedCacheKey('/notes/public')).toBe(true);
     expect(isBlockAffectedCacheKey('/users/me/blocks')).toBe(true);
     expect(isBlockAffectedCacheKey({ apiType: 'public' })).toBe(true);
+    expect(isBlockAffectedCacheKey({ apiType: 'mine' })).toBe(true);
     expect(
       isBlockAffectedCacheKey([
         'viewer-aware',
@@ -31,7 +32,9 @@ describe('user block cache helpers', () => {
         '/articles/article-id',
       ])
     ).toBe(true);
-    expect(isBlockAffectedCacheKey({ apiType: 'mine' })).toBe(false);
+    expect(
+      isBlockAffectedCacheKey(['viewer-aware', 'https://rote.example|account-id', 'randomRote'])
+    ).toBe(true);
     expect(isBlockAffectedCacheKey('https://api.github.com/repo')).toBe(false);
   });
 });

--- a/web/src/features/user-blocks/cache.ts
+++ b/web/src/features/user-blocks/cache.ts
@@ -20,13 +20,14 @@ export function isBlockAffectedCacheKey(key: unknown): boolean {
       key.startsWith('/notes') ||
       key.startsWith('/articles') ||
       key.startsWith('/users/') ||
-      key === '/users/me/blocks'
+      key === '/users/me/blocks' ||
+      key === 'randomRote'
     );
   }
 
   if (!key || typeof key !== 'object') return false;
   const apiType = (key as { apiType?: unknown }).apiType;
-  return apiType === 'public' || apiType === 'userPublic';
+  return apiType === 'mine' || apiType === 'public' || apiType === 'userPublic';
 }
 
 export async function refreshBlockAffectedCaches() {

--- a/web/src/features/user-blocks/cache.ts
+++ b/web/src/features/user-blocks/cache.ts
@@ -1,0 +1,34 @@
+import type { Rotes } from '@/types/main';
+import { mutate } from 'swr';
+
+export function removeUserContentFromPages(
+  pages: Rotes[] | undefined,
+  target: { id: string; username: string }
+): Rotes[] | undefined {
+  return pages?.map((page) =>
+    page.filter((rote) => rote.authorid !== target.id && rote.author?.username !== target.username)
+  );
+}
+
+export function isBlockAffectedCacheKey(key: unknown): boolean {
+  if (Array.isArray(key)) {
+    return key.some(isBlockAffectedCacheKey);
+  }
+
+  if (typeof key === 'string') {
+    return (
+      key.startsWith('/notes') ||
+      key.startsWith('/articles') ||
+      key.startsWith('/users/') ||
+      key === '/users/me/blocks'
+    );
+  }
+
+  if (!key || typeof key !== 'object') return false;
+  const apiType = (key as { apiType?: unknown }).apiType;
+  return apiType === 'public' || apiType === 'userPublic';
+}
+
+export async function refreshBlockAffectedCaches() {
+  await mutate(isBlockAffectedCacheKey, undefined, { revalidate: true });
+}

--- a/web/src/features/user-blocks/useUserBlockAction.ts
+++ b/web/src/features/user-blocks/useUserBlockAction.ts
@@ -1,0 +1,114 @@
+import { useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+
+import { blockUser, unblockUser } from './api';
+import { refreshBlockAffectedCaches } from './cache';
+
+interface UseUserBlockActionOptions {
+  blocked: boolean;
+  targetUserId: string;
+  onChanged?: (blocked: boolean) => void | Promise<void>;
+}
+
+interface UserBlockActionState {
+  confirmOpen: boolean;
+  effectiveBlocked: boolean;
+  sourceBlocked: boolean;
+  targetUserId: string;
+}
+
+export function useUserBlockAction({
+  blocked,
+  targetUserId,
+  onChanged,
+}: UseUserBlockActionOptions) {
+  const { t } = useTranslation('translation', { keyPrefix: 'userBlocks' });
+  const [blockState, setBlockState] = useState<UserBlockActionState>({
+    confirmOpen: false,
+    effectiveBlocked: blocked,
+    sourceBlocked: blocked,
+    targetUserId,
+  });
+  const [isMutating, setIsMutating] = useState(false);
+
+  if (blockState.sourceBlocked !== blocked || blockState.targetUserId !== targetUserId) {
+    setBlockState({
+      confirmOpen: false,
+      effectiveBlocked: blocked,
+      sourceBlocked: blocked,
+      targetUserId,
+    });
+  }
+
+  const setConfirmOpen = useCallback((open: boolean) => {
+    setBlockState((current) => ({ ...current, confirmOpen: open }));
+  }, []);
+
+  const performMutation = useCallback(
+    async (nextBlocked: boolean) => {
+      const previousBlocked = blockState.effectiveBlocked;
+      setBlockState((current) => ({
+        ...current,
+        effectiveBlocked: nextBlocked,
+      }));
+      setIsMutating(true);
+
+      try {
+        if (nextBlocked) {
+          await blockUser(targetUserId);
+        } else {
+          await unblockUser(targetUserId);
+        }
+      } catch (error: unknown) {
+        setBlockState((current) => ({
+          ...current,
+          confirmOpen: false,
+          effectiveBlocked: previousBlocked,
+        }));
+        const responseMessage = (
+          error as { response?: { data?: { message?: string } }; message?: string }
+        )?.response?.data?.message;
+        const message =
+          responseMessage ||
+          (error instanceof Error ? error.message : undefined) ||
+          t('mutationFailed');
+        toast.error(t('mutationFailedWithReason', { error: message }));
+        setIsMutating(false);
+        return;
+      }
+
+      setConfirmOpen(false);
+      toast.success(nextBlocked ? t('blockSuccess') : t('unblockSuccess'));
+
+      const changeResults = await Promise.allSettled([
+        Promise.resolve().then(() => onChanged?.(nextBlocked)),
+      ]);
+      const refreshResults = await Promise.allSettled([
+        Promise.resolve().then(refreshBlockAffectedCaches),
+      ]);
+      if ([...changeResults, ...refreshResults].some((result) => result.status === 'rejected')) {
+        toast.error(t('refreshFailed'));
+      }
+      setIsMutating(false);
+    },
+    [blockState.effectiveBlocked, onChanged, setConfirmOpen, t, targetUserId]
+  );
+
+  const requestBlock = useCallback(() => {
+    setConfirmOpen(true);
+  }, [setConfirmOpen]);
+
+  const confirmBlock = useCallback(() => performMutation(true), [performMutation]);
+  const unblock = useCallback(() => performMutation(false), [performMutation]);
+
+  return {
+    confirmBlock,
+    confirmOpen: blockState.confirmOpen,
+    effectiveBlocked: blockState.effectiveBlocked,
+    isMutating,
+    requestBlock,
+    setConfirmOpen,
+    unblock,
+  };
+}

--- a/web/src/features/user-blocks/viewerCacheScope.ts
+++ b/web/src/features/user-blocks/viewerCacheScope.ts
@@ -1,0 +1,12 @@
+import { authService } from '@/utils/auth';
+
+export function getViewerCacheScope(accountId?: string): string {
+  const token = authService.getAccessToken();
+  const tokenAccountId = token ? authService.getUserInfoFromToken(token)?.userId : undefined;
+  const origin = typeof window === 'undefined' ? 'server' : window.location.origin;
+  return `${origin}|${accountId || tokenAccountId || 'anonymous'}`;
+}
+
+export function viewerAwareCacheKey(key: string, accountId?: string) {
+  return ['viewer-aware', getViewerCacheScope(accountId), key] as const;
+}

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1949,12 +1949,16 @@
     "cancel": "Cancel",
     "confirmTitle": "Block {{user}}?",
     "confirmDescription": "You will stop seeing each other's content and cannot interact while signed in.",
-    "publicContentNotice": "Blocking does not make public content private. Signed-out visitors may still access public Rotes and articles.",
     "blockSuccess": "User blocked",
     "unblockSuccess": "User unblocked",
+    "notesHidden": {
+      "title": "This user's public notes are hidden",
+      "description": "Unblock this user to view them again."
+    },
     "mutationFailed": "Request failed",
     "mutationFailedWithReason": "Could not update block: {{error}}",
     "refreshFailed": "The block was saved, but some on-screen content could not be refreshed. Reload the page to update it.",
+    "menuAria": "Actions for {{user}}",
     "blockAria": "Block {{user}}",
     "unblockAria": "Unblock {{user}}",
     "management": {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -365,6 +365,11 @@
         "saving": "Saving…",
         "saveSuccess": "Settings saved",
         "saveFailed": "Failed to save: {{error}}",
+        "blockedUsers": {
+          "title": "Blocked users",
+          "description": "Review accounts you have blocked and unblock them.",
+          "open": "Manage blocked users"
+        },
         "passkey": {
           "title": "Passkeys",
           "description": "Manage your passkeys for passwordless login.",
@@ -1933,6 +1938,31 @@
       "loadFailed": "Failed to load article",
       "notFound": "Article content not found",
       "edit": "Edit article"
+    }
+  },
+  "userBlocks": {
+    "block": "Block",
+    "blocking": "Blocking…",
+    "unblock": "Unblock",
+    "unblocking": "Unblocking…",
+    "confirm": "Block user",
+    "cancel": "Cancel",
+    "confirmTitle": "Block {{user}}?",
+    "confirmDescription": "You will stop seeing each other's content and cannot interact while signed in.",
+    "publicContentNotice": "Blocking does not make public content private. Signed-out visitors may still access public Rotes and articles.",
+    "blockSuccess": "User blocked",
+    "unblockSuccess": "User unblocked",
+    "mutationFailed": "Request failed",
+    "mutationFailedWithReason": "Could not update block: {{error}}",
+    "refreshFailed": "The block was saved, but some on-screen content could not be refreshed. Reload the page to update it.",
+    "blockAria": "Block {{user}}",
+    "unblockAria": "Unblock {{user}}",
+    "management": {
+      "title": "Blocked users",
+      "sidebarTitle": "Account controls",
+      "description": "This list comes from your server account and stays consistent across devices.",
+      "publicContentNotice": "Blocking applies when you are signed in. It does not make either person's public content private.",
+      "empty": "You have not blocked anyone."
     }
   },
   "common": {

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -1953,12 +1953,16 @@
     "cancel": "キャンセル",
     "confirmTitle": "{{user}} をブロックしますか？",
     "confirmDescription": "ログイン中はお互いのコンテンツが表示されず、リアクションもできなくなります。",
-    "publicContentNotice": "ブロックしても公開コンテンツは非公開になりません。ログアウトした訪問者は公開 Rote や記事にアクセスできます。",
     "blockSuccess": "ユーザーをブロックしました",
     "unblockSuccess": "ブロックを解除しました",
+    "notesHidden": {
+      "title": "このユーザーの公開ノートは非表示です",
+      "description": "ブロックを解除すると、再び表示できます。"
+    },
     "mutationFailed": "リクエストに失敗しました",
     "mutationFailedWithReason": "ブロック状態を更新できませんでした：{{error}}",
     "refreshFailed": "ブロック状態は保存されましたが、一部の画面表示を更新できませんでした。ページを再読み込みしてください。",
+    "menuAria": "{{user}} の操作",
     "blockAria": "{{user}} をブロック",
     "unblockAria": "{{user}} のブロックを解除",
     "management": {

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -369,6 +369,11 @@
         "saving": "保存中…",
         "saveSuccess": "設定を保存しました",
         "saveFailed": "保存に失敗しました：{{error}}",
+        "blockedUsers": {
+          "title": "ブロックしたユーザー",
+          "description": "ブロックしたアカウントを確認し、解除できます。",
+          "open": "ブロックしたユーザーを管理"
+        },
         "passkey": {
           "title": "パスキー",
           "description": "パスワードレスログイン用のパスキーを管理します。",
@@ -1937,6 +1942,31 @@
       "loadFailed": "記事の読み込みに失敗しました",
       "notFound": "記事コンテンツが見つかりません",
       "edit": "記事を編集"
+    }
+  },
+  "userBlocks": {
+    "block": "ブロック",
+    "blocking": "ブロック中…",
+    "unblock": "ブロック解除",
+    "unblocking": "解除中…",
+    "confirm": "ブロックする",
+    "cancel": "キャンセル",
+    "confirmTitle": "{{user}} をブロックしますか？",
+    "confirmDescription": "ログイン中はお互いのコンテンツが表示されず、リアクションもできなくなります。",
+    "publicContentNotice": "ブロックしても公開コンテンツは非公開になりません。ログアウトした訪問者は公開 Rote や記事にアクセスできます。",
+    "blockSuccess": "ユーザーをブロックしました",
+    "unblockSuccess": "ブロックを解除しました",
+    "mutationFailed": "リクエストに失敗しました",
+    "mutationFailedWithReason": "ブロック状態を更新できませんでした：{{error}}",
+    "refreshFailed": "ブロック状態は保存されましたが、一部の画面表示を更新できませんでした。ページを再読み込みしてください。",
+    "blockAria": "{{user}} をブロック",
+    "unblockAria": "{{user}} のブロックを解除",
+    "management": {
+      "title": "ブロックしたユーザー",
+      "sidebarTitle": "アカウント管理",
+      "description": "この一覧は現在のサーバーアカウントから読み込まれ、端末間で同期されます。",
+      "publicContentNotice": "ブロックはログイン中に適用されます。どちらの公開コンテンツも非公開にはなりません。",
+      "empty": "ブロックしたユーザーはいません。"
     }
   },
   "common": {

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -355,6 +355,11 @@
         "saving": "保存中…",
         "saveSuccess": "设置已保存",
         "saveFailed": "保存失败：{{error}}",
+        "blockedUsers": {
+          "title": "已屏蔽用户",
+          "description": "查看你屏蔽的账户并随时解除。",
+          "open": "管理已屏蔽用户"
+        },
         "passkey": {
           "title": "通行密钥",
           "description": "管理您的通行密钥，用于免密码登录。",
@@ -1923,6 +1928,31 @@
       "loadFailed": "加载文章失败",
       "notFound": "未找到文章内容",
       "edit": "编辑文章"
+    }
+  },
+  "userBlocks": {
+    "block": "屏蔽",
+    "blocking": "屏蔽中…",
+    "unblock": "取消屏蔽",
+    "unblocking": "取消中…",
+    "confirm": "确认屏蔽",
+    "cancel": "取消",
+    "confirmTitle": "屏蔽 {{user}}？",
+    "confirmDescription": "登录状态下，双方将看不到彼此的内容，也无法互动。",
+    "publicContentNotice": "屏蔽不会把公开内容变为私密。退出登录的访客仍可能访问公开 Rote 和文章。",
+    "blockSuccess": "已屏蔽用户",
+    "unblockSuccess": "已取消屏蔽",
+    "mutationFailed": "请求失败",
+    "mutationFailedWithReason": "更新屏蔽状态失败：{{error}}",
+    "refreshFailed": "屏蔽状态已保存，但部分当前页面内容未能刷新。请重新加载页面以更新。",
+    "blockAria": "屏蔽 {{user}}",
+    "unblockAria": "取消屏蔽 {{user}}",
+    "management": {
+      "title": "已屏蔽用户",
+      "sidebarTitle": "账户管理",
+      "description": "此列表直接来自当前服务器账户，并会在不同设备间保持一致。",
+      "publicContentNotice": "屏蔽仅在登录状态下生效，不会将任何一方的公开内容变为私密。",
+      "empty": "你还没有屏蔽任何用户。"
     }
   },
   "common": {

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1939,12 +1939,16 @@
     "cancel": "取消",
     "confirmTitle": "屏蔽 {{user}}？",
     "confirmDescription": "登录状态下，双方将看不到彼此的内容，也无法互动。",
-    "publicContentNotice": "屏蔽不会把公开内容变为私密。退出登录的访客仍可能访问公开 Rote 和文章。",
     "blockSuccess": "已屏蔽用户",
     "unblockSuccess": "已取消屏蔽",
+    "notesHidden": {
+      "title": "已隐藏该用户的公开笔记",
+      "description": "取消屏蔽后即可重新查看。"
+    },
     "mutationFailed": "请求失败",
     "mutationFailedWithReason": "更新屏蔽状态失败：{{error}}",
     "refreshFailed": "屏蔽状态已保存，但部分当前页面内容未能刷新。请重新加载页面以更新。",
+    "menuAria": "{{user}} 的操作",
     "blockAria": "屏蔽 {{user}}",
     "unblockAria": "取消屏蔽 {{user}}",
     "management": {

--- a/web/src/pages/article/[articleid].tsx
+++ b/web/src/pages/article/[articleid].tsx
@@ -5,6 +5,7 @@ import LoadingPlaceholder from '@/components/others/LoadingPlaceholder';
 import PageRequestError from '@/components/others/PageRequestError';
 import UserAvatar from '@/components/others/UserAvatar';
 import { Button } from '@/components/ui/button';
+import { viewerAwareCacheKey } from '@/features/user-blocks/viewerCacheScope';
 import { useArticleActions } from '@/hooks/useArticleActions';
 import ContainerWithSideBar from '@/layout/ContainerWithSideBar';
 import { profileAtom } from '@/state/profile';
@@ -41,7 +42,7 @@ function ArticleDetailPage() {
     mutate,
     isValidating,
   } = useAPIGet<any>(
-    articleid ? `/articles/${articleid}` : null,
+    articleid ? viewerAwareCacheKey(`/articles/${articleid}`, profile?.id) : null,
     () => get('/articles/' + articleid).then((res) => res.data),
     {
       revalidateOnFocus: false,

--- a/web/src/pages/explore/index.tsx
+++ b/web/src/pages/explore/index.tsx
@@ -114,7 +114,13 @@ function ExplorePage() {
           ))}
       </NavBar>
       <Announcement />
-      <RoteList data={data} loadMore={loadMore} mutate={mutate} isValidating={isValidating} />
+      <RoteList
+        data={data}
+        loadMore={loadMore}
+        mutate={mutate}
+        isValidating={isValidating}
+        showAuthorActions
+      />
     </ContainerWithSideBar>
   );
 }

--- a/web/src/pages/profile/blocked/BlockedUsersPage.test.tsx
+++ b/web/src/pages/profile/blocked/BlockedUsersPage.test.tsx
@@ -1,0 +1,75 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { SWRConfig } from 'swr';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import BlockedUsersPage from './index';
+import { listBlockedUsers, unblockUser } from '@/features/user-blocks/api';
+import { refreshBlockAffectedCaches } from '@/features/user-blocks/cache';
+
+vi.mock('@/features/user-blocks/api', () => ({
+  blockUser: vi.fn(),
+  listBlockedUsers: vi.fn(),
+  unblockUser: vi.fn(),
+}));
+
+vi.mock('@/features/user-blocks/cache', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@/features/user-blocks/cache')>();
+  return {
+    ...original,
+    refreshBlockAffectedCaches: vi.fn(),
+  };
+});
+
+vi.mock('../components/ProfileSidebar', () => ({
+  default: () => <div>profile-sidebar</div>,
+}));
+
+function renderPage() {
+  return render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      <MemoryRouter>
+        <BlockedUsersPage />
+      </MemoryRouter>
+    </SWRConfig>
+  );
+}
+
+describe('BlockedUsersPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(refreshBlockAffectedCaches).mockResolvedValue();
+  });
+
+  it('loads the complete server list and removes an item after unblock', async () => {
+    vi.mocked(listBlockedUsers).mockResolvedValue([
+      {
+        id: 'target-id',
+        username: 'target',
+        nickname: 'Target',
+        avatar: null,
+        description: null,
+        certified: false,
+        blockedAt: '2026-07-28T08:00:00Z',
+      },
+    ]);
+    vi.mocked(unblockUser).mockResolvedValue({
+      blocked: false,
+      targetUserId: 'target-id',
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('@target')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'unblockAria' }));
+
+    await waitFor(() => expect(unblockUser).toHaveBeenCalledWith('target-id'));
+    await waitFor(() => expect(screen.queryByText('@target')).not.toBeInTheDocument());
+    expect(refreshBlockAffectedCaches).toHaveBeenCalled();
+  });
+
+  it('renders the server-backed empty state', async () => {
+    vi.mocked(listBlockedUsers).mockResolvedValue([]);
+    renderPage();
+    expect(await screen.findByText('empty')).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/profile/blocked/index.tsx
+++ b/web/src/pages/profile/blocked/index.tsx
@@ -1,0 +1,89 @@
+import NavBar from '@/components/layout/navBar';
+import LoadingPlaceholder from '@/components/others/LoadingPlaceholder';
+import PageRequestError from '@/components/others/PageRequestError';
+import UserAvatar from '@/components/others/UserAvatar';
+import { VerifiedIcon } from '@/components/icons/Verified';
+import { viewerAwareCacheKey } from '@/features/user-blocks/viewerCacheScope';
+import ContainerWithSideBar from '@/layout/ContainerWithSideBar';
+import ProfileSidebar from '../components/ProfileSidebar';
+import BlockUserButton from '@/features/user-blocks/BlockUserButton';
+import { listBlockedUsers } from '@/features/user-blocks/api';
+import type { BlockedUserSummary } from '@/types/main';
+import { useAPIGet } from '@/utils/fetcher';
+import { ShieldX, Stars } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+import { profileAtom } from '@/state/profile';
+import { useAtomValue } from 'jotai';
+
+export default function BlockedUsersPage() {
+  const { t } = useTranslation('translation', { keyPrefix: 'userBlocks.management' });
+  const profile = useAtomValue(profileAtom);
+  const { data, error, isLoading, mutate } = useAPIGet<BlockedUserSummary[]>(
+    viewerAwareCacheKey('/users/me/blocks', profile?.id),
+    listBlockedUsers
+  );
+
+  return (
+    <ContainerWithSideBar
+      sidebar={<ProfileSidebar />}
+      sidebarHeader={
+        <div className="flex items-center gap-2 p-3 text-lg font-semibold">
+          <Stars className="size-5" />
+          {t('sidebarTitle')}
+        </div>
+      }
+    >
+      <NavBar title={t('title')} icon={<ShieldX className="size-5" />} />
+
+      <div className="p-4">
+        <p className="text-muted-foreground mb-4 text-sm">{t('description')}</p>
+        <div className="bg-muted text-muted-foreground mb-4 rounded-md p-3 text-sm">
+          {t('publicContentNotice')}
+        </div>
+
+        {isLoading ? (
+          <LoadingPlaceholder className="py-16" size={6} />
+        ) : error ? (
+          <PageRequestError error={error} onRetry={() => void mutate()} />
+        ) : !data?.length ? (
+          <div className="text-muted-foreground rounded-lg border border-dashed p-10 text-center">
+            {t('empty')}
+          </div>
+        ) : (
+          <div className="grid gap-3">
+            {data.map((user) => (
+              <div
+                key={user.id}
+                className="flex items-center justify-between gap-4 rounded-lg border p-4"
+              >
+                <Link to={`/${user.username}`} className="flex min-w-0 items-center gap-3">
+                  <UserAvatar avatar={user.avatar || undefined} className="size-11 shrink-0" />
+                  <div className="min-w-0">
+                    <div className="inline-flex max-w-full items-center gap-1 font-semibold">
+                      <span className="truncate">{user.nickname || user.username}</span>
+                      {user.certified && <VerifiedIcon className="text-theme size-4 shrink-0" />}
+                    </div>
+                    <div className="text-muted-foreground truncate text-sm">@{user.username}</div>
+                  </div>
+                </Link>
+                <BlockUserButton
+                  blocked
+                  targetDisplayName={user.nickname || user.username}
+                  targetUserId={user.id}
+                  onChanged={async (blocked) => {
+                    if (!blocked) {
+                      await mutate((current) => current?.filter((item) => item.id !== user.id), {
+                        revalidate: false,
+                      });
+                    }
+                  }}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </ContainerWithSideBar>
+  );
+}

--- a/web/src/pages/profile/setting/index.tsx
+++ b/web/src/pages/profile/setting/index.tsx
@@ -33,10 +33,12 @@ import {
   RefreshCw,
   RotateCcw,
   Key,
+  ShieldX,
 } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
+import { Link } from 'react-router-dom';
 import DeleteAccountDialog from '../components/DeleteAccountDialog';
 import MergeAccountDialog from '../components/MergeAccountDialog';
 import ProfileSidebar from '../components/ProfileSidebar';
@@ -254,6 +256,19 @@ export default function SettingsPage() {
         >
           {settingsSaving && <Loader className="mr-2 size-4 animate-spin" />}
           {settingsSaving ? t('settings.saving') : t('settings.save')}
+        </Button>
+      </div>
+
+      <div className="space-y-4 p-4">
+        <div>
+          <div className="text-base font-semibold">{t('settings.blockedUsers.title')}</div>
+          <p className="text-muted-foreground text-sm">{t('settings.blockedUsers.description')}</p>
+        </div>
+        <Button variant="outline" className="w-full" asChild>
+          <Link to="/profile/blocked">
+            <ShieldX className="size-4" />
+            {t('settings.blockedUsers.open')}
+          </Link>
         </Button>
       </div>
 

--- a/web/src/pages/rote/[roteid].tsx
+++ b/web/src/pages/rote/[roteid].tsx
@@ -1,5 +1,6 @@
 import { VerifiedIcon } from '@/components/icons/Verified';
 import { RelatedNotesBlock } from '@/components/ai/RelatedNotesBlock';
+import { viewerAwareCacheKey } from '@/features/user-blocks/viewerCacheScope';
 import NavBar from '@/components/layout/navBar';
 import LoadingPlaceholder from '@/components/others/LoadingPlaceholder';
 import PageRequestError from '@/components/others/PageRequestError';
@@ -35,7 +36,7 @@ function SingleRotePage() {
     mutate,
     isValidating,
   } = useAPIGet<Rote>(
-    roteid ? `/notes/${roteid}` : null,
+    roteid ? viewerAwareCacheKey(`/notes/${roteid}`, profile?.id) : null,
     () => get('/notes/' + roteid).then((res) => res.data),
     {
       onError: (err: unknown) => {

--- a/web/src/pages/user/[username].tsx
+++ b/web/src/pages/user/[username].tsx
@@ -6,7 +6,11 @@ import LoadingPlaceholder from '@/components/others/LoadingPlaceholder';
 import PageRequestError from '@/components/others/PageRequestError';
 import UserAvatar from '@/components/others/UserAvatar';
 import RoteList from '@/components/rote/roteList';
+import BlockUserButton from '@/features/user-blocks/BlockUserButton';
+import { removeUserContentFromPages } from '@/features/user-blocks/cache';
+import { viewerAwareCacheKey } from '@/features/user-blocks/viewerCacheScope';
 import ContainerWithSideBar from '@/layout/ContainerWithSideBar';
+import { profileAtom } from '@/state/profile';
 import type { ApiGetRotesParams, Profile, Rotes } from '@/types/main';
 import { API_URL, get } from '@/utils/api';
 import { isNotFoundError } from '@/utils/error';
@@ -18,18 +22,20 @@ import { Globe2, RefreshCw, Stars } from 'lucide-react';
 import moment from 'moment';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
+import { useAtomValue } from 'jotai';
 
 function UserPage() {
   const { t } = useTranslation('translation', { keyPrefix: 'pages.user' });
   const navigate = useNavigate();
   const { username }: any = useParams();
+  const currentProfile = useAtomValue(profileAtom);
   const {
     data: userInfo,
     isLoading,
     error,
     mutate: mutateUser,
   } = useAPIGet<Profile>(
-    username ? `/users/${username}` : null,
+    username ? viewerAwareCacheKey(`/users/${username}`, currentProfile?.id) : null,
     () => get('/users/' + username).then((res) => res.data),
     {
       onError: (err: unknown) => {
@@ -75,6 +81,23 @@ function UserPage() {
       return;
     }
     mutate();
+  };
+
+  const handleBlockChanged = async (blocked: boolean) => {
+    if (!userInfo) return;
+    await mutateUser({ ...userInfo, viewerHasBlocked: blocked }, { revalidate: false });
+
+    if (blocked) {
+      await mutate(
+        removeUserContentFromPages(data, {
+          id: userInfo.id,
+          username: userInfo.username,
+        }),
+        { revalidate: false }
+      );
+    } else {
+      await mutate();
+    }
   };
 
   if (hasLoadFailure) {
@@ -155,6 +178,16 @@ function UserPage() {
             />
           </div>
           <div className="mx-4 flex flex-col gap-1">
+            {currentProfile?.id && userInfo?.id && currentProfile.id !== userInfo.id && (
+              <div className="mb-2 flex justify-end">
+                <BlockUserButton
+                  blocked={userInfo.viewerHasBlocked === true}
+                  targetDisplayName={userInfo.nickname || userInfo.username}
+                  targetUserId={userInfo.id}
+                  onChanged={handleBlockChanged}
+                />
+              </div>
+            )}
             <div className="inline-flex items-center gap-1 text-2xl font-semibold">
               {userInfo?.nickname}
               {userInfo?.certified && <VerifiedIcon className="text-theme size-5 shrink-0" />}

--- a/web/src/pages/user/[username].tsx
+++ b/web/src/pages/user/[username].tsx
@@ -6,8 +6,9 @@ import LoadingPlaceholder from '@/components/others/LoadingPlaceholder';
 import PageRequestError from '@/components/others/PageRequestError';
 import UserAvatar from '@/components/others/UserAvatar';
 import RoteList from '@/components/rote/roteList';
-import BlockUserButton from '@/features/user-blocks/BlockUserButton';
+import BlockedUserNotesState from '@/features/user-blocks/BlockedUserNotesState';
 import { removeUserContentFromPages } from '@/features/user-blocks/cache';
+import UserBlockMenu from '@/features/user-blocks/UserBlockMenu';
 import { viewerAwareCacheKey } from '@/features/user-blocks/viewerCacheScope';
 import ContainerWithSideBar from '@/layout/ContainerWithSideBar';
 import { profileAtom } from '@/state/profile';
@@ -85,9 +86,9 @@ function UserPage() {
 
   const handleBlockChanged = async (blocked: boolean) => {
     if (!userInfo) return;
-    await mutateUser({ ...userInfo, viewerHasBlocked: blocked }, { revalidate: false });
 
     if (blocked) {
+      await mutateUser({ ...userInfo, viewerHasBlocked: true }, { revalidate: false });
       await mutate(
         removeUserContentFromPages(data, {
           id: userInfo.id,
@@ -95,9 +96,11 @@ function UserPage() {
         }),
         { revalidate: false }
       );
-    } else {
-      await mutate();
+      return;
     }
+
+    await mutate();
+    await mutateUser({ ...userInfo, viewerHasBlocked: false }, { revalidate: false });
   };
 
   if (hasLoadFailure) {
@@ -169,18 +172,16 @@ function UserPage() {
               alt=""
             />
           </div>
-          <div className="mx-4 flex h-16">
+          <div className="mx-4 flex h-16 items-center">
             {/* 主页顶部头像展示，shadcn Avatar 不支持 size 属性，直接用 className 控制尺寸 */}
             <UserAvatar
               avatar={userInfo?.avatar}
               className="bg-background size-20 shrink-0 translate-y-[-50%] border-[4px] sm:block"
               fallbackClassName="bg-muted/80"
             />
-          </div>
-          <div className="mx-4 flex flex-col gap-1">
             {currentProfile?.id && userInfo?.id && currentProfile.id !== userInfo.id && (
-              <div className="mb-2 flex justify-end">
-                <BlockUserButton
+              <div className="ml-auto flex items-center gap-2">
+                <UserBlockMenu
                   blocked={userInfo.viewerHasBlocked === true}
                   targetDisplayName={userInfo.nickname || userInfo.username}
                   targetUserId={userInfo.id}
@@ -188,6 +189,8 @@ function UserPage() {
                 />
               </div>
             )}
+          </div>
+          <div className="mx-4 flex flex-col gap-1">
             <div className="inline-flex items-center gap-1 text-2xl font-semibold">
               {userInfo?.nickname}
               {userInfo?.certified && <VerifiedIcon className="text-theme size-5 shrink-0" />}
@@ -209,7 +212,13 @@ function UserPage() {
           {t('publicNotes')}
         </div>
 
-        {userInfo && <RoteList data={data} loadMore={loadMore} mutate={mutate} />}
+        {userInfo ? (
+          userInfo.viewerHasBlocked ? (
+            <BlockedUserNotesState />
+          ) : (
+            <RoteList data={data} loadMore={loadMore} mutate={mutate} />
+          )
+        ) : null}
       </ContainerWithSideBar>
     </>
   );

--- a/web/src/route/main.tsx
+++ b/web/src/route/main.tsx
@@ -24,6 +24,7 @@ import Landing from '@/pages/landing';
 import Login from '@/pages/login';
 import OAuthAuthorizePage from '@/pages/oauth/authorize';
 import ProfilePage from '@/pages/profile';
+import BlockedUsersPage from '@/pages/profile/blocked';
 import SettingsPage from '@/pages/profile/setting';
 import SingleRotePage from '@/pages/rote/[roteid]';
 import SetupPage from '@/pages/setup';
@@ -168,6 +169,15 @@ export default function GlobalRouterProvider() {
               element: (
                 <ProtectedRoute>
                   <SettingsPage />
+                </ProtectedRoute>
+              ),
+              errorElement: <RouteErrorPage />,
+            },
+            {
+              path: 'profile/blocked',
+              element: (
+                <ProtectedRoute>
+                  <BlockedUsersPage />
                 </ProtectedRoute>
               ),
               errorElement: <RouteErrorPage />,

--- a/web/src/types/main.ts
+++ b/web/src/types/main.ts
@@ -157,6 +157,7 @@ export type Profile =
       createdAt: string;
       updatedAt: string;
       certified?: boolean;
+      viewerHasBlocked?: boolean;
       allowExplore?: boolean;
       hasPassword?: boolean;
       // 注意：authProvider 已移除，主登录方式可以通过 passwordhash 和 oauthBindings 推断
@@ -169,6 +170,16 @@ export type Profile =
       }>; // 新增：完整的绑定信息数组
     }
   | undefined;
+
+export type BlockedUserSummary = {
+  id: string;
+  username: string;
+  nickname: string | null;
+  avatar: string | null;
+  description: string | null;
+  certified: boolean;
+  blockedAt: string;
+};
 
 export type ProfileAction =
   | { type: 'updateProfile'; profile: Profile }
@@ -222,6 +233,7 @@ export type TempState = {
 export type ApiGetRotesParams = {
   archived?: boolean;
   apiType?: 'mine' | 'public' | 'userPublic';
+  viewerScope?: string;
   params?: {
     username?: string;
     limit?: number;

--- a/web/src/utils/fetcher.ts
+++ b/web/src/utils/fetcher.ts
@@ -1,4 +1,5 @@
 import type { ApiGetRotesParams } from '@/types/main';
+import { getViewerCacheScope } from '@/features/user-blocks/viewerCacheScope';
 import axios, { type AxiosResponse } from 'axios';
 import { useCallback } from 'react';
 import useSWR, { type SWRConfiguration } from 'swr';
@@ -42,9 +43,7 @@ export const swrMutationFetcher = async <TResponse, TData = unknown>(
   return fetcher<TResponse, TData>(method, url, data);
 };
 
-interface APIGetProps {
-  [key: string]: unknown;
-}
+type APIGetProps = Record<string, unknown> | readonly unknown[];
 
 export function useAPIGet<TData>(
   props: APIGetProps | string | null,
@@ -67,8 +66,15 @@ export function useAPIInfinite<TData = unknown>(
   fetcher: (_data: ApiGetRotesParams) => Promise<TData>,
   options?: SWRInfiniteConfiguration
 ) {
+  const getScopedKey = useCallback(
+    (pageIndex: number, previousPageData: TData | null) => {
+      const key = getKey(pageIndex, previousPageData);
+      return key ? { ...key, viewerScope: getViewerCacheScope() } : null;
+    },
+    [getKey]
+  );
   const { data, size, setSize, isLoading, isValidating, mutate, error } = useSWRInfinite(
-    getKey,
+    getScopedKey,
     fetcher,
     options
   );


### PR DESCRIPTION
## Summary

- add a normalized `user_blocks` table, Drizzle migration, constraints, cascade foreign keys, and query indexes
- add server-authoritative block/list/unblock APIs plus viewer-aware user profiles
- filter blocked authors and named reactions before pagination across public notes, search, random, detail, batch, articles, AI, MCP, and OpenKey surfaces
- reject authenticated reactions when either account has blocked the other while preserving anonymous public behavior
- add Web profile block/unblock actions, confirmation and rollback handling, a complete blocked-user management page, account-scoped viewer caches, and en/zh/ja localization
- document the API and the signed-in-only/public-content semantics

## Behavior

Blocking is account-level and server-authoritative. Signed-in users cannot see or interact with content across a block in either direction. The blocker can still open the target's public profile with `viewerHasBlocked=true` to unblock them; the reverse direction receives the same not-found response as a missing resource. Public resources remain publicly accessible to signed-out visitors.

## Validation

- `cd server && bun run lint`
- `cd server && bun run build`
- `cd server && POSTGRESQL_URL='postgres://rote:rote_password_123@localhost:5433/rote' bun test userBlocks/userBlock.integration.test.ts` — 11 passed, 45 expectations
- `cd server && POSTGRESQL_URL='postgres://rote:rote_password_123@localhost:5433/rote' bun run db:migrate`
- `cd web && bun run lint`
- `cd web && bun run build`
- `cd web && bun run test -- src/features/user-blocks/BlockUserButton.test.tsx src/features/user-blocks/cache.test.ts src/pages/profile/blocked/BlockedUsersPage.test.tsx` — 8 passed

## Companion iOS PR

- Rabithua/RoteIOS#36