### PR TITLE
fix(server): detect and repair mislabelled HEIC uploads

### DIFF
--- a/server/attachments/attachmentUpload.test.ts
+++ b/server/attachments/attachmentUpload.test.ts
@@ -26,6 +26,12 @@ const uploadPolicy = {
   maxVideoUploadSizeMB: 300,
 };
 
+const detectedContentTypeForKey = async (key: string) => {
+  if (key.includes('mislabelled') || /\.(heic|heif)$/i.test(key)) return 'image/heic' as const;
+  if (/\.jpe?g$/i.test(key)) return 'image/jpeg' as const;
+  return null;
+};
+
 describe('attachment upload flow', () => {
   it('uses the signed Content-Type to choose the key extension', () => {
     expect(getUploadExtension('photo.webp', 'image/jpeg')).toBe('.jpg');
@@ -107,6 +113,7 @@ describe('attachment upload flow', () => {
       },
       {
         checkObjectExists: async (key) => key === originalKey || key === pairedVideoKey,
+        detectStoredImageContentTypeByKey: detectedContentTypeForKey,
         ensureHeicBrowserCover: async () => ({
           contentType: 'image/jpeg',
           key: coverKey,
@@ -152,6 +159,7 @@ describe('attachment upload flow', () => {
       },
       {
         checkObjectExists: async (key) => key === originalKey,
+        detectStoredImageContentTypeByKey: detectedContentTypeForKey,
         ensureHeicBrowserCover: async () => {
           coverCalls++;
           return {
@@ -171,6 +179,44 @@ describe('attachment upload flow', () => {
     expect(result[0].url).toBe(`${URL_PREFIX}/${originalKey}`);
     expect(result[0].compressUrl).toBe(`${URL_PREFIX}/${coverKey}`);
     expect(result[0].details.compressKey).toBe(coverKey);
+  });
+
+  it('corrects a mislabelled standalone HEIC and generates a JPEG cover', async () => {
+    const originalKey = `users/${USER_ID}/uploads/mislabelled-standalone.jpg`;
+    const coverKey = `users/${USER_ID}/compressed/mislabelled-standalone.v2.jpg`;
+
+    const result = await finalizeAttachmentUploads(
+      {
+        attachments: [
+          {
+            mimetype: 'image/jpeg',
+            mediaKind: 'image',
+            originalKey,
+            size: 1024,
+            uuid: 'mislabelled-standalone',
+          },
+        ],
+        scopes: [],
+        userId: USER_ID,
+      },
+      {
+        checkObjectExists: async (key) => key === originalKey,
+        detectStoredImageContentTypeByKey: detectedContentTypeForKey,
+        ensureHeicBrowserCover: async () => ({
+          contentType: 'image/jpeg',
+          key: coverKey,
+          size: 512,
+          status: 'generated',
+        }),
+        getAttachmentUploadPolicy: async () => uploadPolicy,
+        requireStorageAvailable: () => storageConfig,
+        upsertAttachmentsByOriginalKey: async (_userId, _noteId, uploads) => uploads,
+      }
+    );
+
+    expect(result[0].details.mimetype).toBe('image/heic');
+    expect(result[0].details.compressKey).toBe(coverKey);
+    expect(result[0].compressUrl).toBe(`${URL_PREFIX}/${coverKey}`);
   });
 
   it('reuses a browser-compatible JPEG Live Photo still without HEIC decoding', async () => {
@@ -197,6 +243,7 @@ describe('attachment upload flow', () => {
       },
       {
         checkObjectExists: async () => true,
+        detectStoredImageContentTypeByKey: detectedContentTypeForKey,
         ensureHeicBrowserCover: async () => {
           coverCalls++;
           throw new Error('JPEG still must not be sent to the HEIC decoder');
@@ -212,6 +259,89 @@ describe('attachment upload flow', () => {
     expect(result[0].compressUrl).toBe(`${URL_PREFIX}/${originalKey}`);
     expect(result[0].details.compressKey).toBe(originalKey);
     expect(result[0].details.pairedVideoKey).toBe(pairedVideoKey);
+  });
+
+  it('corrects a mislabelled HEIC Live Photo and generates a JPEG cover', async () => {
+    const originalKey = `users/${USER_ID}/uploads/mislabelled.jpg`;
+    const pairedVideoKey = `users/${USER_ID}/paired-videos/mislabelled.mov`;
+    const coverKey = `users/${USER_ID}/compressed/mislabelled.v2.jpg`;
+
+    const result = await finalizeAttachmentUploads(
+      {
+        attachments: [
+          {
+            mimetype: 'image/jpeg',
+            mediaKind: 'livePhoto',
+            originalKey,
+            pairedVideoKey,
+            pairedVideoMimetype: 'video/quicktime',
+            pairedVideoSize: 2048,
+            size: 1024,
+            uuid: 'mislabelled',
+          },
+        ],
+        scopes: ['video:upload'],
+        userId: USER_ID,
+      },
+      {
+        checkObjectExists: async () => true,
+        detectStoredImageContentTypeByKey: detectedContentTypeForKey,
+        ensureHeicBrowserCover: async () => ({
+          contentType: 'image/jpeg',
+          key: coverKey,
+          size: 512,
+          status: 'generated',
+        }),
+        getAttachmentUploadPolicy: async () => uploadPolicy,
+        requireStorageAvailable: () => storageConfig,
+        upsertAttachmentsByOriginalKey: async (_userId, _noteId, uploads) => uploads,
+      }
+    );
+
+    expect(result[0].details.mimetype).toBe('image/heic');
+    expect(result[0].details.compressKey).toBe(coverKey);
+    expect(result[0].compressUrl).toBe(`${URL_PREFIX}/${coverKey}`);
+  });
+
+  it('rejects finalize when an uploaded image signature cannot be read', async () => {
+    const originalKey = `users/${USER_ID}/uploads/unreadable.jpg`;
+    const pairedVideoKey = `users/${USER_ID}/paired-videos/unreadable.mov`;
+    let persisted = false;
+
+    await expect(
+      finalizeAttachmentUploads(
+        {
+          attachments: [
+            {
+              mimetype: 'image/jpeg',
+              mediaKind: 'livePhoto',
+              originalKey,
+              pairedVideoKey,
+              pairedVideoMimetype: 'video/quicktime',
+              pairedVideoSize: 2048,
+              size: 1024,
+              uuid: 'unreadable',
+            },
+          ],
+          scopes: ['video:upload'],
+          userId: USER_ID,
+        },
+        {
+          checkObjectExists: async () => true,
+          detectStoredImageContentTypeByKey: async () => {
+            throw new Error('range read failed');
+          },
+          getAttachmentUploadPolicy: async () => uploadPolicy,
+          requireStorageAvailable: () => storageConfig,
+          upsertAttachmentsByOriginalKey: async () => {
+            persisted = true;
+            return [];
+          },
+        }
+      )
+    ).rejects.toThrow(`Failed to inspect uploaded image ${originalKey}: range read failed`);
+
+    expect(persisted).toBe(false);
   });
 
   it('validates note attachment limits before generating a HEIC browser cover', async () => {
@@ -298,6 +428,7 @@ describe('attachment upload flow', () => {
       { attachments: inputs, scopes: ['video:upload'], userId: USER_ID },
       {
         checkObjectExists: async () => true,
+        detectStoredImageContentTypeByKey: detectedContentTypeForKey,
         getAttachmentUploadPolicy: async () => uploadPolicy,
         requireStorageAvailable: () => storageConfig,
         upsertAttachmentsByOriginalKey: async (_userId, _noteId, uploads) => {

--- a/server/attachments/finalizeUpload.ts
+++ b/server/attachments/finalizeUpload.ts
@@ -24,9 +24,11 @@ import attachmentErrors from './errorCodes.json';
 import { ensureHeicBrowserCover } from './heicBrowserCover';
 import { assertLivePhotoFinalizeBatch } from './livePhotoFinalize';
 import { finalizeInputIncludesVideo, isHeicLikeUpload } from './uploadMedia';
+import { detectStoredImageContentTypeByKey } from './storedImageContent';
 
 export type FinalizeAttachmentDependencies = {
   checkObjectExists: typeof checkObjectExists;
+  detectStoredImageContentTypeByKey: typeof detectStoredImageContentTypeByKey;
   ensureHeicBrowserCover: typeof ensureHeicBrowserCover;
   getAttachmentDetailsByRoteId: typeof getAttachmentDetailsByRoteId;
   getAttachmentUploadPolicy: typeof getAttachmentUploadPolicy;
@@ -36,6 +38,7 @@ export type FinalizeAttachmentDependencies = {
 
 const defaultDependencies: FinalizeAttachmentDependencies = {
   checkObjectExists,
+  detectStoredImageContentTypeByKey,
   ensureHeicBrowserCover,
   getAttachmentDetailsByRoteId,
   getAttachmentUploadPolicy,
@@ -275,14 +278,37 @@ export async function finalizeAttachmentUploads(
       pairedVideoKey: item.pairedVideoKey,
       key: item.originalKey,
     });
+    let detectedContentType: Awaited<ReturnType<typeof detectStoredImageContentTypeByKey>> = null;
+    if (mediaKind === 'image' || mediaKind === 'livePhoto') {
+      try {
+        detectedContentType = await dependencies.detectStoredImageContentTypeByKey(
+          item.originalKey
+        );
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error);
+        throw new Error(`Failed to inspect uploaded image ${item.originalKey}: ${reason}`);
+      }
+
+      if (detectedContentType && detectedContentType !== item.mimetype?.toLowerCase()) {
+        // eslint-disable-next-line no-console
+        console.info(
+          `[attachment-content-type] status=corrected originalKey=${item.originalKey} declared=${item.mimetype ?? 'missing'} detected=${detectedContentType}`
+        );
+        item.mimetype = detectedContentType;
+      }
+    }
+
+    const requiresHeicBrowserCover =
+      detectedContentType === 'image/heic' ||
+      (detectedContentType === null && isHeicLikeUpload(item));
     if (mediaKind === 'livePhoto') {
-      if (isHeicLikeUpload(item)) {
+      if (requiresHeicBrowserCover) {
         const cover = await dependencies.ensureHeicBrowserCover(item.originalKey);
         item.compressedKey = cover.key;
       } else {
         item.compressedKey = item.originalKey;
       }
-    } else if (mediaKind === 'image' && isHeicLikeUpload(item) && !item.compressedKey) {
+    } else if (mediaKind === 'image' && requiresHeicBrowserCover && !item.compressedKey) {
       const cover = await dependencies.ensureHeicBrowserCover(item.originalKey);
       item.compressedKey = cover.key;
     }

--- a/server/attachments/heicBrowserCoverBackfill.test.ts
+++ b/server/attachments/heicBrowserCoverBackfill.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'bun:test';
+import type { HeicBrowserCoverBackfillCandidate } from './heicBrowserCoverBackfill';
+
+process.env.POSTGRESQL_URL ||= 'postgres://test:test@localhost:5432/rote_test';
+const { processHeicBrowserCoverCandidate } = await import('./heicBrowserCoverBackfill');
+
+const candidate: HeicBrowserCoverBackfillCandidate = {
+  compressUrl: 'https://cdn.example.com/users/user-1/uploads/photo.jpg',
+  details: {
+    key: 'users/user-1/uploads/photo.jpg',
+    mediaKind: 'livePhoto',
+    mimetype: 'image/jpeg',
+  },
+  id: 'attachment-1',
+  url: 'https://cdn.example.com/users/user-1/uploads/photo.jpg',
+  userId: 'user-1',
+};
+
+const cover = {
+  contentType: 'image/jpeg' as const,
+  key: 'users/user-1/compressed/photo.v2.jpg',
+  size: 512,
+  status: 'generated' as const,
+};
+
+describe('mislabelled HEIC backfill candidates', () => {
+  it('inspects dry-run candidates without creating objects or writing data', async () => {
+    const result = await processHeicBrowserCoverCandidate(
+      candidate,
+      { detectMislabelled: true, dryRun: true, urlPrefix: 'https://cdn.example.com' },
+      {
+        detectStoredImageContentTypeByKey: async () => 'image/heic',
+        ensureHeicBrowserCover: async () => {
+          throw new Error('dry-run must not create a cover');
+        },
+        writeback: async () => {
+          throw new Error('dry-run must not write data');
+        },
+      }
+    );
+
+    expect(result).toEqual({ detectedHeic: true, reason: 'dry-run', status: 'skipped' });
+  });
+
+  it('skips JPEG objects discovered during a broad audit', async () => {
+    const result = await processHeicBrowserCoverCandidate(
+      candidate,
+      { detectMislabelled: true, dryRun: false, urlPrefix: 'https://cdn.example.com' },
+      {
+        detectStoredImageContentTypeByKey: async () => 'image/jpeg',
+        ensureHeicBrowserCover: async () => {
+          throw new Error('JPEG must not create a HEIC cover');
+        },
+        writeback: async () => {
+          throw new Error('JPEG must not write data');
+        },
+      }
+    );
+
+    expect(result).toEqual({
+      detectedHeic: false,
+      reason: 'detected-image/jpeg',
+      status: 'skipped',
+    });
+  });
+
+  it('does not overwrite an attachment changed concurrently', async () => {
+    let writebackDetails: Record<string, unknown> | undefined;
+    const result = await processHeicBrowserCoverCandidate(
+      candidate,
+      { detectMislabelled: true, dryRun: false, urlPrefix: 'https://cdn.example.com' },
+      {
+        detectStoredImageContentTypeByKey: async () => 'image/heic',
+        ensureHeicBrowserCover: async () => cover,
+        writeback: async ({ details }) => {
+          writebackDetails = details;
+          return false;
+        },
+      }
+    );
+
+    expect(result.status).toBe('skipped');
+    expect(result.reason).toBe('already-updated');
+    expect(result.detectedHeic).toBe(true);
+    expect(writebackDetails?.mimetype).toBe('image/heic');
+    expect(writebackDetails?.compressKey).toBe(cover.key);
+  });
+});

--- a/server/attachments/heicBrowserCoverBackfill.ts
+++ b/server/attachments/heicBrowserCoverBackfill.ts
@@ -1,18 +1,21 @@
 import { and, asc, eq, gt, isNull, or, sql, type SQL } from 'drizzle-orm';
 import { attachments } from '../drizzle/schema';
 import db from '../utils/drizzle';
-import { ensureHeicBrowserCover } from './heicBrowserCover';
+import { ensureHeicBrowserCover, type EnsureHeicBrowserCoverResult } from './heicBrowserCover';
+import { detectStoredImageContentTypeByKey } from './storedImageContent';
 import { requireStorageAvailable } from './types';
 
 export type HeicBrowserCoverBackfillOptions = {
   afterAttachmentId?: string;
   attachmentId?: string;
+  detectMislabelled?: boolean;
   dryRun?: boolean;
   limit?: number;
   noteId?: string;
 };
 
 export type HeicBrowserCoverBackfillResult = {
+  detectedHeic: number;
   failed: number;
   lastAttachmentId: string | null;
   scanned: number;
@@ -20,25 +23,110 @@ export type HeicBrowserCoverBackfillResult = {
   updated: number;
 };
 
+export type HeicBrowserCoverBackfillCandidate = {
+  compressUrl: string | null;
+  details: unknown;
+  id: string;
+  url: string;
+  userId: string | null;
+};
+
+export type HeicBrowserCoverCandidateResult = {
+  cover?: EnsureHeicBrowserCoverResult;
+  detectedHeic: boolean;
+  reason: string;
+  status: 'failed' | 'skipped' | 'updated';
+};
+
+export type HeicBrowserCoverCandidateDependencies = {
+  detectStoredImageContentTypeByKey: typeof detectStoredImageContentTypeByKey;
+  ensureHeicBrowserCover: typeof ensureHeicBrowserCover;
+  writeback: (_input: {
+    candidate: HeicBrowserCoverBackfillCandidate;
+    compressUrl: string;
+    details: Record<string, unknown>;
+    originalKey: string;
+  }) => Promise<boolean>;
+};
+
 export function isOwnedAttachmentOriginalKey(userId: string, originalKey: string): boolean {
   return originalKey.startsWith(`users/${userId}/uploads/`);
 }
 
 function getCandidateFilters(options: HeicBrowserCoverBackfillOptions): SQL[] {
+  const previewNeedsRepair = or(
+    isNull(attachments.compressUrl),
+    eq(attachments.compressUrl, ''),
+    sql`${attachments.compressUrl} = ${attachments.url}`,
+    sql`(${attachments.compressUrl} ~* ${String.raw`/compressed/[^/?]+\.jpg(\?.*)?$`} AND ${attachments.compressUrl} !~* ${String.raw`\.v2\.jpg(\?.*)?$`})`
+  )!;
   const filters: SQL[] = [
     sql`${attachments.details}->>'mediaKind' IN ('image', 'livePhoto')`,
-    sql`${attachments.url} ~* ${'\\.(heic|heif)(\\?.*)?$'}`,
-    or(
-      isNull(attachments.compressUrl),
-      eq(attachments.compressUrl, ''),
-      sql`(${attachments.compressUrl} ~* ${'/compressed/[^/?]+\\.jpg(\\?.*)?$'} AND ${attachments.compressUrl} !~* ${'\\.v2\\.jpg(\\?.*)?$'})`
-    )!,
+    previewNeedsRepair,
     or(isNull(attachments.posterUrl), eq(attachments.posterUrl, ''))!,
   ];
+  if (!options.detectMislabelled) {
+    filters.push(sql`${attachments.url} ~* ${String.raw`\.(heic|heif)(\?.*)?$`}`);
+  }
   if (options.afterAttachmentId) filters.push(gt(attachments.id, options.afterAttachmentId));
   if (options.attachmentId) filters.push(eq(attachments.id, options.attachmentId));
   if (options.noteId) filters.push(eq(attachments.roteid, options.noteId));
   return filters;
+}
+
+export async function processHeicBrowserCoverCandidate(
+  candidate: HeicBrowserCoverBackfillCandidate,
+  options: Pick<HeicBrowserCoverBackfillOptions, 'detectMislabelled' | 'dryRun'> & {
+    urlPrefix: string;
+  },
+  dependencies: HeicBrowserCoverCandidateDependencies
+): Promise<HeicBrowserCoverCandidateResult> {
+  const details =
+    candidate.details && typeof candidate.details === 'object' && !Array.isArray(candidate.details)
+      ? (candidate.details as Record<string, unknown>)
+      : {};
+  const originalKey = typeof details.key === 'string' ? details.key : '';
+  if (!originalKey) {
+    return { detectedHeic: false, reason: 'details.key-is-empty', status: 'failed' };
+  }
+  if (!candidate.userId || !isOwnedAttachmentOriginalKey(candidate.userId, originalKey)) {
+    return { detectedHeic: false, reason: 'ownership-mismatch', status: 'skipped' };
+  }
+
+  try {
+    if (options.detectMislabelled) {
+      const detected = await dependencies.detectStoredImageContentTypeByKey(originalKey);
+      if (detected !== 'image/heic') {
+        return {
+          detectedHeic: false,
+          reason: `detected-${detected ?? 'unknown'}`,
+          status: 'skipped',
+        };
+      }
+    }
+
+    if (options.dryRun) {
+      return { detectedHeic: true, reason: 'dry-run', status: 'skipped' };
+    }
+
+    const cover = await dependencies.ensureHeicBrowserCover(originalKey);
+    const compressUrl = `${options.urlPrefix}/${cover.key}`;
+    const updated = await dependencies.writeback({
+      candidate,
+      compressUrl,
+      details: { ...details, compressKey: cover.key, mimetype: 'image/heic' },
+      originalKey,
+    });
+    return updated
+      ? { cover, detectedHeic: true, reason: 'writeback-success', status: 'updated' }
+      : { cover, detectedHeic: true, reason: 'already-updated', status: 'skipped' };
+  } catch (error) {
+    return {
+      detectedHeic: false,
+      reason: error instanceof Error ? error.message : String(error),
+      status: 'failed',
+    };
+  }
 }
 
 export async function backfillHeicBrowserCovers(
@@ -61,87 +149,67 @@ export async function backfillHeicBrowserCovers(
 
   // eslint-disable-next-line no-console
   console.info(
-    `[heic-cover-backfill] status=started candidates=${candidates.length} dryRun=${Boolean(options.dryRun)} attachmentId=${options.attachmentId ?? 'all'} noteId=${options.noteId ?? 'all'} afterAttachmentId=${options.afterAttachmentId ?? 'start'} limit=${options.limit ?? 'all'}`
+    `[heic-cover-backfill] status=started candidates=${candidates.length} detectMislabelled=${Boolean(options.detectMislabelled)} dryRun=${Boolean(options.dryRun)} attachmentId=${options.attachmentId ?? 'all'} noteId=${options.noteId ?? 'all'} afterAttachmentId=${options.afterAttachmentId ?? 'start'} limit=${options.limit ?? 'all'}`
   );
 
+  let detectedHeic = 0;
   let failed = 0;
   let skipped = 0;
   let updated = 0;
   for (const candidate of candidates) {
-    const details = candidate.details as Record<string, unknown>;
-    const originalKey = typeof details.key === 'string' ? details.key : '';
-    if (!originalKey) {
-      failed++;
-      // eslint-disable-next-line no-console
-      console.error(
-        `[heic-cover-backfill] status=failed attachmentId=${candidate.id} originalKey=missing reason=details.key-is-empty`
-      );
-      continue;
-    }
-    if (!candidate.userId || !isOwnedAttachmentOriginalKey(candidate.userId, originalKey)) {
-      skipped++;
-      // eslint-disable-next-line no-console
-      console.error(
-        `[heic-cover-backfill] status=skipped attachmentId=${candidate.id} originalKey=${originalKey} reason=ownership-mismatch`
-      );
-      continue;
-    }
-
-    if (options.dryRun) {
-      skipped++;
-      // eslint-disable-next-line no-console
-      console.info(
-        `[heic-cover-backfill] status=dry-run attachmentId=${candidate.id} originalKey=${originalKey} writeback=skipped`
-      );
-      continue;
-    }
-
-    try {
-      const cover = await ensureHeicBrowserCover(originalKey);
-      const compressUrl = `${urlPrefix}/${cover.key}`;
-      const writeback = await db
-        .update(attachments)
-        .set({
-          compressUrl,
-          details: { ...details, compressKey: cover.key },
-          updatedAt: new Date(),
-        })
-        .where(
-          and(
-            eq(attachments.id, candidate.id),
-            candidate.compressUrl
-              ? eq(attachments.compressUrl, candidate.compressUrl)
-              : or(isNull(attachments.compressUrl), eq(attachments.compressUrl, '')),
-            or(isNull(attachments.posterUrl), eq(attachments.posterUrl, ''))
-          )
-        )
-        .returning({ id: attachments.id });
-
-      if (writeback.length === 0) {
-        skipped++;
-        // eslint-disable-next-line no-console
-        console.info(
-          `[heic-cover-backfill] status=skipped attachmentId=${candidate.id} originalKey=${originalKey} format=jpeg outputKey=${cover.key} outputBytes=${cover.size} writeback=already-updated`
-        );
-        continue;
+    const result = await processHeicBrowserCoverCandidate(
+      candidate,
+      { detectMislabelled: options.detectMislabelled, dryRun: options.dryRun, urlPrefix },
+      {
+        detectStoredImageContentTypeByKey,
+        ensureHeicBrowserCover,
+        writeback: async ({ candidate, compressUrl, details, originalKey }) => {
+          const writeback = await db
+            .update(attachments)
+            .set({ compressUrl, details, updatedAt: new Date() })
+            .where(
+              and(
+                eq(attachments.id, candidate.id),
+                eq(attachments.url, candidate.url),
+                eq(attachments.userid, candidate.userId!),
+                eq(attachments.details, candidate.details),
+                sql`${attachments.details}->>'key' = ${originalKey}`,
+                candidate.compressUrl
+                  ? eq(attachments.compressUrl, candidate.compressUrl)
+                  : or(isNull(attachments.compressUrl), eq(attachments.compressUrl, '')),
+                or(isNull(attachments.posterUrl), eq(attachments.posterUrl, ''))
+              )
+            )
+            .returning({ id: attachments.id });
+          return writeback.length > 0;
+        },
       }
+    );
 
-      updated++;
-      // eslint-disable-next-line no-console
-      console.info(
-        `[heic-cover-backfill] status=updated attachmentId=${candidate.id} originalKey=${originalKey} format=jpeg outputKey=${cover.key} outputBytes=${cover.size} writeback=success`
-      );
-    } catch (error) {
-      failed++;
-      const reason = error instanceof Error ? error.message : String(error);
+    if (result.detectedHeic) detectedHeic++;
+    if (result.status === 'failed') failed++;
+    if (result.status === 'skipped') skipped++;
+    if (result.status === 'updated') updated++;
+    const details = candidate.details as Record<string, unknown>;
+    const originalKey = typeof details.key === 'string' ? details.key : 'missing';
+    const coverDetails = result.cover
+      ? ` outputKey=${result.cover.key} outputBytes=${result.cover.size}`
+      : '';
+    if (result.status === 'failed') {
       // eslint-disable-next-line no-console
       console.error(
-        `[heic-cover-backfill] status=failed attachmentId=${candidate.id} originalKey=${originalKey} reason=${reason}`
+        `[heic-cover-backfill] status=${result.status} attachmentId=${candidate.id} originalKey=${originalKey} detectedHeic=${result.detectedHeic} reason=${result.reason}${coverDetails}`
+      );
+    } else {
+      // eslint-disable-next-line no-console
+      console.info(
+        `[heic-cover-backfill] status=${result.status} attachmentId=${candidate.id} originalKey=${originalKey} detectedHeic=${result.detectedHeic} reason=${result.reason}${coverDetails}`
       );
     }
   }
 
   const result = {
+    detectedHeic,
     failed,
     lastAttachmentId: candidates[candidates.length - 1]?.id ?? null,
     scanned: candidates.length,
@@ -150,7 +218,7 @@ export async function backfillHeicBrowserCovers(
   };
   // eslint-disable-next-line no-console
   console.info(
-    `[heic-cover-backfill] status=completed scanned=${result.scanned} updated=${updated} skipped=${skipped} failed=${failed} lastAttachmentId=${result.lastAttachmentId ?? 'none'}`
+    `[heic-cover-backfill] status=completed scanned=${result.scanned} detectedHeic=${detectedHeic} updated=${updated} skipped=${skipped} failed=${failed} lastAttachmentId=${result.lastAttachmentId ?? 'none'}`
   );
   return result;
 }

--- a/server/attachments/heicBrowserCoverBackfillWorker.test.ts
+++ b/server/attachments/heicBrowserCoverBackfillWorker.test.ts
@@ -30,6 +30,7 @@ describe('automatic HEIC browser cover backfill', () => {
     const calls: HeicBrowserCoverBackfillOptions[] = [];
     const results: HeicBrowserCoverBackfillResult[] = [
       {
+        detectedHeic: 18,
         failed: 2,
         lastAttachmentId: 'attachment-020',
         scanned: HEIC_COVER_BACKFILL_BATCH_SIZE,
@@ -37,6 +38,7 @@ describe('automatic HEIC browser cover backfill', () => {
         updated: 18,
       },
       {
+        detectedHeic: 2,
         failed: 0,
         lastAttachmentId: 'attachment-023',
         scanned: 3,
@@ -65,6 +67,7 @@ describe('automatic HEIC browser cover backfill', () => {
     ]);
     expect(result).toEqual({
       acquiredLock: true,
+      detectedHeic: 20,
       failed: 2,
       scanned: 23,
       skipped: 1,
@@ -89,6 +92,7 @@ describe('automatic HEIC browser cover backfill', () => {
     expect(called).toBe(false);
     expect(result).toEqual({
       acquiredLock: false,
+      detectedHeic: 0,
       failed: 0,
       scanned: 0,
       skipped: 0,

--- a/server/attachments/heicBrowserCoverBackfillWorker.ts
+++ b/server/attachments/heicBrowserCoverBackfillWorker.ts
@@ -33,13 +33,14 @@ export async function runAutomaticHeicBrowserCoverBackfill(
   const withLock = dependencyOverrides.withLock ?? withDatabaseAdvisoryLock;
   const locked = await withLock(HEIC_COVER_BACKFILL_LOCK, async () => {
     let afterAttachmentId: string | undefined;
-    const aggregate = { failed: 0, scanned: 0, skipped: 0, updated: 0 };
+    const aggregate = { detectedHeic: 0, failed: 0, scanned: 0, skipped: 0, updated: 0 };
 
     while (true) {
       const batch = await runBackfill({
         afterAttachmentId,
         limit: HEIC_COVER_BACKFILL_BATCH_SIZE,
       });
+      aggregate.detectedHeic += batch.detectedHeic;
       aggregate.failed += batch.failed;
       aggregate.scanned += batch.scanned;
       aggregate.skipped += batch.skipped;
@@ -61,12 +62,19 @@ export async function runAutomaticHeicBrowserCoverBackfill(
   if (!locked.acquired) {
     // eslint-disable-next-line no-console
     console.info('[heic-cover-backfill] status=skipped reason=lock-held-by-another-instance');
-    return { acquiredLock: false, failed: 0, scanned: 0, skipped: 0, updated: 0 };
+    return {
+      acquiredLock: false,
+      detectedHeic: 0,
+      failed: 0,
+      scanned: 0,
+      skipped: 0,
+      updated: 0,
+    };
   }
 
   // eslint-disable-next-line no-console
   console.info(
-    `[heic-cover-backfill] status=automatic-completed scanned=${locked.result.scanned} updated=${locked.result.updated} skipped=${locked.result.skipped} failed=${locked.result.failed}`
+    `[heic-cover-backfill] status=automatic-completed scanned=${locked.result.scanned} detectedHeic=${locked.result.detectedHeic} updated=${locked.result.updated} skipped=${locked.result.skipped} failed=${locked.result.failed}`
   );
   return { acquiredLock: true, ...locked.result };
 }

--- a/server/attachments/storedImageContent.test.ts
+++ b/server/attachments/storedImageContent.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'bun:test';
+import { detectStoredImageContentType } from './storedImageContent';
+
+function ftyp(majorBrand: string, compatibleBrands: string[] = []): Uint8Array {
+  const bytes = new Uint8Array(16 + compatibleBrands.length * 4);
+  new DataView(bytes.buffer).setUint32(0, bytes.byteLength);
+  bytes.set(Buffer.from('ftyp'), 4);
+  bytes.set(Buffer.from(majorBrand), 8);
+  compatibleBrands.forEach((brand, index) => bytes.set(Buffer.from(brand), 16 + index * 4));
+  return bytes;
+}
+
+describe('stored image content detection', () => {
+  it('detects JPEG signatures', () => {
+    expect(detectStoredImageContentType(Uint8Array.from([0xff, 0xd8, 0xff, 0xe1]))).toBe(
+      'image/jpeg'
+    );
+  });
+
+  it('detects HEIC from the major brand', () => {
+    expect(detectStoredImageContentType(ftyp('heic'))).toBe('image/heic');
+  });
+
+  it('detects HEIC from a compatible brand', () => {
+    expect(detectStoredImageContentType(ftyp('mif1', ['miaf', 'heic']))).toBe('image/heic');
+  });
+
+  it('does not classify unrelated ISO media as HEIC', () => {
+    expect(detectStoredImageContentType(ftyp('qt  ', ['mp42']))).toBeNull();
+  });
+});

--- a/server/attachments/storedImageContent.ts
+++ b/server/attachments/storedImageContent.ts
@@ -1,0 +1,51 @@
+import { getObjectPrefix } from '../utils/r2';
+
+export const STORED_IMAGE_SIGNATURE_BYTES = 64;
+
+const HEIF_BRANDS = new Set([
+  'heic',
+  'heix',
+  'hevc',
+  'hevx',
+  'heim',
+  'heis',
+  'hevm',
+  'hevs',
+  'mif1',
+  'msf1',
+]);
+
+export type DetectedStoredImageContentType = 'image/heic' | 'image/jpeg';
+
+function ascii(bytes: Uint8Array, offset: number, length: number): string {
+  return String.fromCharCode(...bytes.subarray(offset, offset + length)).toLowerCase();
+}
+
+export function detectStoredImageContentType(
+  bytes: Uint8Array
+): DetectedStoredImageContentType | null {
+  if (bytes.byteLength >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) {
+    return 'image/jpeg';
+  }
+
+  if (bytes.byteLength < 12 || ascii(bytes, 4, 4) !== 'ftyp') return null;
+
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const declaredBoxSize = view.getUint32(0);
+  const boxEnd =
+    declaredBoxSize >= 16 ? Math.min(declaredBoxSize, bytes.byteLength) : bytes.byteLength;
+  const brands = [ascii(bytes, 8, 4)];
+  for (let offset = 16; offset + 4 <= boxEnd; offset += 4) {
+    brands.push(ascii(bytes, offset, 4));
+  }
+
+  return brands.some((brand) => HEIF_BRANDS.has(brand)) ? 'image/heic' : null;
+}
+
+export async function detectStoredImageContentTypeByKey(
+  key: string,
+  readPrefix: typeof getObjectPrefix = getObjectPrefix
+): Promise<DetectedStoredImageContentType | null> {
+  const bytes = await readPrefix(key, STORED_IMAGE_SIGNATURE_BYTES);
+  return detectStoredImageContentType(bytes);
+}

--- a/server/scripts/backfillHeicBrowserCovers.ts
+++ b/server/scripts/backfillHeicBrowserCovers.ts
@@ -1,27 +1,98 @@
-import { backfillHeicBrowserCovers } from '../attachments/heicBrowserCoverBackfill';
+import {
+  backfillHeicBrowserCovers,
+  type HeicBrowserCoverBackfillOptions,
+  type HeicBrowserCoverBackfillResult,
+} from '../attachments/heicBrowserCoverBackfill';
 import { initializeConfig } from '../utils/config';
 import { closeDatabase } from '../utils/drizzle';
+
+const DEFAULT_BATCH_SIZE = 20;
 
 function getOption(name: string): string | undefined {
   const index = process.argv.indexOf(name);
   return index >= 0 ? process.argv[index + 1] : undefined;
 }
 
-if (require.main === module) {
-  initializeConfig()
-    .then(() =>
-      backfillHeicBrowserCovers({
-        attachmentId: getOption('--attachment-id'),
-        dryRun: process.argv.includes('--dry-run'),
-        noteId: getOption('--note-id'),
-      })
-    )
-    .then(async () => {
-      await closeDatabase();
-    })
-    .catch(async (error) => {
-      console.error('[heic-cover-backfill] status=fatal', error);
-      await closeDatabase();
-      process.exitCode = 1;
+function getPositiveIntegerOption(name: string): number | undefined {
+  const value = getOption(name);
+  if (value === undefined) return undefined;
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function emptyAggregate(): Omit<HeicBrowserCoverBackfillResult, 'lastAttachmentId'> {
+  return { detectedHeic: 0, failed: 0, scanned: 0, skipped: 0, updated: 0 };
+}
+
+function addBatch(
+  aggregate: Omit<HeicBrowserCoverBackfillResult, 'lastAttachmentId'>,
+  batch: HeicBrowserCoverBackfillResult
+): void {
+  aggregate.detectedHeic += batch.detectedHeic;
+  aggregate.failed += batch.failed;
+  aggregate.scanned += batch.scanned;
+  aggregate.skipped += batch.skipped;
+  aggregate.updated += batch.updated;
+}
+
+async function run(options: HeicBrowserCoverBackfillOptions, allBatches: boolean) {
+  if (!allBatches) return backfillHeicBrowserCovers(options);
+
+  const batchSize = options.limit ?? DEFAULT_BATCH_SIZE;
+  const aggregate = emptyAggregate();
+  let afterAttachmentId = options.afterAttachmentId;
+  let lastAttachmentId: string | null = null;
+  while (true) {
+    const batch = await backfillHeicBrowserCovers({
+      ...options,
+      afterAttachmentId,
+      limit: batchSize,
     });
+    addBatch(aggregate, batch);
+    lastAttachmentId = batch.lastAttachmentId;
+    if (
+      batch.scanned < batchSize ||
+      !batch.lastAttachmentId ||
+      batch.lastAttachmentId === afterAttachmentId
+    ) {
+      break;
+    }
+    afterAttachmentId = batch.lastAttachmentId;
+  }
+
+  const result = { ...aggregate, lastAttachmentId };
+  console.info(
+    `[heic-cover-backfill] status=all-batches-completed scanned=${result.scanned} detectedHeic=${result.detectedHeic} updated=${result.updated} skipped=${result.skipped} failed=${result.failed} lastAttachmentId=${result.lastAttachmentId ?? 'none'}`
+  );
+  return result;
+}
+
+async function main(): Promise<void> {
+  await initializeConfig();
+  try {
+    const result = await run(
+      {
+        afterAttachmentId: getOption('--after-attachment-id'),
+        attachmentId: getOption('--attachment-id'),
+        detectMislabelled: process.argv.includes('--detect-mislabelled'),
+        dryRun: process.argv.includes('--dry-run'),
+        limit: getPositiveIntegerOption('--limit'),
+        noteId: getOption('--note-id'),
+      },
+      process.argv.includes('--all-batches')
+    );
+    if (result.failed > 0) process.exitCode = 1;
+  } finally {
+    await closeDatabase();
+  }
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error('[heic-cover-backfill] status=fatal', error);
+    process.exitCode = 1;
+  });
 }

--- a/server/utils/r2.ts
+++ b/server/utils/r2.ts
@@ -360,6 +360,39 @@ export async function getObjectBytes(key: string): Promise<Uint8Array> {
   return result.Body.transformToByteArray();
 }
 
+export async function getObjectPrefix(key: string, maxBytes: number): Promise<Uint8Array> {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 1 || maxBytes > 4096) {
+    throw new Error(`Invalid storage prefix length: ${maxBytes}`);
+  }
+
+  const r2Config = getR2Client();
+  if (!r2Config) {
+    throw new Error(
+      'R2 storage is not configured. Please complete the storage configuration first.'
+    );
+  }
+
+  const result = await r2Config.s3.send(
+    new GetObjectCommand({
+      Bucket: r2Config.bucketName,
+      Key: key,
+      Range: `bytes=0-${maxBytes - 1}`,
+    })
+  );
+  if (!result.Body) {
+    throw new Error(`Storage object has no body: ${key}`);
+  }
+  if (result.ContentLength && result.ContentLength > maxBytes) {
+    throw new Error(`Storage endpoint ignored byte range for object: ${key}`);
+  }
+
+  const bytes = await result.Body.transformToByteArray();
+  if (bytes.byteLength === 0) {
+    throw new Error(`Storage object prefix is empty: ${key}`);
+  }
+  return bytes.subarray(0, maxBytes);
+}
+
 export async function putObjectBytes(
   key: string,
   bytes: Uint8Array,


### PR DESCRIPTION
## Summary
- inspect the first 64 bytes of finalized image objects and correct mislabelled HEIC metadata
- generate browser-safe `.v2.jpg` covers without replacing original HEIC or paired Live Photo video objects
- extend the backfill CLI with signature detection, batching, dry-run inspection, and concurrency-safe writeback

## Validation
- `bun test attachments/storedImageContent.test.ts attachments/heicBrowserCoverBackfill.test.ts attachments/attachmentUpload.test.ts attachments/heicBrowserCoverBackfillWorker.test.ts`
- `bun run lint`
- `bun run build`