### PR TITLE
Restrict anonymous reaction permissions

### DIFF
--- a/doc/userguide/SITE-API.md
+++ b/doc/userguide/SITE-API.md
@@ -123,6 +123,7 @@ curl -X GET 'https://your-domain.com/v2/api/site/status'
     },
     "frontendConfig": {
       "preReactions": ["❤️", "👍", "..."],
+      "anonymousPreReactions": ["❤️", "👍", "🎉", "..."],
       "permissionKeys": ["SENDROTE", "GETROTE", "EDITROTE"],
       "roteMaxLetter": 10000,
       "roteContentExpandedLetter": 600,
@@ -165,6 +166,7 @@ curl -X GET 'https://your-domain.com/v2/api/site/status'
       - `enabled`: boolean - 该提供商是否已启用
 - `frontendConfig`: object - 前端通用配置（从 main.json 统一下发）
   - `preReactions`: string[] - 预置表情列表（用于反应组件）
+  - `anonymousPreReactions`: string[] - 匿名用户允许新增的预置表情白名单
   - `permissionKeys`: string[] - OpenKey 权限 key 列表（如 `SENDROTE`、`GETROTE`、`EDITROTE`），前端自行映射展示文案
   - `roteMaxLetter`: number - 单条笔记最大字数限制
   - `roteContentExpandedLetter`: number - 内容展开阈值

--- a/server/json/main.json
+++ b/server/json/main.json
@@ -37,6 +37,20 @@
     "🌚",
     "🌝"
   ],
+  "anonymousPreReactions": [
+    "❤️",
+    "👍",
+    "🎉",
+    "👏",
+    "✨",
+    "💡",
+    "🚀",
+    "🙏",
+    "💪",
+    "🤝",
+    "🔥",
+    "🌟"
+  ],
   "roteMaxLetter": 10000,
   "roteContentExpandedLetter": 600,
   "safeRoutes": [

--- a/server/reactions/policy.test.ts
+++ b/server/reactions/policy.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'bun:test';
+import mainJson from '../json/main.json';
+import { anonymousPreReactions, isAnonymousReactionAllowed, mayAddReaction } from './policy';
+
+describe('anonymous reaction policy', () => {
+  it('contains twelve unique positive presets in the configured order', () => {
+    expect(anonymousPreReactions).toEqual([
+      '❤️',
+      '👍',
+      '🎉',
+      '👏',
+      '✨',
+      '💡',
+      '🚀',
+      '🙏',
+      '💪',
+      '🤝',
+      '🔥',
+      '🌟',
+    ]);
+    expect(new Set(anonymousPreReactions).size).toBe(12);
+    expect(
+      anonymousPreReactions.every((reaction) => mainJson.preReactions.includes(reaction))
+    ).toBe(true);
+  });
+
+  it('allows only configured anonymous reaction types', () => {
+    expect(isAnonymousReactionAllowed('❤️')).toBe(true);
+    expect(isAnonymousReactionAllowed('👎')).toBe(false);
+    expect(isAnonymousReactionAllowed('custom reaction')).toBe(false);
+  });
+
+  it('keeps custom reactions available to authenticated users', () => {
+    expect(mayAddReaction(false, '❤️')).toBe(true);
+    expect(mayAddReaction(false, 'custom reaction')).toBe(false);
+    expect(mayAddReaction(true, 'custom reaction')).toBe(true);
+  });
+});

--- a/server/reactions/policy.ts
+++ b/server/reactions/policy.ts
@@ -1,0 +1,13 @@
+import mainJson from '../json/main.json';
+
+export const anonymousPreReactions = mainJson.anonymousPreReactions;
+
+const anonymousReactionSet = new Set<string>(anonymousPreReactions);
+
+export function isAnonymousReactionAllowed(type: string): boolean {
+  return anonymousReactionSet.has(type);
+}
+
+export function mayAddReaction(isAuthenticated: boolean, type: string): boolean {
+  return isAuthenticated || isAnonymousReactionAllowed(type);
+}

--- a/server/reactions/route.test.ts
+++ b/server/reactions/route.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'bun:test';
+
+process.env.POSTGRESQL_URL ||= 'postgres://rote:rote_password_123@localhost:5433/rote';
+
+const { default: reactionsRouter } = await import('../route/v2/reaction');
+
+describe('anonymous reaction route policy', () => {
+  it('rejects a custom anonymous reaction before accessing the note', async () => {
+    const response = await reactionsRouter.request('/', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        type: 'custom reaction',
+        roteid: '10000000-0000-4000-8000-000000000001',
+        visitorId: 'anonymous-reaction-route-test',
+      }),
+    });
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      code: 403,
+      message: 'anonymous_reaction_not_allowed',
+      data: null,
+    });
+  });
+
+  it('treats an invalid access token as anonymous for reaction admission', async () => {
+    const response = await reactionsRouter.request('/', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer invalid-token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        type: '👎',
+        roteid: '10000000-0000-4000-8000-000000000001',
+        visitorId: 'anonymous-reaction-invalid-token-test',
+      }),
+    });
+
+    expect(response.status).toBe(403);
+    expect((await response.json()).message).toBe('anonymous_reaction_not_allowed');
+  });
+});

--- a/server/route/v2/reaction.ts
+++ b/server/route/v2/reaction.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import type { User } from '../../drizzle/schema';
 import { optionalJWT } from '../../middleware/jwtAuth';
+import { mayAddReaction } from '../../reactions/policy';
 import type { HonoContext, HonoVariables } from '../../types/hono';
 import { assertUsersMayInteract } from '../../userBlocks/service';
 import { addReaction, findRoteById, removeReaction } from '../../utils/dbMethods';
@@ -26,6 +27,10 @@ reactionsRouter.post('/', async (c: HonoContext) => {
 
   // 验证输入长度和格式
   ReactionCreateZod.parse(body);
+
+  if (!mayAddReaction(Boolean(user), type)) {
+    return c.json(createResponse(null, 'anonymous_reaction_not_allowed', 403), 403);
+  }
 
   // 验证 roteid 格式（zod 已经验证了 UUID 格式，但保留双重检查）
   if (!isValidUUID(roteid)) {

--- a/server/route/v2/site.ts
+++ b/server/route/v2/site.ts
@@ -222,6 +222,7 @@ siteRouter.get('/status', async (c: HonoContext) => {
       // 前端通用配置（来自 main.json）
       frontendConfig: {
         preReactions: mainJson.preReactions,
+        anonymousPreReactions: mainJson.anonymousPreReactions,
         permissionKeys: mainJson.openkeyPermissions,
         roteMaxLetter: mainJson.roteMaxLetter,
         roteContentExpandedLetter: mainJson.roteContentExpandedLetter,

--- a/web/src/components/rote/Reactions.test.tsx
+++ b/web/src/components/rote/Reactions.test.tsx
@@ -1,0 +1,201 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Reaction, Rote } from '@/types/main';
+
+import { ReactionsPart } from './Reactions';
+
+const mocks = vi.hoisted(() => ({
+  isAuthenticated: false,
+  visitorId: 'visitor-current' as string | null,
+  anonymousPreReactions: ['❤️', '👍'] as string[],
+  post: vi.fn(),
+  del: vi.fn(),
+}));
+
+vi.mock('@/components/animate-ui/text/sliding-number', () => ({
+  SlidingNumber: ({ number }: { number: number }) => <span>{number}</span>,
+}));
+
+vi.mock('@/components/ui/avatar', () => ({
+  Avatar: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  AvatarFallback: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  AvatarImage: () => null,
+}));
+
+vi.mock('@/components/ui/popover', () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/hooks/useSiteStatus', () => ({
+  useSiteStatus: () => ({
+    data: {
+      frontendConfig: {
+        preReactions: ['❤️', '👍', '👎'],
+        anonymousPreReactions: mocks.anonymousPreReactions,
+      },
+    },
+  }),
+}));
+
+vi.mock('@/state/profile', () => ({
+  useAuthState: () => ({
+    authReady: true,
+    isAuthenticated: mocks.isAuthenticated,
+    isAuthPending: false,
+    profile: mocks.isAuthenticated ? { id: 'user-current' } : undefined,
+  }),
+}));
+
+vi.mock('@/state/visitorId', () => ({ visitorIdAtom: {} }));
+vi.mock('jotai', () => ({ useAtom: () => [mocks.visitorId, vi.fn()] }));
+vi.mock('@/utils/api', () => ({
+  post: mocks.post,
+  del: mocks.del,
+}));
+vi.mock('@/utils/deviceFingerprint', () => ({
+  generateVisitorId: vi.fn(() => new Promise<string>(() => undefined)),
+  getVisitorInfo: vi.fn(() => ({})),
+}));
+
+const makeRote = (reactions: Reaction[] = []): Rote => ({
+  id: 'rote-id',
+  tags: [],
+  content: 'Reaction test',
+  state: 'public',
+  archived: false,
+  pin: false,
+  createdAt: '2026-08-01T00:00:00.000Z',
+  updatedAt: '2026-08-01T00:00:00.000Z',
+  author: {
+    username: 'author',
+    nickname: 'Author',
+    avatar: '',
+  },
+  attachments: [],
+  reactions,
+});
+
+const makeReaction = (patch: Partial<Reaction>): Reaction => ({
+  id: 'reaction-id',
+  type: 'custom',
+  roteid: 'rote-id',
+  createdAt: '2026-08-01T00:00:00.000Z',
+  updatedAt: '2026-08-01T00:00:00.000Z',
+  ...patch,
+});
+
+function renderReactions(rote = makeRote()) {
+  return render(
+    <MemoryRouter>
+      <ReactionsPart rote={rote} />
+    </MemoryRouter>
+  );
+}
+
+describe('ReactionsPart anonymous access', () => {
+  beforeEach(() => {
+    mocks.isAuthenticated = false;
+    mocks.visitorId = 'visitor-current';
+    mocks.anonymousPreReactions = ['❤️', '👍'];
+    mocks.post.mockReset();
+    mocks.del.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('shows only the server-provided anonymous presets', () => {
+    renderReactions();
+
+    expect(screen.getByText('❤️')).toBeInTheDocument();
+    expect(screen.getByText('👍')).toBeInTheDocument();
+    expect(screen.queryByText('👎')).not.toBeInTheDocument();
+  });
+
+  it('does not open the custom composer on anonymous long press', () => {
+    vi.useFakeTimers();
+    renderReactions();
+
+    fireEvent.pointerDown(screen.getByRole('button'), { button: 0, pointerType: 'touch' });
+    act(() => vi.advanceTimersByTime(2_000));
+
+    expect(screen.queryByPlaceholderText('placeholder')).not.toBeInTheDocument();
+  });
+
+  it('keeps another user custom reaction read-only', () => {
+    renderReactions(
+      makeRote([
+        makeReaction({
+          user: { username: 'other', nickname: 'Other', avatar: null },
+          userid: 'user-other',
+        }),
+      ])
+    );
+
+    fireEvent.click(screen.getByText('custom'));
+
+    expect(mocks.post).not.toHaveBeenCalled();
+    expect(mocks.del).not.toHaveBeenCalled();
+  });
+
+  it('does not treat a missing visitor id as ownership', () => {
+    mocks.visitorId = null;
+    renderReactions(
+      makeRote([
+        makeReaction({
+          user: { username: 'other', nickname: 'Other', avatar: null },
+          userid: 'user-other',
+          visitorId: null,
+        }),
+      ])
+    );
+
+    expect(screen.getByRole('button')).toBeDisabled();
+    fireEvent.click(screen.getByText('custom'));
+
+    expect(mocks.post).not.toHaveBeenCalled();
+    expect(mocks.del).not.toHaveBeenCalled();
+  });
+
+  it('hides the anonymous add control for an explicit empty allowlist', () => {
+    mocks.anonymousPreReactions = [];
+    renderReactions();
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('allows an anonymous visitor to remove their own legacy custom reaction', async () => {
+    mocks.del.mockResolvedValue({});
+    renderReactions(
+      makeRote([makeReaction({ id: 'legacy-reaction', visitorId: mocks.visitorId })])
+    );
+
+    fireEvent.click(screen.getByText('custom'));
+
+    await waitFor(() =>
+      expect(mocks.del).toHaveBeenCalledWith('/reactions/rote-id/custom?visitorId=visitor-current')
+    );
+  });
+
+  it('keeps the complete picker and custom composer for authenticated users', () => {
+    vi.useFakeTimers();
+    mocks.isAuthenticated = true;
+    renderReactions();
+
+    expect(screen.getByText('👎')).toBeInTheDocument();
+    fireEvent.pointerDown(screen.getByRole('button'), { button: 0, pointerType: 'touch' });
+    act(() => vi.advanceTimersByTime(2_000));
+    expect(screen.getByPlaceholderText('placeholder')).toBeInTheDocument();
+  });
+});

--- a/web/src/components/rote/Reactions.tsx
+++ b/web/src/components/rote/Reactions.tsx
@@ -2,6 +2,12 @@ import { SlidingNumber } from '@/components/animate-ui/text/sliding-number';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import {
+  availablePreReactions,
+  defaultAnonymousPreReactions,
+  mayCreateCustomReaction,
+  mayToggleReaction,
+} from '@/features/reactions/policy';
 import { useSiteStatus } from '@/hooks/useSiteStatus';
 import { useAuthState } from '@/state/profile';
 import { visitorIdAtom } from '@/state/visitorId';
@@ -38,9 +44,18 @@ export function ReactionsPart({ rote, mutate, mutateSingle }: ReactionsPartProps
     keyPrefix: 'components.reactions',
   });
   const preReactions = siteStatus?.frontendConfig?.preReactions ?? [];
+  const anonymousPreReactions: readonly string[] =
+    siteStatus?.frontendConfig?.anonymousPreReactions ?? defaultAnonymousPreReactions;
+  const pickerReactions = availablePreReactions(
+    isAuthenticated,
+    preReactions,
+    siteStatus?.frontendConfig?.anonymousPreReactions
+  );
+  const hasReactionPicker = isAuthenticated || pickerReactions.length > 0;
 
   const [open, setOpen] = useState(false);
   const [visitorId, setVisitorId] = useAtom(visitorIdAtom);
+  const isReactionIdentityReady = isAuthenticated || Boolean(visitorId);
   const [isLoading, setIsLoading] = useState(false);
   const [isVisitorIdLoading, setIsVisitorIdLoading] = useState(false);
 
@@ -51,6 +66,7 @@ export function ReactionsPart({ rote, mutate, mutateSingle }: ReactionsPartProps
   const isLongPressRef = React.useRef(false);
 
   const startLongPress = (e: React.PointerEvent) => {
+    if (!mayCreateCustomReaction(isAuthenticated)) return;
     if (e.button !== 0 && e.pointerType === 'mouse') return;
 
     isLongPressRef.current = false;
@@ -108,7 +124,7 @@ export function ReactionsPart({ rote, mutate, mutateSingle }: ReactionsPartProps
 
   const handleInlineSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (isLoading || !customReaction.trim()) {
+    if (!mayCreateCustomReaction(isAuthenticated) || isLoading || !customReaction.trim()) {
       setShowInlineInput(false);
       setCustomReaction('');
       return;
@@ -130,6 +146,13 @@ export function ReactionsPart({ rote, mutate, mutateSingle }: ReactionsPartProps
     }
   }, [authReady, isAuthenticated, visitorId, setVisitorId]);
 
+  React.useEffect(() => {
+    if (!isAuthenticated) {
+      setShowInlineInput(false);
+      setCustomReaction('');
+    }
+  }, [isAuthenticated]);
+
   const groupedReactions = rote.reactions.reduce(
     (acc, reaction) => {
       acc[reaction.type] = acc[reaction.type] || [];
@@ -140,7 +163,23 @@ export function ReactionsPart({ rote, mutate, mutateSingle }: ReactionsPartProps
   );
 
   const handleReactionClick = async (reactionType: string) => {
-    if (isAuthPending) {
+    if (isAuthPending || !isReactionIdentityReady) {
+      return;
+    }
+
+    const existingReaction = isAuthenticated
+      ? rote.reactions.find((r) => r.type === reactionType && r.userid === profile?.id)
+      : visitorId
+        ? rote.reactions.find((r) => r.type === reactionType && r.visitorId === visitorId)
+        : undefined;
+
+    if (
+      !mayToggleReaction({
+        isAuthenticated,
+        isAllowedAnonymousType: anonymousPreReactions.includes(reactionType),
+        hasOwnReaction: Boolean(existingReaction),
+      })
+    ) {
       return;
     }
 
@@ -148,10 +187,6 @@ export function ReactionsPart({ rote, mutate, mutateSingle }: ReactionsPartProps
     setIsLoading(true);
 
     try {
-      const existingReaction = isAuthenticated
-        ? rote.reactions.find((r) => r.type === reactionType && r.userid === profile?.id)
-        : rote.reactions.find((r) => r.type === reactionType && r.visitorId === visitorId);
-
       if (existingReaction) {
         await del(
           isAuthenticated
@@ -214,23 +249,35 @@ export function ReactionsPart({ rote, mutate, mutateSingle }: ReactionsPartProps
           const hasUserReactions = reactionGroup.some((r) => r.user);
           const isCustomReaction = !preReactions.includes(type);
           const firstUser = isCustomReaction ? reactionGroup.find((r) => r.user)?.user : null;
+          const hasOwnReaction = isAuthenticated
+            ? reactionGroup.some((reaction) => reaction.userid === profile?.id)
+            : Boolean(visitorId) &&
+              reactionGroup.some((reaction) => reaction.visitorId === visitorId);
+          const isInteractive =
+            isReactionIdentityReady &&
+            mayToggleReaction({
+              isAuthenticated,
+              isAllowedAnonymousType: anonymousPreReactions.includes(type),
+              hasOwnReaction,
+            });
 
           const ReactionButton = (
             <div
               className={`flex h-6 ${
-                isLoading ? 'cursor-not-allowed' : 'cursor-pointer'
+                isLoading || !isInteractive ? 'cursor-not-allowed' : 'cursor-pointer'
               } items-center gap-1.5 rounded-full ${
                 firstUser ? 'pr-2.5 pl-1' : 'px-2 pr-3'
               } text-xs duration-300 ${
                 (
                   isAuthenticated
                     ? rote.reactions.some((r) => r.type === type && r.userid === profile?.id)
-                    : rote.reactions.some((r) => r.type === type && r.visitorId === visitorId)
+                    : Boolean(visitorId) &&
+                      rote.reactions.some((r) => r.type === type && r.visitorId === visitorId)
                 )
                   ? 'border-theme/30 bg-theme/10 text-theme hover:bg-theme/30 border-[0.5px]'
                   : 'bg-foreground/5 hover:bg-foreground/5'
               }`}
-              onClick={() => (isLoading ? undefined : handleReactionClick(type))}
+              onClick={() => (isLoading || !isInteractive ? undefined : handleReactionClick(type))}
             >
               {firstUser && (
                 <Link
@@ -291,7 +338,7 @@ export function ReactionsPart({ rote, mutate, mutateSingle }: ReactionsPartProps
         })}
       </div>
 
-      {showInlineInput ? (
+      {mayCreateCustomReaction(isAuthenticated) && showInlineInput ? (
         <form
           onSubmit={handleInlineSubmit}
           className="bg-foreground/5 flex h-6 w-32 items-center rounded-2xl px-1.5 transition-all duration-300 focus-within:w-36"
@@ -308,11 +355,12 @@ export function ReactionsPart({ rote, mutate, mutateSingle }: ReactionsPartProps
             autoFocus
           />
         </form>
-      ) : (
+      ) : hasReactionPicker ? (
         <Popover open={open} onOpenChange={handleOpenChange}>
           <PopoverTrigger asChild>
             <button
               type="button"
+              disabled={!isReactionIdentityReady}
               className="transition-transform select-none focus:outline-none active:scale-95"
               style={{
                 WebkitUserSelect: 'none',
@@ -335,7 +383,7 @@ export function ReactionsPart({ rote, mutate, mutateSingle }: ReactionsPartProps
           </PopoverTrigger>
           <PopoverContent side="bottom" className="bg-background/90 w-fit p-0 backdrop-blur-sm">
             <div className="grid grid-cols-6 divide-x divide-y">
-              {preReactions.map((reaction) => (
+              {pickerReactions.map((reaction) => (
                 <div
                   className="flex size-10 cursor-pointer items-center justify-center"
                   key={reaction}
@@ -351,7 +399,7 @@ export function ReactionsPart({ rote, mutate, mutateSingle }: ReactionsPartProps
             </div>
           </PopoverContent>
         </Popover>
-      )}
+      ) : null}
     </div>
   );
 }

--- a/web/src/features/reactions/policy.test.ts
+++ b/web/src/features/reactions/policy.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import {
+  availablePreReactions,
+  defaultAnonymousPreReactions,
+  mayCreateCustomReaction,
+  mayToggleReaction,
+} from './policy';
+
+describe('reaction access policy', () => {
+  it('uses the complete preset list for authenticated users', () => {
+    expect(availablePreReactions(true, ['❤️', '👎'], [])).toEqual(['❤️', '👎']);
+  });
+
+  it('uses server anonymous presets and preserves an explicit empty list', () => {
+    expect(availablePreReactions(false, ['👎'], ['❤️'])).toEqual(['❤️']);
+    expect(availablePreReactions(false, ['👎'], [])).toEqual([]);
+  });
+
+  it('falls back to twelve anonymous presets for an older server', () => {
+    expect(availablePreReactions(false, [], undefined)).toEqual([
+      '❤️',
+      '👍',
+      '🎉',
+      '👏',
+      '✨',
+      '💡',
+      '🚀',
+      '🙏',
+      '💪',
+      '🤝',
+      '🔥',
+      '🌟',
+    ]);
+    expect(defaultAnonymousPreReactions).toHaveLength(12);
+  });
+
+  it('lets anonymous visitors add allowed reactions or remove their own legacy reaction', () => {
+    expect(
+      mayToggleReaction({
+        isAuthenticated: false,
+        isAllowedAnonymousType: true,
+        hasOwnReaction: false,
+      })
+    ).toBe(true);
+    expect(
+      mayToggleReaction({
+        isAuthenticated: false,
+        isAllowedAnonymousType: false,
+        hasOwnReaction: true,
+      })
+    ).toBe(true);
+    expect(
+      mayToggleReaction({
+        isAuthenticated: false,
+        isAllowedAnonymousType: false,
+        hasOwnReaction: false,
+      })
+    ).toBe(false);
+  });
+
+  it('reserves custom reaction creation for authenticated users', () => {
+    expect(mayCreateCustomReaction(false)).toBe(false);
+    expect(mayCreateCustomReaction(true)).toBe(true);
+  });
+});

--- a/web/src/features/reactions/policy.ts
+++ b/web/src/features/reactions/policy.ts
@@ -1,0 +1,41 @@
+export const defaultAnonymousPreReactions = [
+  '❤️',
+  '👍',
+  '🎉',
+  '👏',
+  '✨',
+  '💡',
+  '🚀',
+  '🙏',
+  '💪',
+  '🤝',
+  '🔥',
+  '🌟',
+] as const;
+
+interface ReactionAccessInput {
+  isAuthenticated: boolean;
+  isAllowedAnonymousType: boolean;
+  hasOwnReaction: boolean;
+}
+
+export function availablePreReactions(
+  isAuthenticated: boolean,
+  preReactions: readonly string[],
+  anonymousPreReactions?: readonly string[]
+): readonly string[] {
+  if (isAuthenticated) return preReactions;
+  return anonymousPreReactions ?? defaultAnonymousPreReactions;
+}
+
+export function mayToggleReaction({
+  isAuthenticated,
+  isAllowedAnonymousType,
+  hasOwnReaction,
+}: ReactionAccessInput): boolean {
+  return isAuthenticated || isAllowedAnonymousType || hasOwnReaction;
+}
+
+export function mayCreateCustomReaction(isAuthenticated: boolean): boolean {
+  return isAuthenticated;
+}

--- a/web/src/hooks/useSiteStatus.ts
+++ b/web/src/hooks/useSiteStatus.ts
@@ -9,6 +9,7 @@ interface SiteStatusResponse<T = any> {
 
 interface FrontendConfig {
   preReactions: string[];
+  anonymousPreReactions?: string[];
   permissionKeys: string[];
   roteMaxLetter: number;
   roteContentExpandedLetter: number;

--- a/web/src/types/main.ts
+++ b/web/src/types/main.ts
@@ -17,13 +17,13 @@ export interface Reaction {
   id: string;
   type: string; // 支持任意 Emoji 或反应类型字符串
   roteid: string;
-  userid?: string;
+  userid?: string | null;
   user?: {
     username: string;
     nickname: string | null;
     avatar: string | null;
   };
-  visitorId?: string;
+  visitorId?: string | null;
   visitorInfo?: any; // 存储访客的额外信息（IP、User-Agent等）
   metadata?: any; // 可以存储额外的反应数据
   createdAt: string;


### PR DESCRIPTION
## Summary

- define a fixed 12-item positive reaction allowlist for anonymous visitors
- expose the allowlist as `frontendConfig.anonymousPreReactions` while preserving the complete authenticated preset list
- enforce the anonymous policy at `POST /reactions`, including invalid JWT requests that fall back to anonymous identity
- keep authenticated, OpenKey, MCP, historical reaction visibility, and owner deletion behavior unchanged
- limit the Web picker and mutation paths, disable anonymous custom reactions, and preserve legacy owner deletion
- fall back to the built-in allowlist when the new site-status field is absent; treat an explicit empty array as disabling anonymous additions
- wait for a non-empty visitor ID before anonymous mutation so null owner fields cannot be mistaken for ownership

## Why

Anonymous visitors previously had the same reaction creation surface as authenticated users, including arbitrary custom reactions. This made abusive or unwanted anonymous reactions possible. The server now provides the authoritative boundary, while the Web client reflects the same policy and remains compatible with older servers.

## Validation

### Server

- targeted anonymous reaction policy and route tests passed
- `bun run lint`
- `bun run build`

### Web

- 32 test files / 146 tests passed
- `bun run lint`
- `bun run build`

Historical reactions are not migrated, hidden, or deleted by this change.