### PR TITLE
Ship HEIC backfill CLI in backend image

### DIFF
--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -69,4 +69,5 @@ vitest.config.*
 # 脚本文件（运行时不需要，但保留迁移脚本）
 scripts/*
 !scripts/runMigrations.ts
+!scripts/backfillHeicBrowserCovers.ts
 *.sh

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -61,6 +61,11 @@ RUN if [ ! -d "./drizzle/migrations" ]; then \
       echo "💡 This indicates migrations were not copied correctly during build." && \
       exit 1; \
     fi && \
+    if [ ! -f "./dist/scripts/backfillHeicBrowserCovers.js" ]; then \
+      echo "❌ ERROR: HEIC browser cover backfill CLI not found!" && \
+      echo "💡 This indicates the operations CLI was excluded from the runtime image." && \
+      exit 1; \
+    fi && \
     echo "✅ Migration files verified successfully"
 
 # 🔥 终极清理：删除所有不必要的文件以减小镜像大小


### PR DESCRIPTION
## Summary
- include the HEIC browser-cover backfill entrypoint in the Docker build context
- fail the runtime-image build when the compiled operations CLI is missing

## Validation
- bun run lint
- bun run build
- Docker build reached dependency installation with the corrected build context; final local image build was canceled after the registry dependency step stalled