### PR TITLE
Fix import attachment safety review findings

### DIFF
--- a/server/imports/remoteAttachmentMigrationService.test.ts
+++ b/server/imports/remoteAttachmentMigrationService.test.ts
@@ -27,9 +27,11 @@ function attachment(overrides: Record<string, unknown> = {}) {
 function dependencies(contentTypes = new Map<string, string>()) {
   const stored: string[] = [];
   const removed: string[] = [];
+  const finalizedInputs: unknown[] = [];
   return {
     stored,
     removed,
+    finalizedInputs,
     values: {
       assertSafeOutboundUrl: async () => {},
       fetcher: async (url: string | URL | Request) =>
@@ -39,16 +41,19 @@ function dependencies(contentTypes = new Map<string, string>()) {
             'content-length': '3',
           },
         }),
-      finalizeAttachmentUploads: async () => [
-        {
-          id: '550e8400-e29b-41d4-a716-446655440000',
-          url: 'https://cdn.example/image.png',
-          compressUrl: '',
-          posterUrl: '',
-          storage: 'R2',
-          details: { key: stored[0], mimetype: 'image/png', mediaKind: 'image' },
-        },
-      ],
+      finalizeAttachmentUploads: async (input: unknown) => {
+        finalizedInputs.push(input);
+        return [
+          {
+            id: '550e8400-e29b-41d4-a716-446655440000',
+            url: 'https://cdn.example/image.png',
+            compressUrl: '',
+            posterUrl: '',
+            storage: 'R2',
+            details: { key: stored[0], mimetype: 'image/png', mediaKind: 'image' },
+          },
+        ];
+      },
       getAttachmentUploadPolicy: async () => policy,
       randomUUID: () => 'asset-id',
       removeObject: async (key: string) => {
@@ -125,6 +130,68 @@ describe('single remote attachment migration', () => {
       code: 'remote_attachment_invalid',
     });
     expect(deps.removed).toEqual(['users/user-1/uploads/asset-id.png']);
+  });
+
+  test('does not upload a compressed still that Live Photo finalization discards', async () => {
+    const compressedUrl = 'https://source.example/image.webp';
+    const pairedVideoUrl = 'https://source.example/image.mov';
+    const deps = dependencies(
+      new Map([
+        [compressedUrl, 'image/webp'],
+        [pairedVideoUrl, 'video/quicktime'],
+      ])
+    );
+
+    await migrateOneRemoteAttachment(
+      'user-1',
+      attachment({
+        compressUrl: compressedUrl,
+        details: {
+          ...attachment().details,
+          pairedVideoUrl,
+          pairedVideoFilename: 'image.mov',
+          pairedVideoMimetype: 'video/quicktime',
+        },
+      }),
+      deps.values as never
+    );
+
+    expect(deps.stored).toEqual([
+      'users/user-1/uploads/asset-id.png',
+      'users/user-1/paired-videos/asset-id.mov',
+    ]);
+    expect(deps.finalizedInputs).toEqual([
+      expect.objectContaining({
+        attachments: [
+          expect.objectContaining({
+            compressedKey: undefined,
+            mediaKind: 'livePhoto',
+            pairedVideoKey: 'users/user-1/paired-videos/asset-id.mov',
+          }),
+        ],
+      }),
+    ]);
+  });
+
+  test('preserves the streamed too-large error instead of reporting a storage outage', async () => {
+    const deps = dependencies();
+    deps.values.fetcher = async () =>
+      new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new Uint8Array(20 * 1024 * 1024 + 1));
+            controller.close();
+          },
+        }),
+        { headers: { 'content-type': 'image/png' } }
+      );
+
+    await expect(
+      migrateOneRemoteAttachment('user-1', attachment(), deps.values as never)
+    ).rejects.toMatchObject<RemoteAttachmentMigrationError>({
+      code: 'remote_attachment_too_large',
+      status: 413,
+    });
   });
 
   test('limits concurrent work and refills the queue', async () => {

--- a/server/imports/remoteAttachmentMigrationService.ts
+++ b/server/imports/remoteAttachmentMigrationService.ts
@@ -129,8 +129,9 @@ export async function migrateOneRemoteAttachment(
     const compressedUrl = distinctRemoteUrl(attachment.compressUrl, attachment.url);
     const posterUrl = distinctRemoteUrl(attachment.posterUrl, attachment.url);
     const pairedVideoUrl = stringDetail(details, 'pairedVideoUrl');
+    const hasPairedVideo = isRemoteUrl(pairedVideoUrl);
     const companionResults = await Promise.allSettled([
-      compressedUrl
+      compressedUrl && !hasPairedVideo
         ? migrateAsset({
             userId,
             uuid,
@@ -162,7 +163,7 @@ export async function migrateOneRemoteAttachment(
             signal: options.signal,
           })
         : undefined,
-      isRemoteUrl(pairedVideoUrl)
+      hasPairedVideo
         ? migrateAsset({
             userId,
             uuid,
@@ -286,7 +287,8 @@ async function migrateAsset({
     });
     const source = Readable.fromWeb(response.body as never);
     limiter.once('error', () => source.destroy());
-    await dependencies.storeObjectStream(key, source.pipe(limiter), contentType).catch(() => {
+    await dependencies.storeObjectStream(key, source.pipe(limiter), contentType).catch((error) => {
+      if (error instanceof RemoteAttachmentMigrationError) throw error;
       throw new RemoteAttachmentMigrationError('remote_attachment_storage_unavailable', 503);
     });
     uploadedKeys.push(key);

--- a/server/integrations/memosGateway.test.ts
+++ b/server/integrations/memosGateway.test.ts
@@ -5,6 +5,7 @@ describe('requestMemosPage', () => {
   test('forwards a bounded page request through the backend', async () => {
     let requestedUrl = '';
     let authorization = '';
+    let redirectMode: RequestRedirect | undefined;
     const data = await requestMemosPage({
       accessToken: 'memos_pat_test',
       body: { baseUrl: 'https://memos.example.com/', state: 'NORMAL', pageToken: 'next' },
@@ -12,6 +13,7 @@ describe('requestMemosPage', () => {
       fetcher: async (input, init) => {
         requestedUrl = String(input);
         authorization = new Headers(init?.headers).get('authorization') ?? '';
+        redirectMode = init?.redirect;
         return Response.json({ memos: [], nextPageToken: '' });
       },
     });
@@ -21,6 +23,93 @@ describe('requestMemosPage', () => {
       'https://memos.example.com/api/v1/memos?pageSize=50&state=NORMAL&pageToken=next'
     );
     expect(authorization).toBe('Bearer memos_pat_test');
+    expect(redirectMode).toBe('manual');
+  });
+
+  test('validates every redirect and does not forward credentials across origins', async () => {
+    const checkedUrls: string[] = [];
+    const requests: Array<{ url: string; authorization: string | null }> = [];
+    const data = await requestMemosPage({
+      accessToken: 'memos_pat_test',
+      body: { baseUrl: 'https://memos.example.com', state: 'NORMAL' },
+      assertSafeUrl: async (url) => {
+        checkedUrls.push(url);
+      },
+      fetcher: async (input, init) => {
+        const url = String(input);
+        requests.push({
+          url,
+          authorization: new Headers(init?.headers).get('authorization'),
+        });
+        if (url.startsWith('https://memos.example.com/')) {
+          return new Response(null, {
+            status: 302,
+            headers: { location: 'https://cdn.example.com/memos-page' },
+          });
+        }
+        return Response.json({ memos: [], nextPageToken: '' });
+      },
+    });
+
+    expect(data).toEqual({ memos: [], nextPageToken: '' });
+    expect(checkedUrls).toEqual([
+      'https://memos.example.com/api/v1/memos?pageSize=50&state=NORMAL',
+      'https://cdn.example.com/memos-page',
+    ]);
+    expect(requests).toEqual([
+      {
+        url: 'https://memos.example.com/api/v1/memos?pageSize=50&state=NORMAL',
+        authorization: 'Bearer memos_pat_test',
+      },
+      { url: 'https://cdn.example.com/memos-page', authorization: null },
+    ]);
+  });
+
+  test('rejects an unsafe redirect before requesting it', async () => {
+    const requestedUrls: string[] = [];
+    await expect(
+      requestMemosPage({
+        accessToken: 'memos_pat_test',
+        body: { baseUrl: 'https://memos.example.com', state: 'NORMAL' },
+        assertSafeUrl: async (url) => {
+          if (url.includes('169.254.169.254')) throw new Error('unsafe');
+        },
+        fetcher: async (input) => {
+          requestedUrls.push(String(input));
+          return new Response(null, {
+            status: 302,
+            headers: { location: 'http://169.254.169.254/latest/meta-data' },
+          });
+        },
+      })
+    ).rejects.toMatchObject<MemosGatewayError>({ code: 'memos_invalid_request', status: 400 });
+
+    expect(requestedUrls).toEqual([
+      'https://memos.example.com/api/v1/memos?pageSize=50&state=NORMAL',
+    ]);
+  });
+
+  test('rejects an oversized streamed response without buffering the full body', async () => {
+    let canceled = false;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(6 * 1024 * 1024));
+        controller.enqueue(new Uint8Array(6 * 1024 * 1024));
+      },
+      cancel() {
+        canceled = true;
+      },
+    });
+
+    await expect(
+      requestMemosPage({
+        accessToken: 'memos_pat_test',
+        body: { baseUrl: 'https://memos.example.com', state: 'NORMAL' },
+        assertSafeUrl: async () => {},
+        fetcher: async () => new Response(body),
+      })
+    ).rejects.toMatchObject<MemosGatewayError>({ code: 'memos_invalid_response', status: 502 });
+    expect(canceled).toBe(true);
   });
 
   test('rejects invalid states and upstream authentication failures', async () => {

--- a/server/integrations/memosGateway.ts
+++ b/server/integrations/memosGateway.ts
@@ -1,6 +1,8 @@
 import { assertSafeOutboundUrl } from '../utils/adminHooks/network';
 
 const UPSTREAM_TIMEOUT_MS = 30_000;
+const MAX_REDIRECTS = 3;
+const MAX_RESPONSE_BYTES = 10 * 1024 * 1024;
 
 export class MemosGatewayError extends Error {
   constructor(
@@ -41,29 +43,132 @@ export async function requestMemosPage({
   url.searchParams.set('pageSize', '50');
   url.searchParams.set('state', state);
   if (pageToken) url.searchParams.set('pageToken', pageToken);
-  await assertSafeUrl(url.toString(), 'Memos instance URL');
-
-  let response: Response;
-  try {
-    response = await fetcher(url, {
-      headers: { Authorization: `Bearer ${accessToken}`, Accept: 'application/json' },
-      signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
-    });
-  } catch (error) {
-    if (error instanceof Error && (error.name === 'TimeoutError' || error.name === 'AbortError')) {
-      throw new MemosGatewayError('memos_timeout', 504);
-    }
-    throw new MemosGatewayError('memos_unreachable', 502);
-  }
+  const response = await fetchSafeMemosResponse({
+    initialUrl: url.toString(),
+    baseUrl,
+    accessToken,
+    fetcher,
+    assertSafeUrl,
+  });
   if (response.status === 401) throw new MemosGatewayError('memos_unauthorized', 401);
   if (response.status === 403) throw new MemosGatewayError('memos_forbidden', 403);
   if (!response.ok) throw new MemosGatewayError('memos_invalid_response', 502);
 
-  const data = await response.json().catch(() => null);
+  const data = await readLimitedJson(response);
   if (!data || typeof data !== 'object' || !Array.isArray((data as { memos?: unknown }).memos)) {
     throw new MemosGatewayError('memos_invalid_response', 502);
   }
   return data;
+}
+
+async function fetchSafeMemosResponse({
+  initialUrl,
+  baseUrl,
+  accessToken,
+  fetcher,
+  assertSafeUrl,
+}: {
+  initialUrl: string;
+  baseUrl: string;
+  accessToken: string;
+  fetcher: typeof fetch;
+  assertSafeUrl: typeof assertSafeOutboundUrl;
+}) {
+  let currentUrl = initialUrl;
+  for (let redirect = 0; redirect <= MAX_REDIRECTS; redirect++) {
+    try {
+      await assertSafeUrl(currentUrl, 'Memos instance URL');
+    } catch {
+      throw new MemosGatewayError('memos_invalid_request', 400);
+    }
+
+    let response: Response;
+    try {
+      const headers: Record<string, string> = { Accept: 'application/json' };
+      if (sameOrigin(currentUrl, baseUrl)) headers.Authorization = `Bearer ${accessToken}`;
+      response = await fetcher(currentUrl, {
+        headers,
+        redirect: 'manual',
+        signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
+      });
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        (error.name === 'TimeoutError' || error.name === 'AbortError')
+      ) {
+        throw new MemosGatewayError('memos_timeout', 504);
+      }
+      throw new MemosGatewayError('memos_unreachable', 502);
+    }
+
+    if (response.status < 300 || response.status >= 400) return response;
+    const location = response.headers.get('location');
+    if (!location || redirect === MAX_REDIRECTS) {
+      await response.body?.cancel();
+      throw new MemosGatewayError('memos_invalid_response', 502);
+    }
+    await response.body?.cancel();
+    try {
+      currentUrl = new URL(location, currentUrl).toString();
+    } catch {
+      throw new MemosGatewayError('memos_invalid_response', 502);
+    }
+  }
+  throw new MemosGatewayError('memos_invalid_response', 502);
+}
+
+async function readLimitedJson(response: Response): Promise<unknown> {
+  const declaredLength = response.headers.get('content-length');
+  if (
+    declaredLength !== null &&
+    /^(0|[1-9][0-9]*)$/u.test(declaredLength) &&
+    BigInt(declaredLength) > BigInt(MAX_RESPONSE_BYTES)
+  ) {
+    await response.body?.cancel();
+    throw new MemosGatewayError('memos_invalid_response', 502);
+  }
+  if (!response.body) throw new MemosGatewayError('memos_invalid_response', 502);
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      totalBytes += value.byteLength;
+      if (totalBytes > MAX_RESPONSE_BYTES) {
+        await reader.cancel();
+        throw new MemosGatewayError('memos_invalid_response', 502);
+      }
+      chunks.push(value);
+    }
+  } catch (error) {
+    if (error instanceof MemosGatewayError) throw error;
+    throw new MemosGatewayError('memos_invalid_response', 502);
+  } finally {
+    reader.releaseLock();
+  }
+
+  const body = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  try {
+    return JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(body));
+  } catch {
+    throw new MemosGatewayError('memos_invalid_response', 502);
+  }
+}
+
+function sameOrigin(value: string, baseUrl: string) {
+  try {
+    return new URL(value).origin === new URL(baseUrl).origin;
+  } catch {
+    return false;
+  }
 }
 
 function normalizeBaseUrl(value: unknown) {

--- a/web/src/features/import/importTask.test.ts
+++ b/web/src/features/import/importTask.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { migrateWithRetry, runAttachmentQueue, runImportTask } from './importTask';
 
 const { postMock, deleteMock } = vi.hoisted(() => ({
@@ -7,6 +7,11 @@ const { postMock, deleteMock } = vi.hoisted(() => ({
 }));
 
 vi.mock('@/utils/api', () => ({ post: postMock, del: deleteMock }));
+
+beforeEach(() => {
+  postMock.mockReset();
+  deleteMock.mockReset();
+});
 
 describe('import attachment queue', () => {
   test('uses eight total slots, no more than two videos, and refills immediately', async () => {
@@ -82,6 +87,63 @@ describe('import attachment queue', () => {
     expect(permanent).toHaveBeenCalledOnce();
   });
 
+  test('skips an overwrite when any attachment fails and removes migrated temporary files', async () => {
+    const noteId = crypto.randomUUID();
+    postMock.mockImplementation(async (path: string, body: Record<string, unknown>) => {
+      if (path === '/users/me/import/plan') return { data: { noteIndexes: [0] } };
+      if (path === '/imports/attachments/migrate') {
+        const migratedAttachment = body.attachment as { url: string };
+        if (migratedAttachment.url.endsWith('/failed.png')) {
+          throw {
+            response: { status: 413, data: { message: 'remote_attachment_too_large' } },
+          };
+        }
+        return { data: { id: 'migrated-attachment' } };
+      }
+      throw new Error('overwrite with a failed attachment must not be imported');
+    });
+    deleteMock.mockResolvedValue({});
+
+    const result = await runImportTask({
+      payload: {
+        notes: [
+          {
+            id: noteId,
+            content: 'existing memo',
+            source: { provider: 'memos', accountId: 'account', externalId: 'memo-1' },
+            attachments: [
+              {
+                url: 'https://memos.example.com/success.png',
+                storage: 'REMOTE',
+                details: { mimetype: 'image/png' },
+                source: { provider: 'memos', accountId: 'account', externalId: 'asset-1' },
+              },
+              {
+                url: 'https://memos.example.com/failed.png',
+                storage: 'REMOTE',
+                details: { mimetype: 'image/png' },
+                source: { provider: 'memos', accountId: 'account', externalId: 'asset-2' },
+              },
+            ],
+          },
+        ],
+      },
+      overwriteExisting: true,
+      preserveVisibility: false,
+      signal: new AbortController().signal,
+      onProgress: vi.fn(),
+    });
+
+    expect(postMock.mock.calls.filter(([path]) => path === '/users/me/import')).toHaveLength(0);
+    expect(deleteMock).toHaveBeenCalledWith('/attachments', {
+      data: { ids: ['migrated-attachment'] },
+    });
+    expect(result.skippedAfterAttachmentFailure).toBe(1);
+    expect(result.failures).toEqual([
+      expect.objectContaining({ reason: 'remote_attachment_too_large' }),
+    ]);
+  });
+
   test('still imports articles when every note is skipped by preflight', async () => {
     postMock.mockResolvedValueOnce({ data: { noteIndexes: [] } }).mockResolvedValueOnce({
       data: {
@@ -112,8 +174,6 @@ describe('import attachment queue', () => {
   });
 
   test('keeps Memos credentials in memory and sends them only with attachment migration', async () => {
-    postMock.mockReset();
-    deleteMock.mockReset();
     const noteId = crypto.randomUUID();
     postMock
       .mockResolvedValueOnce({ data: { noteIndexes: [0] } })

--- a/web/src/features/import/importTask.ts
+++ b/web/src/features/import/importTask.ts
@@ -104,7 +104,7 @@ export async function runImportTask({
     if (noteChunks.length === 0 && (payload.articles?.length ?? 0) > 0) noteChunks.push([]);
     for (const chunk of noteChunks) {
       throwIfAborted(signal);
-      const migratedNotes = await migrateChunk(
+      const { notes: migratedNotes, failedNoteIndexes } = await migrateChunk(
         chunk,
         signal,
         session,
@@ -118,7 +118,21 @@ export async function runImportTask({
           });
         }
       );
-      const importableNotes = migratedNotes.filter((note) => {
+      const noteIndexesToSkip = overwriteExisting ? failedNoteIndexes : new Set<number>();
+      const migratedIdsToDiscard = migratedNotes.flatMap((note, noteIndex) =>
+        noteIndexesToSkip.has(noteIndex)
+          ? (note.attachments ?? []).map((attachment: ImportRecord) => attachment.id)
+          : []
+      );
+      if (migratedIdsToDiscard.length > 0) {
+        await cleanupAttachmentIds(migratedIdsToDiscard);
+        removeAttachmentIds(session, migratedIdsToDiscard);
+      }
+      const importableNotes = migratedNotes.filter((note, noteIndex) => {
+        if (noteIndexesToSkip.has(noteIndex)) {
+          skippedAfterAttachmentFailure += 1;
+          return false;
+        }
         const importable = hasContent(note) || (note.attachments?.length ?? 0) > 0;
         if (!importable) skippedAfterAttachmentFailure += 1;
         return importable;
@@ -185,6 +199,7 @@ async function migrateChunk(
   onDelta: (delta: { active: number; completed: number; failed: number }) => void
 ) {
   const output = notes.map((note) => ({ ...note, attachments: [] as ImportRecord[] }));
+  const failedNoteIndexes = new Set<number>();
   const tasks = notes.flatMap((note, noteIndex) =>
     (Array.isArray(note.attachments) ? note.attachments : []).map(
       (attachment: ImportRecord, attachmentIndex: number) => ({
@@ -217,6 +232,7 @@ async function migrateChunk(
       onDelta({ active: -1, completed: 1, failed: 0 });
     } catch (error) {
       if (signal.aborted) throw error;
+      failedNoteIndexes.add(task.noteIndex);
       failures.push({
         attachmentName: attachmentName(task.attachment, task.attachmentIndex),
         noteTitle: String(task.note.title || ''),
@@ -229,7 +245,7 @@ async function migrateChunk(
   output.forEach((note) =>
     note.attachments.sort((a, b) => (a.sortIndex ?? 0) - (b.sortIndex ?? 0))
   );
-  return output;
+  return { notes: output, failedNoteIndexes };
 }
 
 export async function migrateWithRetry(
@@ -360,6 +376,12 @@ function removeBoundIds(session: InterruptedSession, notes: ImportRecord[]) {
     )
   );
   session.attachmentIds = session.attachmentIds.filter((id) => !bound.has(id));
+  persistInterruptedSession(session);
+}
+
+function removeAttachmentIds(session: InterruptedSession, ids: string[]) {
+  const removed = new Set(ids);
+  session.attachmentIds = session.attachmentIds.filter((id) => !removed.has(id));
   persistInterruptedSession(session);
 }
 


### PR DESCRIPTION
## What changed

- skip overwrite imports for any note whose remote attachment migration fails, preserving existing attachment mappings and cleaning successfully migrated temporary attachments
- handle Memos redirects manually, validate every hop against outbound-network policy, cap redirects, and avoid forwarding the access token across origins
- stream Memos JSON through a strict 10 MiB response limit before UTF-8 decoding and parsing
- avoid uploading a compressed still for Live Photos because finalization discards that object
- preserve `remote_attachment_too_large` (413) when the streaming limiter rejects an upload

## Why

These changes address the five unresolved import/security review threads from release PR #314. The prior behavior could delete working attachments during overwrite, follow an unsafe redirect, buffer unbounded upstream JSON, leave an unreachable compressed object, and misreport a streamed size violation as a storage outage.

## Validation

- server targeted tests: 12 passed
- web import task tests: 6 passed
- `server: bun run lint`
- `server: bun run build`
- `web: bun run lint`
- `web: bun run build`

No billing files are changed.