### PR TITLE
Fix storage maintenance retention cleanup

### DIFF
--- a/server/resources/worker.ts
+++ b/server/resources/worker.ts
@@ -23,7 +23,7 @@ export type ReconciledObject = {
 type InspectedObject = ReconciledObject & { actualBytes: bigint };
 
 const RECONCILIATION_HEAD_CONCURRENCY = 8;
-const RECONCILIATION_USERS_PER_RUN = 10;
+const RECONCILIATION_USERS_PER_RUN = 100;
 
 export async function inspectReconciledObjects(
   objects: readonly ReconciledObject[],
@@ -371,7 +371,7 @@ export async function runResourceMaintenance(now = new Date()) {
     .where(
       and(
         sql`${resourceUploadReservations.status} <> 'pending'`,
-        sql`COALESCE(${resourceUploadReservations.completedAt}, ${resourceUploadReservations.createdAt}) <= ${reservationRetention}`
+        sql`COALESCE(${resourceUploadReservations.completedAt}, ${resourceUploadReservations.createdAt}) <= ${reservationRetention.toISOString()}::timestamptz`
       )
     );
   const cleanupRetention = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);


### PR DESCRIPTION
## Summary

- bind the 30-day reservation retention cutoff as an ISO timestamp instead of a raw JavaScript Date
- increase official baseline progress from 10 to 100 users per run while keeping object-store HEAD concurrency bounded at 8

## Root cause

The untyped raw SQL fragment passed a Date directly to the Postgres driver, which rejected it after every maintenance run.

## Validation

- resource worker tests: 4 passed
- Server TypeScript build
- changed-file ESLint
- git diff check