### PR TITLE
docs: plan Rote Pro subscription integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ For more deployment options and configuration instructions, please check the doc
 - [API Key Guide](doc/userguide/API-KEY-GUIDE.md) - How to use API Key
 - [AI Vector Migration Guide](doc/userguide/AI-VECTOR-MIGRATION.zh.md) - Upgrade an existing self-hosted database to Memory and pgvector support (Chinese)
 - [User-local AI Guide](doc/userguide/LOCAL-AI.zh.md) - Run Gemma on the user's own computer without sending model requests through the Rote server (Chinese)
+- [Rote Pro Billing Integration](doc/paid-subscription-integration.zh.md) - Optional official-instance subscription projection design (Chinese)
+- [Rote Pro Server Plan](doc/paid-subscription-plan.zh.md) - Server-side implementation phases and acceptance criteria (Chinese)
 
 ### Video Tutorials (Bilibili)
 

--- a/doc/README.zh.md
+++ b/doc/README.zh.md
@@ -115,10 +115,12 @@ iOS App 支持连接到你自部署的后端。
 更多部署选项和配置说明，请查看 `doc/` 目录下的文档：
 
 - [自托管部署指南](https://rote.ink/doc/selfhosted) - 完整的部署和配置说明
-- [API 文档](doc/userguide/API-ENDPOINTS.md) - API 接口使用指南
-- [API Key 指南](doc/userguide/API-KEY-GUIDE.md) - 如何使用 API Key
-- [AI Vector 迁移指南](doc/userguide/AI-VECTOR-MIGRATION.zh.md) - 旧版线上数据库升级到记忆与 pgvector 的操作说明
+- [API 文档](userguide/API-ENDPOINTS.md) - API 接口使用指南
+- [API Key 指南](userguide/API-KEY-GUIDE.md) - 如何使用 API Key
+- [AI Vector 迁移指南](userguide/AI-VECTOR-MIGRATION.zh.md) - 旧版线上数据库升级到记忆与 pgvector 的操作说明
 - [用户本地 AI 指南](userguide/LOCAL-AI.zh.md) - 在用户自己的电脑运行 Gemma，模型请求不经过 Rote 服务端
+- [Rote Pro 订阅接入设计](paid-subscription-integration.zh.md) - 官方实例的可选订阅授权投影方案
+- [Rote Pro 服务端实施计划](paid-subscription-plan.zh.md) - 服务端分阶段任务与验收标准
 
 ### 视频教程（B 站）
 

--- a/doc/paid-subscription-integration.zh.md
+++ b/doc/paid-subscription-integration.zh.md
@@ -59,20 +59,11 @@ callback 应在数据库事务中比较 revision 并完整 upsert：
 - 相同 revision/相同 hash：200 duplicate。
 - 相同 revision/不同 hash：409 并告警。
 
-grant 表可以引用用户，但删除流程不能依靠 cascade 撤销 Paid 状态。
+grant 表应随本地用户删除而删除；Paid 不参与删除事务，并在下一次 lease refresh callback 收到 404 后自行转为 orphaned。
 
 ### `billing_inbound_deliveries`
 
 保存 HMAC `deliveryId`、keyId、body hash 和最终响应，用于重放防护。相同 ID/相同 body 返回保存的响应；相同 ID/不同 body 返回 409。记录至少保留 24 小时，grant revision 继续提供永久顺序保护。
-
-### `billing_account_event_outbox`
-
-账号 merge/delete 需要 Rote→Paid 的 durable outbox，不能在用户事务后 fire-and-forget：
-
-- 保存不可变 `eventId`、event type、source/target userId、occurredAt、payload、attempt 和 nextAttemptAt。
-- 不使用随 `users` 删除而 cascade 的外键。
-- 账号事务内先写 outbox，再完成 delete；worker 使用 HMAC 投递 `account-events`。
-- 重试直到 Paid 返回 2xx/幂等成功；401/403 立即告警。
 
 ### 安全限额数据
 
@@ -102,7 +93,7 @@ v1
 <lowercase-hex-sha256-of-exact-body-bytes>
 ```
 
-Rote 发送请求和接收 callback 必须复用同一经过 fixture 验证的 canonicalization 实现。时间偏差最大 300 秒。body 的 `requestId`、`eventId` 或 `deliveryId` 必须等于 header request ID。比较签名使用 constant-time API。
+Rote 发送请求和接收 callback 必须复用同一经过 fixture 验证的 canonicalization 实现。时间偏差最大 300 秒。body 的 `requestId` 或 `deliveryId` 必须等于 header request ID。比较签名使用 constant-time API。幂等唯一键是方向 + request/delivery ID，不能包含 keyId；keyId 只作审计，避免轮换时重复执行。
 
 轮换时接收端同时接受 active/previous keyId，发送端只使用 active；排空后移除 previous。日志不得包含 secret、签名、Authorization、完整 JWS 或完整交易 ID。
 
@@ -182,7 +173,7 @@ disabled 时仍返回 200 和 `enabled: false`。不得返回 Paid URL、keyId �
 
 验证 issuer/instance、revision 格式、ISO 日期、`leaseExpiresAt <= entitlementExpiresAt` 和 capability allowlist。撤销 snapshot 使用 `status: none`、null product/expiry、空 capabilities。
 
-用户在 merge/delete 后不存在时，只有空 snapshot callback 才返回 404；非空 snapshot 返回 409 并告警，防止授权投向未知用户。
+目标用户不存在时，无论 snapshot 是否为空都返回标准 JSON 404，message 固定为 `billing_grant_user_not_found`。Paid 只把该结构化错误解释为账号已删除；反向代理/未知格式 404 不得触发 orphaned。Rote 不发送专用删除事件。
 
 ## 7. capability 解析
 
@@ -255,11 +246,10 @@ presign 流程：
 
 ## 10. 账号生命周期
 
-- merge 用户事务写入 `account.merged` outbox，包含 source/target；Paid 回调空 source grant 和聚合 target grant。
-- delete 在用户记录消失前写 `account.deleted` outbox；事件记录不得被 cascade。
-- worker 重试使用同一 eventId，Paid 幂等处理。
-- 删除后 source 的空 grant callback 404 是预期终态；非空授权 404 不是成功。
-- Rote 不自行解释 Apple transaction，也不直接移动订阅归属。
+- v1 不实现 Paid account event outbox、订阅账号 alias、自动转移或删除后的自动重新认领。
+- 账号 merge 开始前只读 source/target 的本地 billing grant；任一账号最后状态为 active、grace_period 或 lease-expired `unavailable` 时返回 409 `billing_account_operation_requires_support`，不执行自动合并。只有明确 `none` 时沿用现有 merge。
+- 账号删除不依赖 Paid 可用性：正常删除用户，本地 billing grant 随用户删除。下一次 Paid 定期续租 callback 得到 404 后会把映射标记 orphaned。
+- Rote 不自行解释 Apple transaction，也不直接移动订阅归属；orphaned 订阅不迁移，支持只提供原账号、取消或退款指引。
 
 ## 11. 错误与故障语义
 
@@ -270,7 +260,10 @@ presign 流程：
 | 400 | `billing_invalid_transaction` | 停止自动重试并展示支持入口 |
 | 403 | `billing_environment_not_allowed` | Sandbox 非 allowlist |
 | 409 | `billing_subscription_owned_by_another_account` | 展示账号归属提示 |
+| 409 | `billing_account_operation_requires_support` | 有有效订阅的账号不支持自动合并 |
 | 429 | `billing_safety_limit_reached` | 按返回时间重试 |
+
+内部 callback 的 `billing_grant_user_not_found` 不返回给 App。
 
 原有能力不足错误继续为 `capability_required:<capability>`。
 
@@ -283,4 +276,4 @@ presign 流程：
 - override deny 高于 subscription；dependency 能关闭 video；subscription validUntil 缺失/损坏/过期 fail closed。
 - AI 多实例速率、并发、token 边界和异常 finally 释放。
 - 视频 batch、Live Photo、重复 presign、放弃 reservation、actual bytes 和 UTC 日切。
-- merge/delete outbox 在用户删除和 worker 重启后仍可送达。
+- 有 active/grace 订阅的账号 merge 被阻止；账号删除不调用 Paid，grant cascade 删除，下一次 callback 404。

--- a/doc/paid-subscription-integration.zh.md
+++ b/doc/paid-subscription-integration.zh.md
@@ -1,0 +1,286 @@
+# Rote Pro 订阅服务端接入设计
+
+本文只定义开源 Rote Server 的实现边界。Apple 订阅验证、归属、通知和运行规则的权威规范位于私有 `Rabithua/RotePaidServer`；若两者冲突，先修订主规范，再同步本文。
+
+## 1. 设计边界
+
+Rote Server 仍是唯一 capability 判定方。Paid Server 只把 Apple 订阅转换为最长 24 小时的授权快照；AI、附件和 `/permissions/me` 不实时请求 Paid Server。
+
+- 未配置 Paid Server 的自托管实例行为完全不变。
+- v1 只有官方 origin `https://api.rote.ink` 启用购买桥接。
+- Web v1 不提供购买页；它只消费与 iOS 相同的服务端 capability 结果。
+- 客户端 StoreKit 状态不能绕过 Rote capability middleware。
+
+## 2. 配置
+
+建议新增类型安全配置：
+
+```text
+BILLING_ENABLED=false
+BILLING_INSTANCE_ID=rote-official
+BILLING_OFFICIAL_ORIGIN=https://api.rote.ink
+BILLING_PAID_SERVER_URL=https://billing.rote.ink
+BILLING_PRODUCT_IDS=ink.rote.pro.monthly,ink.rote.pro.yearly
+BILLING_ROTE_TO_PAID_ACTIVE_KEY_ID=<id>
+BILLING_ROTE_TO_PAID_ACTIVE_SECRET=<secret>
+BILLING_ROTE_TO_PAID_PREVIOUS_KEY_ID=<optional>
+BILLING_ROTE_TO_PAID_PREVIOUS_SECRET=<optional>
+BILLING_PAID_TO_ROTE_ACTIVE_KEY_ID=<id>
+BILLING_PAID_TO_ROTE_ACTIVE_SECRET=<secret>
+BILLING_PAID_TO_ROTE_PREVIOUS_KEY_ID=<optional>
+BILLING_PAID_TO_ROTE_PREVIOUS_SECRET=<optional>
+```
+
+约束：
+
+- `BILLING_ENABLED=false` 时不得要求任何 Paid 配置，四个公开 billing endpoint 中 config 返回 disabled，其余返回 `billing_not_configured`。
+- enabled 时 origin 必须是精确 HTTPS URL，Paid URL 不得暴露给客户端。
+- 发送/接收 secret 必须不同，active/previous 必须成对配置。
+- Product ID 必须属于编译期允许集合，不能仅信任环境变量。
+
+## 3. 本地数据
+
+### `billing_grants`
+
+每个 Rote user 保留一份完整投影：
+
+- `user_id` 唯一。
+- `issuer`、`instance_id`。
+- `revision bigint`；API JSON 使用十进制字符串。
+- `plan_id`、`status`、`product_id`。
+- `entitlement_expires_at`、`lease_expires_at`。
+- `capabilities jsonb`，写入前只接受已知 capability。
+- `snapshot_hash`、`updated_at`。
+
+callback 应在数据库事务中比较 revision 并完整 upsert：
+
+- 更高 revision：应用。
+- 更低 revision：200 ignored。
+- 相同 revision/相同 hash：200 duplicate。
+- 相同 revision/不同 hash：409 并告警。
+
+grant 表可以引用用户，但删除流程不能依靠 cascade 撤销 Paid 状态。
+
+### `billing_inbound_deliveries`
+
+保存 HMAC `deliveryId`、keyId、body hash 和最终响应，用于重放防护。相同 ID/相同 body 返回保存的响应；相同 ID/不同 body 返回 409。记录至少保留 24 小时，grant revision 继续提供永久顺序保护。
+
+### `billing_account_event_outbox`
+
+账号 merge/delete 需要 Rote→Paid 的 durable outbox，不能在用户事务后 fire-and-forget：
+
+- 保存不可变 `eventId`、event type、source/target userId、occurredAt、payload、attempt 和 nextAttemptAt。
+- 不使用随 `users` 删除而 cascade 的外键。
+- 账号事务内先写 outbox，再完成 delete；worker 使用 HMAC 投递 `account-events`。
+- 重试直到 Paid 返回 2xx/幂等成功；401/403 立即告警。
+
+### 安全限额数据
+
+- AI 使用分布式速率计数、并发 lease 和滚动 token ledger；多实例部署不得使用纯内存计数。
+- 视频使用 `(user_id, client_upload_id)` 唯一 reservation，包含逻辑视频数、预估字节、过期时间和 committed 状态。
+- finalized 附件的计费字段必须能区分视频原件、poster、Live Photo 配对视频和静态图。
+
+## 4. HMAC 协议
+
+请求头：
+
+```http
+X-Rote-Key-Id: <key-id>
+X-Rote-Timestamp: <unix-seconds>
+X-Rote-Request-Id: <UUIDv7>
+X-Rote-Signature: v1=<lowercase-hex-hmac-sha256>
+```
+
+canonical string 固定为：
+
+```text
+v1
+<UPPERCASE_METHOD>
+<path-and-canonical-query>
+<unix-seconds>
+<request-id>
+<lowercase-hex-sha256-of-exact-body-bytes>
+```
+
+Rote 发送请求和接收 callback 必须复用同一经过 fixture 验证的 canonicalization 实现。时间偏差最大 300 秒。body 的 `requestId`、`eventId` 或 `deliveryId` 必须等于 header request ID。比较签名使用 constant-time API。
+
+轮换时接收端同时接受 active/previous keyId，发送端只使用 active；排空后移除 previous。日志不得包含 secret、签名、Authorization、完整 JWS 或完整交易 ID。
+
+## 5. 对 App API
+
+路径均位于 `/v2/api`，沿用 `{ code, message, data }`。
+
+### `GET /billing/config`
+
+无需登录，只读本地配置：
+
+```json
+{
+  "enabled": true,
+  "officialOrigin": "https://api.rote.ink",
+  "products": ["ink.rote.pro.monthly", "ink.rote.pro.yearly"],
+  "features": { "offerCode": true, "promotedPurchases": false }
+}
+```
+
+disabled 时仍返回 200 和 `enabled: false`。不得返回 Paid URL、keyId 或 Sandbox allowlist。
+
+### `GET /billing/me`
+
+要求登录，只读 `billing_grants`。响应字段：
+
+```json
+{
+  "planId": "rote_pro",
+  "status": "active",
+  "productId": "ink.rote.pro.yearly",
+  "entitlementExpiresAt": "2027-08-07T00:00:00.000Z",
+  "leaseExpiresAt": "2026-08-08T00:00:00.000Z",
+  "capabilities": ["ai.chat", "attachment.video.upload"]
+}
+```
+
+本地时间不早于 lease 时返回 `status: unavailable` 和空 capabilities；不得为了刷新页面同步查询 Paid。无记录返回 `status: none`。
+
+### `POST /billing/app-store/session`
+
+要求登录，body 为 `{}`。Rote 生成 UUIDv7 requestId，以当前 JWT userId 调用 Paid `POST /v1/rote/accounts/session`，返回 appAccountToken 和本地 allowlist Product ID。
+
+### `POST /billing/app-store/activate`
+
+要求登录：
+
+```json
+{ "signedTransactionInfo": "<JWS>" }
+```
+
+- 设置严格 body 长度上限；不解析或记录完整 JWS。
+- 生成 requestId 调用 Paid `POST /v1/rote/app-store/activate`。
+- 在事务中按更高 revision 应用返回 snapshot，成功后才向 App 返回 200。
+- Paid 已成功而本地写入失败时返回 503 `billing_provider_unavailable`；App 保持 transaction unfinished，Paid outbox 后续修复。
+
+## 6. Paid callback
+
+### `PUT /internal/billing/grants/:userId`
+
+该路由不接受 Rote JWT，只接受 Paid→Rote HMAC。body：
+
+```json
+{
+  "deliveryId": "UUIDv7",
+  "issuer": "rote-paid-server",
+  "instanceId": "rote-official",
+  "revision": "42",
+  "planId": "rote_pro",
+  "status": "active",
+  "productId": "ink.rote.pro.yearly",
+  "entitlementExpiresAt": "2027-08-07T00:00:00.000Z",
+  "leaseExpiresAt": "2026-08-08T00:00:00.000Z",
+  "capabilities": ["ai.chat", "attachment.video.upload"]
+}
+```
+
+验证 issuer/instance、revision 格式、ISO 日期、`leaseExpiresAt <= entitlementExpiresAt` 和 capability allowlist。撤销 snapshot 使用 `status: none`、null product/expiry、空 capabilities。
+
+用户在 merge/delete 后不存在时，只有空 snapshot callback 才返回 404；非空 snapshot 返回 409 并告警，防止授权投向未知用户。
+
+## 7. capability 解析
+
+现有类型增加：
+
+```ts
+type CapabilitySource =
+  | 'user_override'
+  | 'subscription'
+  | 'role_policy'
+  | 'role_default'
+  | 'dependency';
+
+type EffectiveCapability = {
+  allowed: boolean;
+  source: CapabilitySource;
+  role: string;
+  validUntil?: string;
+};
+```
+
+优先级：
+
+1. super-admin。
+2. 有效 user override，包括 deny。
+3. 本地有效 subscription grant。
+4. role policy。
+5. role default。
+6. dependency 后处理。
+
+subscription 只有在 status active/grace、lease 晚于当前时间且包含 capability 时参与。subscription source 的 `validUntil` 必须等于 leaseExpiresAt；缺失、无效或已过期按 deny。其他 source 不要求该字段，保证旧客户端兼容。
+
+Rote Pro 直接授予 `ai.chat`、`attachment.video.upload`；视频最终仍要求 dependency `attachment.upload`。管理员 user override deny 能压过订阅。
+
+## 8. AI 安全限额
+
+仅对由 `subscription` 解锁的普通用户应用 Rote Pro 保护限额；super-admin、管理员明确 override 和自托管 role policy 沿用原配置，避免订阅功能改变开源实例管理语义。
+
+- 10 次请求/滚动 60 秒。
+- 2 个同时执行的模型生成。
+- 200,000 token/滚动 24 小时。
+
+开始模型调用前按以下顺序原子执行：
+
+1. 检查并占用一分钟请求计数。
+2. 清理过期并发 lease，获取一个最长覆盖请求 timeout 的槽。
+3. 汇总 token ledger；已达到 200,000 时拒绝。
+4. 对输入、历史和最大输出使用服务端硬上限。
+5. 在 finally 释放并发槽；成功/已得到 provider usage 的失败请求写实际 token。
+
+达到限制返回 HTTP 429、`billing_safety_limit_reached`，data 包含 `limitKind`、`retryAfterSeconds`/`windowEndsAt`。两个已开始的请求可以造成有限超量，除此之外不能先放行再异步统计。
+
+## 9. 视频安全限额
+
+同样仅对 subscription 来源应用：
+
+- 视频相关已提交对象总计 10GB。
+- UTC 自然日最多 20 个逻辑视频附件。
+- 一个 Live Photo 配对视频计 1；批量请求按逻辑视频元素数计，不按 HTTP 次数计。
+
+presign 流程：
+
+1. 客户端为每个逻辑附件发送稳定 `clientUploadId`、类型和预估字节。
+2. Rote 在事务中计算 committed + 未过期 reserved 次数/容量，创建短期 reservation。
+3. 相同 `(userId, clientUploadId)` 重试返回同一 reservation，不重复占额。
+4. finalize 验证对象元数据，原子将 reservation committed，并以实际字节更新用量。
+5. 未 finalize reservation 到期释放；对象清理任务处理已上传但未提交的孤儿。
+
+10GB 包含视频原件、视频 poster、Live Photo 配对视频；Live Photo 静态图片按普通附件存储，不计视频容量。失败返回 429 同一错误码和 `limitKind`、`resetAt`/支持信息，不实现额度 dashboard。
+
+## 10. 账号生命周期
+
+- merge 用户事务写入 `account.merged` outbox，包含 source/target；Paid 回调空 source grant 和聚合 target grant。
+- delete 在用户记录消失前写 `account.deleted` outbox；事件记录不得被 cascade。
+- worker 重试使用同一 eventId，Paid 幂等处理。
+- 删除后 source 的空 grant callback 404 是预期终态；非空授权 404 不是成功。
+- Rote 不自行解释 Apple transaction，也不直接移动订阅归属。
+
+## 11. 错误与故障语义
+
+| HTTP | message | 行为 |
+| --- | --- | --- |
+| 403 | `billing_not_configured` | 不展示/不重试购买入口 |
+| 503 | `billing_provider_unavailable` | 保留 StoreKit transaction，稍后重试 |
+| 400 | `billing_invalid_transaction` | 停止自动重试并展示支持入口 |
+| 403 | `billing_environment_not_allowed` | Sandbox 非 allowlist |
+| 409 | `billing_subscription_owned_by_another_account` | 展示账号归属提示 |
+| 429 | `billing_safety_limit_reached` | 按返回时间重试 |
+
+原有能力不足错误继续为 `capability_required:<capability>`。
+
+## 12. 验收场景
+
+- billing disabled 时现有登录、权限、AI 和上传测试无变化。
+- callback 的高/低/相同 revision、相同 revision 冲突、HMAC active/previous、过期和重放。
+- `/billing/me` 在 lease 到期时本地失效，Paid 故障不阻塞读取。
+- 激活本地写失败返回 503，后续 callback 可恢复。
+- override deny 高于 subscription；dependency 能关闭 video；subscription validUntil 缺失/损坏/过期 fail closed。
+- AI 多实例速率、并发、token 边界和异常 finally 释放。
+- 视频 batch、Live Photo、重复 presign、放弃 reservation、actual bytes 和 UTC 日切。
+- merge/delete outbox 在用户删除和 worker 重启后仍可送达。

--- a/doc/paid-subscription-integration.zh.md
+++ b/doc/paid-subscription-integration.zh.md
@@ -67,9 +67,9 @@ grant 表应随本地用户删除而删除；Paid 不参与删除事务，并在
 
 ### 安全限额数据
 
-- AI 使用分布式速率计数、并发 lease 和滚动 token ledger；多实例部署不得使用纯内存计数。
-- 视频使用 `(user_id, client_upload_id)` 唯一 reservation，包含逻辑视频数、预估字节、过期时间和 committed 状态。
-- finalized 附件的计费字段必须能区分视频原件、poster、Live Photo 配对视频和静态图。
+- AI 使用共享存储保存滚动分钟请求计数、UTC 日请求计数和带过期时间的并发 lease；多实例部署不得使用纯内存计数。
+- v1 不创建 token ledger、视频 quota/reservation 表，也不为了订阅限额扩展客户端上传协议。
+- 视频数量和存储增长从现有 finalized 附件数据聚合为运维指标，不作为 v1 用户级计费账本。
 
 ## 4. HMAC 协议
 
@@ -214,35 +214,27 @@ Rote Pro 直接授予 `ai.chat`、`attachment.video.upload`；视频最终仍要
 
 - 10 次请求/滚动 60 秒。
 - 2 个同时执行的模型生成。
-- 200,000 token/滚动 24 小时。
+- 每个 UTC 自然日最多 100 次实际发送给模型 provider 的请求。
 
 开始模型调用前按以下顺序原子执行：
 
-1. 检查并占用一分钟请求计数。
-2. 清理过期并发 lease，获取一个最长覆盖请求 timeout 的槽。
-3. 汇总 token ledger；已达到 200,000 时拒绝。
-4. 对输入、历史和最大输出使用服务端硬上限。
-5. 在 finally 释放并发槽；成功/已得到 provider usage 的失败请求写实际 token。
+1. 清理过期并发 lease，获取一个最长覆盖请求 timeout 的槽。
+2. 在共享存储中检查分钟和 UTC 日计数；只有即将实际 dispatch 的请求才递增日计数。
+3. 继续应用现有模型上下文、输入和最大输出限制，不另建订阅 token 预算。
+4. 在 finally 释放并发槽；provider timeout、取消和异常退出同样释放。
 
-达到限制返回 HTTP 429、`billing_safety_limit_reached`，data 包含 `limitKind`、`retryAfterSeconds`/`windowEndsAt`。两个已开始的请求可以造成有限超量，除此之外不能先放行再异步统计。
+达到限制返回 HTTP 429、`billing_safety_limit_reached`，data 包含稳定 `limitKind` 和适用的 `retryAfterSeconds`/`resetAt`。不提供 token 余额或用量仪表盘。服务端另保留全局 AI 紧急关闭开关，成本通过 provider 预算/告警和低基数服务指标监控。
 
-## 9. 视频安全限额
+## 9. 视频 v1 最小保护
 
-同样仅对 subscription 来源应用：
+v1 不实现订阅专用的 20 次/日、10GB 用户容量、presign reservation、Live Photo 计费分类或新的 `clientUploadId` 协议。视频上传：
 
-- 视频相关已提交对象总计 10GB。
-- UTC 自然日最多 20 个逻辑视频附件。
-- 一个 Live Photo 配对视频计 1；批量请求按逻辑视频元素数计，不按 HTTP 次数计。
+- 继续服从现有单文件大小、文件类型、对象存在性和附件安全校验。
+- 从现有 finalized 附件记录采集视频数量、字节和存储增长指标，不新增用户配额账本。
+- 配置全局紧急停用能力，并对存储增长和对象存储成本设置运维告警。
+- 停用或存储故障使用现有服务可用性错误语义，不返回暗示用户需要再次购买的限额/paywall 错误。
 
-presign 流程：
-
-1. 客户端为每个逻辑附件发送稳定 `clientUploadId`、类型和预估字节。
-2. Rote 在事务中计算 committed + 未过期 reserved 次数/容量，创建短期 reservation。
-3. 相同 `(userId, clientUploadId)` 重试返回同一 reservation，不重复占额。
-4. finalize 验证对象元数据，原子将 reservation committed，并以实际字节更新用量。
-5. 未 finalize reservation 到期释放；对象清理任务处理已上传但未提交的孤儿。
-
-10GB 包含视频原件、视频 poster、Live Photo 配对视频；Live Photo 静态图片按普通附件存储，不计视频容量。失败返回 429 同一错误码和 `limitKind`、`resetAt`/支持信息，不实现额度 dashboard。
+先观察真实用量、成本和滥用分布；只有数据证明现有保护不足时，才另行设计用户级次数/容量限制。该延期决策不得被实现阶段自行替换为临时 quota 表。
 
 ## 10. 账号生命周期
 
@@ -261,7 +253,7 @@ presign 流程：
 | 403 | `billing_environment_not_allowed` | Sandbox 非 allowlist |
 | 409 | `billing_subscription_owned_by_another_account` | 展示账号归属提示 |
 | 409 | `billing_account_operation_requires_support` | 有有效订阅的账号不支持自动合并 |
-| 429 | `billing_safety_limit_reached` | 按返回时间重试 |
+| 429 | `billing_safety_limit_reached` | AI 基础防滥用触发，按返回时间重试 |
 
 内部 callback 的 `billing_grant_user_not_found` 不返回给 App。
 
@@ -274,6 +266,6 @@ presign 流程：
 - `/billing/me` 在 lease 到期时本地失效，Paid 故障不阻塞读取。
 - 激活本地写失败返回 503，后续 callback 可恢复。
 - override deny 高于 subscription；dependency 能关闭 video；subscription validUntil 缺失/损坏/过期 fail closed。
-- AI 多实例速率、并发、token 边界和异常 finally 释放。
-- 视频 batch、Live Photo、重复 presign、放弃 reservation、actual bytes 和 UTC 日切。
+- AI 多实例分钟/日计数、并发 lease、异常 finally 释放和紧急开关。
+- 视频沿用现有上传校验，finalized 用量指标和全局停用不会引导用户再次购买。
 - 有 active/grace 订阅的账号 merge 被阻止；账号删除不调用 Paid，grant cascade 删除，下一次 callback 404。

--- a/doc/paid-subscription-plan.zh.md
+++ b/doc/paid-subscription-plan.zh.md
@@ -5,9 +5,9 @@
 ## 阶段 1：配置、schema 与 contract fixtures
 
 - 增加 billing 类型安全配置；默认 disabled，缺少配置不得影响自托管启动。
-- 增加 grant、inbound delivery 和 account event outbox migration；event outbox 不使用删除级联外键。
+- 增加 grant 和 inbound delivery migration；grant 随本地用户删除，不增加 account event outbox。
 - 从 Paid 主规范复制无秘密的 HMAC/request/snapshot fixtures，建立双仓 contract tests。
-- 建立 billing domain 模块，隔离 route、Paid client、grant repository、signature 和 account-event worker，避免把逻辑塞进通用 utils。
+- 建立 billing domain 模块，隔离 route、Paid client、grant repository 和 signature，避免把逻辑塞进通用 utils。
 
 验收：迁移从空库和现有库成功；disabled 配置运行全部现有测试；HMAC fixture 与 Paid 一致。
 
@@ -30,14 +30,14 @@
 
 验收：官方/自托管配置、鉴权、错误映射、Paid timeout、本地事务失败和幂等激活均覆盖。
 
-## 阶段 4：账号生命周期 outbox
+## 阶段 4：最小账号生命周期
 
-- 在现有账号 merge/delete 事务中写不可变 outbox，不直接同步 HTTP 调用 Paid。
-- worker 多副本安全领取，使用 eventId 作为 HMAC request ID，指数退避并持久化响应。
-- delete 确保 outbox 不随用户记录删除；merge source/target 顺序固定并防止空 ID。
-- 添加运维查询/重试入口，但不提供绕过签名或删除失败任务的快捷路径。
+- 不实现 Rote→Paid account event、merge outbox、alias 或自动订阅迁移。
+- merge 前检查 source/target 本地 grant；状态为 active、grace_period 或 lease-expired unavailable 时返回 `billing_account_operation_requires_support`，只有明确 none 才沿用现有流程。
+- delete 保持现有可用性，不同步调用 Paid；用户和本地 grant 正常删除。
+- callback 对不存在用户统一返回结构化 404 `billing_grant_user_not_found`，由 Paid 进入 orphaned 终态；普通代理 404 不得使用该 message。
 
-验收：重复事件、网络中断、worker crash、用户已删除、Paid 401/5xx 和终态 2xx 测试通过。
+验收：无订阅 merge 不受影响；有订阅 merge 被阻止；Paid 不可用不阻止立即删除；删除后 callback 稳定返回 404。
 
 ## 阶段 5：AI 限额
 
@@ -62,7 +62,7 @@
 ## 阶段 7：联调、可观测性与发布
 
 - 增加 route latency/error、outbox backlog、签名失败、grant lease horizon、AI/video 限额指标；标签不包含用户或交易高基数字段。
-- 与 Paid contract suite 联调高/低 revision、callback retry、merge/delete、多订阅聚合和 HMAC 轮换。
+- 与 Paid contract suite 联调高/低 revision、callback retry、删除后 404/orphaned、多订阅聚合和 HMAC 轮换。
 - 与 iOS 联调 session、activate 503 后重试、restore、Offer Code 和 transaction finish 时序。
 - 先部署 schema/callback（billing disabled），再部署 Paid，最后只对 sandbox allowlist 开启官方实例。
 
@@ -74,6 +74,6 @@
 - Paid 故障不进入 AI/视频/permissions 正常请求路径。
 - 授权不会越过 24 小时 lease，旧 revision 不覆盖新状态。
 - App 激活只有在本地 grant 已提交后成功。
-- merge/delete 事件不会因用户删除或进程退出丢失。
+- 有效订阅不会被自动合并到其他账号；删除不依赖 Paid 且本地 grant 不残留。
 - AI/video 限额在多实例和重试下不可绕过。
 - 日志、错误和指标不包含完整 JWS、transaction ID、email、JWT 或 HMAC secret。

--- a/doc/paid-subscription-plan.zh.md
+++ b/doc/paid-subscription-plan.zh.md
@@ -1,6 +1,6 @@
 # Rote Server：Rote Pro 实施计划
 
-本文是 Rote 开源仓库的实施清单，只覆盖服务端投影、权限解析和安全限额。Apple 业务状态机在私有 Paid Server 实现。
+本文是 Rote 开源仓库的实施清单，只覆盖服务端投影、权限解析和 v1 最小安全保护。Apple 业务状态机在私有 Paid Server 实现。
 
 ## 阶段 1：配置、schema 与 contract fixtures
 
@@ -42,26 +42,27 @@
 ## 阶段 5：AI 限额
 
 - 在 capability 检查后识别 subscription source，只对该来源执行 Pro 限额。
-- 使用共享存储实现滚动 60 秒请求数、带 lease 的 2 并发槽和滚动 24 小时 token ledger。
-- 在 provider 调用前完成检查/占位；所有退出路径 finally 释放；usage 可得时写实际 token。
-- 429 响应返回稳定 `limitKind`、`retryAfterSeconds` 或 `windowEndsAt`。
-- 明确输入、历史和最大输出 token 上限，使最多两个在途请求的超量有界。
+- 使用共享存储实现滚动 60 秒最多 10 次、带 lease 的 2 并发槽和 UTC 自然日最多 100 次 provider dispatch。
+- 在 provider 调用前完成检查；只有即将实际 dispatch 的请求才占用日计数，所有退出路径 finally 释放并发 lease。
+- 429 响应返回稳定 `limitKind`、`retryAfterSeconds` 或 `resetAt`。
+- 复用现有模型上下文和最大输出限制，不实现 token ledger、token reservation 或用户用量仪表盘。
+- 增加全局 AI 紧急关闭开关；provider 预算/告警和服务指标负责发现成本异常。
 
 验收：多实例并发、边界时间、provider timeout/cancel/error 和槽位回收测试通过。
 
-## 阶段 6：视频 reservation 与容量
+## 阶段 6：视频最小保护与观测
 
-- 扩展 presign contract，要求每个逻辑视频附件具有稳定 clientUploadId、类型和预估大小。
-- 原子检查 UTC 日 20 次和 10GB committed+reserved，重复 clientUploadId 返回原 reservation。
-- finalize 读取对象元数据，用实际字节提交；过期 reservation 和孤儿对象由 worker 清理。
-- 定义 batch/Live Photo 计数，以及 original/poster/paired video/static image 分类。
-- 只对 subscription source 使用这些保护限额；其他授权来源保持现有管理员语义。
+- 不增加订阅专用日次数、用户容量、reservation 表、计费分类或客户端上传字段。
+- 沿用现有单文件大小、类型、对象存在性和附件安全校验，不改变 batch/Live Photo 正常上传体验。
+- 基于现有 finalized 附件记录输出视频数量、字节和存储增长的低基数指标。
+- 增加视频全局紧急停用开关和存储告警；停用不映射为 paywall 或“再次购买”提示。
+- 将精细用户配额列为数据触发的后续设计，不进入 v1 完成条件。
 
-验收：批量、Live Photo、并发 presign、重复/过期 reservation、超预估 actual bytes、删除对象和 UTC 日切通过。
+验收：现有 batch/Live Photo/重试行为无回归；finalized 指标可观测；紧急停用不会误导购买。
 
 ## 阶段 7：联调、可观测性与发布
 
-- 增加 route latency/error、outbox backlog、签名失败、grant lease horizon、AI/video 限额指标；标签不包含用户或交易高基数字段。
+- 增加 route latency/error、outbox backlog、签名失败、grant lease horizon、AI 限额和视频存储增长指标；标签不包含用户或交易高基数字段。
 - 与 Paid contract suite 联调高/低 revision、callback retry、删除后 404/orphaned、多订阅聚合和 HMAC 轮换。
 - 与 iOS 联调 session、activate 503 后重试、restore、Offer Code 和 transaction finish 时序。
 - 先部署 schema/callback（billing disabled），再部署 Paid，最后只对 sandbox allowlist 开启官方实例。
@@ -75,5 +76,5 @@
 - 授权不会越过 24 小时 lease，旧 revision 不覆盖新状态。
 - App 激活只有在本地 grant 已提交后成功。
 - 有效订阅不会被自动合并到其他账号；删除不依赖 Paid 且本地 grant 不残留。
-- AI/video 限额在多实例和重试下不可绕过。
+- AI 基础限额在多实例和重试下不可绕过；视频不引入订阅专用 quota 状态机。
 - 日志、错误和指标不包含完整 JWS、transaction ID、email、JWT 或 HMAC secret。

--- a/doc/paid-subscription-plan.zh.md
+++ b/doc/paid-subscription-plan.zh.md
@@ -1,0 +1,79 @@
+# Rote Server：Rote Pro 实施计划
+
+本文是 Rote 开源仓库的实施清单，只覆盖服务端投影、权限解析和安全限额。Apple 业务状态机在私有 Paid Server 实现。
+
+## 阶段 1：配置、schema 与 contract fixtures
+
+- 增加 billing 类型安全配置；默认 disabled，缺少配置不得影响自托管启动。
+- 增加 grant、inbound delivery 和 account event outbox migration；event outbox 不使用删除级联外键。
+- 从 Paid 主规范复制无秘密的 HMAC/request/snapshot fixtures，建立双仓 contract tests。
+- 建立 billing domain 模块，隔离 route、Paid client、grant repository、signature 和 account-event worker，避免把逻辑塞进通用 utils。
+
+验收：迁移从空库和现有库成功；disabled 配置运行全部现有测试；HMAC fixture 与 Paid 一致。
+
+## 阶段 2：grant callback 与 capability resolver
+
+- 实现 `PUT /internal/billing/grants/:userId` 的 HMAC、时钟、幂等和 schema 校验。
+- 事务内比较 bigint revision、写完整 snapshot 和 delivery response；相同 revision 冲突告警。
+- `CapabilitySource` 增加 subscription，`EffectiveCapability` 增加可选 `validUntil`。
+- 在 `getEffectiveCapabilitiesForUser` 读取有效本地 grant，按 super-admin → override → subscription → role policy/default → dependency 解析。
+- subscription 的 lease 缺失、格式错误或过期全部 fail closed；`/permissions/me` 返回 ISO validUntil。
+
+验收：优先级、依赖、lease 边界、重复/乱序 callback 和旧 DTO 兼容测试通过。
+
+## 阶段 3：App billing bridge
+
+- 增加 config、me、session、activate 四个 `/v2/api/billing` route；沿用现有 JWT 和响应包装。
+- Paid client 使用 direction-specific active HMAC key，previous 只供接收；配置连接/总超时，生成 UUIDv7 requestId。
+- activate 限制 JWS body 大小且不记录 payload；Paid snapshot 在本地成功应用后才返回 200。
+- `/billing/me` 只读本地 grant；disabled 和 lease-expired 语义按接入文档固定。
+
+验收：官方/自托管配置、鉴权、错误映射、Paid timeout、本地事务失败和幂等激活均覆盖。
+
+## 阶段 4：账号生命周期 outbox
+
+- 在现有账号 merge/delete 事务中写不可变 outbox，不直接同步 HTTP 调用 Paid。
+- worker 多副本安全领取，使用 eventId 作为 HMAC request ID，指数退避并持久化响应。
+- delete 确保 outbox 不随用户记录删除；merge source/target 顺序固定并防止空 ID。
+- 添加运维查询/重试入口，但不提供绕过签名或删除失败任务的快捷路径。
+
+验收：重复事件、网络中断、worker crash、用户已删除、Paid 401/5xx 和终态 2xx 测试通过。
+
+## 阶段 5：AI 限额
+
+- 在 capability 检查后识别 subscription source，只对该来源执行 Pro 限额。
+- 使用共享存储实现滚动 60 秒请求数、带 lease 的 2 并发槽和滚动 24 小时 token ledger。
+- 在 provider 调用前完成检查/占位；所有退出路径 finally 释放；usage 可得时写实际 token。
+- 429 响应返回稳定 `limitKind`、`retryAfterSeconds` 或 `windowEndsAt`。
+- 明确输入、历史和最大输出 token 上限，使最多两个在途请求的超量有界。
+
+验收：多实例并发、边界时间、provider timeout/cancel/error 和槽位回收测试通过。
+
+## 阶段 6：视频 reservation 与容量
+
+- 扩展 presign contract，要求每个逻辑视频附件具有稳定 clientUploadId、类型和预估大小。
+- 原子检查 UTC 日 20 次和 10GB committed+reserved，重复 clientUploadId 返回原 reservation。
+- finalize 读取对象元数据，用实际字节提交；过期 reservation 和孤儿对象由 worker 清理。
+- 定义 batch/Live Photo 计数，以及 original/poster/paired video/static image 分类。
+- 只对 subscription source 使用这些保护限额；其他授权来源保持现有管理员语义。
+
+验收：批量、Live Photo、并发 presign、重复/过期 reservation、超预估 actual bytes、删除对象和 UTC 日切通过。
+
+## 阶段 7：联调、可观测性与发布
+
+- 增加 route latency/error、outbox backlog、签名失败、grant lease horizon、AI/video 限额指标；标签不包含用户或交易高基数字段。
+- 与 Paid contract suite 联调高/低 revision、callback retry、merge/delete、多订阅聚合和 HMAC 轮换。
+- 与 iOS 联调 session、activate 503 后重试、restore、Offer Code 和 transaction finish 时序。
+- 先部署 schema/callback（billing disabled），再部署 Paid，最后只对 sandbox allowlist 开启官方实例。
+
+每个代码阶段按仓库规则在 `server/` 运行 `bun run lint`、`bun run build` 及相关测试。任何 DNS、Dokploy、App Store Connect 或生产开关变更必须另获授权。
+
+## 完成定义
+
+- 自托管默认行为和现有 permission API 无回归。
+- Paid 故障不进入 AI/视频/permissions 正常请求路径。
+- 授权不会越过 24 小时 lease，旧 revision 不覆盖新状态。
+- App 激活只有在本地 grant 已提交后成功。
+- merge/delete 事件不会因用户删除或进程退出丢失。
+- AI/video 限额在多实例和重试下不可绕过。
+- 日志、错误和指标不包含完整 JWS、transaction ID、email、JWT 或 HMAC secret。


### PR DESCRIPTION
## Summary

- document the optional Rote Pro billing projection boundary and service contracts
- define capability lease, HMAC/idempotency, and the server-authoritative activation flow
- keep v1 account lifecycle intentionally small: no Paid account-event outbox, alias, automatic merge, or subscription transfer
- block account merges with an active/grace/unavailable paid record; account deletion remains immediate and converges through a structured grant callback 404
- use proportional early-stage protection: AI gets minute, concurrency, and UTC-day request limits without a token ledger
- defer subscription-specific video quotas and reservations; retain existing upload validation, storage metrics, alerts, and an emergency switch
- add a decision-complete server implementation plan and update documentation indexes
- repair three pre-existing relative links in the Chinese documentation index

## Why

The billing design lives in a dedicated private source-of-truth repository. This PR records only the open-source Rote Server responsibilities so self-hosted behavior stays independent and implementation can proceed without protocol decisions. Low-frequency account transfer cases and complex quota systems are explicitly deferred until real usage or abuse data justifies them.

## Impact

Documentation only. No runtime code, schema, configuration, quota, or deployment behavior changes.

## Validation

- changed-file Markdown local link check
- lifecycle, endpoint, and safety-limit terminology consistency review
- placeholder and removed-protocol scan
- `git diff --check`

Bun lint/build were not run locally because this PR changes documentation only; GitHub CI validates the branch.