### PR TITLE
Add detailed reaction push notifications

### DIFF
--- a/server/push/apns.ts
+++ b/server/push/apns.ts
@@ -49,6 +49,8 @@ export type ApnsMessage = {
   body?: string | null;
   titleLocKey?: string | null;
   bodyLocKey?: string | null;
+  titleLocArgs?: string[];
+  bodyLocArgs?: string[];
   route?: string | null;
   payload?: Record<string, unknown>;
   expiration?: Date | null;
@@ -59,15 +61,24 @@ export const APNS_MAX_PAYLOAD_BYTES = 4096;
 
 type ApnsPayloadMessage = Pick<
   ApnsMessage,
-  'title' | 'body' | 'titleLocKey' | 'bodyLocKey' | 'route' | 'payload'
+  | 'title'
+  | 'body'
+  | 'titleLocKey'
+  | 'bodyLocKey'
+  | 'titleLocArgs'
+  | 'bodyLocArgs'
+  | 'route'
+  | 'payload'
 >;
 
 export function serializeApnsPayload(message: ApnsPayloadMessage): string {
-  const alert: Record<string, string> = {};
+  const alert: Record<string, string | string[]> = {};
   if (message.title) alert.title = message.title;
   if (message.body) alert.body = message.body;
   if (message.titleLocKey) alert['title-loc-key'] = message.titleLocKey;
   if (message.bodyLocKey) alert['loc-key'] = message.bodyLocKey;
+  if (message.titleLocArgs?.length) alert['title-loc-args'] = message.titleLocArgs;
+  if (message.bodyLocArgs?.length) alert['loc-args'] = message.bodyLocArgs;
   return JSON.stringify({
     ...message.payload,
     aps: { alert, sound: 'default' },

--- a/server/push/apnsPayload.test.ts
+++ b/server/push/apnsPayload.test.ts
@@ -17,4 +17,23 @@ describe('APNs payload sizing', () => {
     );
     expect(isApnsPayloadWithinLimit(oversized)).toBe(false);
   });
+
+  it('serializes localized title and body arguments into the alert', () => {
+    const payload = JSON.parse(
+      serializeApnsPayload({
+        titleLocKey: 'push.reaction.detail.known.title',
+        bodyLocKey: 'push.reaction.detail.body',
+        titleLocArgs: ['Alice'],
+        bodyLocArgs: ['❤️', 'Summer wind'],
+        route: 'rote://detail?id=rote-a',
+        payload: { roteId: 'rote-a' },
+      })
+    );
+    expect(payload.aps.alert).toEqual({
+      'title-loc-key': 'push.reaction.detail.known.title',
+      'loc-key': 'push.reaction.detail.body',
+      'title-loc-args': ['Alice'],
+      'loc-args': ['❤️', 'Summer wind'],
+    });
+  });
 });

--- a/server/push/payload.test.ts
+++ b/server/push/payload.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'bun:test';
+import { prepareApnsPayload, readPushPayloadMetadata, withPushPayloadMetadata } from './payload';
+
+describe('push payload metadata', () => {
+  it('keeps presentation metadata in the queue but removes it from the device payload', () => {
+    const queued = withPushPayloadMetadata(
+      { roteId: 'rote-a' },
+      {
+        titleLocArgs: ['Alice'],
+        bodyLocArgs: ['❤️', 'Summer wind'],
+        reaction: { actorKeys: ['user:alice'] },
+      }
+    );
+    expect(readPushPayloadMetadata(queued)).toEqual({
+      titleLocArgs: ['Alice'],
+      bodyLocArgs: ['❤️', 'Summer wind'],
+      reaction: { actorKeys: ['user:alice'] },
+    });
+    expect(prepareApnsPayload(queued)).toEqual({
+      payload: { roteId: 'rote-a' },
+      titleLocArgs: ['Alice'],
+      bodyLocArgs: ['❤️', 'Summer wind'],
+    });
+  });
+});

--- a/server/push/payload.ts
+++ b/server/push/payload.ts
@@ -1,0 +1,49 @@
+const PUSH_METADATA_KEY = '_push';
+
+export type PushPayloadMetadata = {
+  titleLocArgs?: string[];
+  bodyLocArgs?: string[];
+  reaction?: unknown;
+};
+
+function stringArguments(value: unknown): string[] | undefined {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) return undefined;
+  return value;
+}
+
+export function readPushPayloadMetadata(
+  payload: Record<string, unknown> | null | undefined
+): PushPayloadMetadata {
+  const metadata = payload?.[PUSH_METADATA_KEY];
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) return {};
+  const value = metadata as Record<string, unknown>;
+  return {
+    titleLocArgs: stringArguments(value.titleLocArgs),
+    bodyLocArgs: stringArguments(value.bodyLocArgs),
+    reaction: value.reaction,
+  };
+}
+
+export function withPushPayloadMetadata(
+  payload: Record<string, unknown>,
+  metadata: PushPayloadMetadata
+): Record<string, unknown> {
+  const publicPayload = { ...payload };
+  delete publicPayload[PUSH_METADATA_KEY];
+  return { ...publicPayload, [PUSH_METADATA_KEY]: metadata };
+}
+
+export function prepareApnsPayload(payload: Record<string, unknown>): {
+  payload: Record<string, unknown>;
+  titleLocArgs?: string[];
+  bodyLocArgs?: string[];
+} {
+  const metadata = readPushPayloadMetadata(payload);
+  const publicPayload = { ...payload };
+  delete publicPayload[PUSH_METADATA_KEY];
+  return {
+    payload: publicPayload,
+    titleLocArgs: metadata.titleLocArgs,
+    bodyLocArgs: metadata.bodyLocArgs,
+  };
+}

--- a/server/push/reactionPresentation.test.ts
+++ b/server/push/reactionPresentation.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test';
+import { APNS_MAX_PAYLOAD_BYTES, serializeApnsPayload } from './apns';
 import {
   canPresentDetailedReactionType,
   mergeReactionNotificationState,
@@ -86,7 +87,7 @@ describe('reaction notification presentation', () => {
 
   it('truncates text on grapheme boundaries', () => {
     const family = '👨‍👩‍👧‍👦';
-    expect(reactionActorName(family.repeat(40), 'fallback')).toBe(`${family.repeat(32)}…`);
+    expect(reactionActorName(family.repeat(40), 'fallback')).toBe(`${family.repeat(6)}…`);
   });
 
   it('deduplicates custom reactions by their full normalized identity', () => {
@@ -105,5 +106,75 @@ describe('reaction notification presentation', () => {
 
   it('rejects reaction details that normalize to empty', () => {
     expect(canPresentDetailedReactionType(' \n\u0000<p></p> ')).toBe(false);
+  });
+
+  it('strips unsafe format controls while preserving visible ZWJ emoji', () => {
+    expect(canPresentDetailedReactionType('\u200B\u202E')).toBe(false);
+    expect(canPresentDetailedReactionType('👩‍💻')).toBe(true);
+  });
+
+  it('normalizes an invisible nickname before falling back to the username', () => {
+    expect(reactionActorName(' <b> </b>\u200B', 'Alice')).toBe('Alice');
+  });
+
+  it('uses localized overflow bodies with the hidden count as a separate argument', () => {
+    let state = mergeReactionNotificationState(null, {
+      actorKey: 'user:alice',
+      reactionType: '❤️',
+      noteLabel: 'Summer wind',
+    });
+    for (const reactionType of ['👍', '🎉', '👏']) {
+      state = mergeReactionNotificationState(state, {
+        actorKey: 'user:alice',
+        reactionType,
+        noteLabel: 'Summer wind',
+      });
+    }
+    expect(reactionNotificationPresentation(state)).toEqual({
+      titleLocKey: 'push.reaction.detail.anonymous.title',
+      bodyLocKey: 'push.reaction.detail.body.overflow',
+      titleLocArgs: [],
+      bodyLocArgs: ['❤️ 👍 🎉', '1', 'Summer wind'],
+    });
+  });
+
+  it('bounds retained aggregate identities while keeping aggregate counts', () => {
+    let state: ReturnType<typeof mergeReactionNotificationState> | null = null;
+    for (let index = 0; index < 100; index += 1) {
+      state = mergeReactionNotificationState(state, {
+        actorKey: `visitor:${index}`,
+        reactionType: `custom-${index}`,
+        noteLabel: 'Summer wind',
+      });
+    }
+    expect(state.actorKeyHashes).toHaveLength(32);
+    expect(state.actorCount).toBe(100);
+    expect(state.reactionTypes).toHaveLength(8);
+    expect(state.reactionTypeCount).toBe(100);
+    expect(Buffer.byteLength(JSON.stringify(state), 'utf8')).toBeLessThan(5_000);
+  });
+
+  it('bounds pathological graphemes so the completed APNs payload remains below 4 KB', () => {
+    const noteLabel = reactionNoteLabel('', `a${'\u0301'.repeat(5_000)}`);
+    const state = mergeReactionNotificationState(null, {
+      actorKey: 'visitor:alpha',
+      reactionType: '❤️',
+      noteLabel,
+    });
+    const presentation = reactionNotificationPresentation(state);
+    const payload = serializeApnsPayload({
+      titleLocKey: presentation.titleLocKey,
+      bodyLocKey: presentation.bodyLocKey,
+      titleLocArgs: presentation.titleLocArgs,
+      bodyLocArgs: presentation.bodyLocArgs,
+      route: 'rote://detail?id=00000000-0000-0000-0000-000000000000',
+      payload: { roteId: '00000000-0000-0000-0000-000000000000' },
+    });
+    expect(noteLabel).toBeUndefined();
+    expect(Buffer.byteLength(payload, 'utf8')).toBeLessThanOrEqual(APNS_MAX_PAYLOAD_BYTES);
+  });
+
+  it('truncates a maximal plain-text note without changing its bounded preview', () => {
+    expect(reactionNoteLabel('', 'x'.repeat(1_000_000))).toBe(`${'x'.repeat(36)}…`);
   });
 });

--- a/server/push/reactionPresentation.test.ts
+++ b/server/push/reactionPresentation.test.ts
@@ -71,6 +71,10 @@ describe('reaction notification presentation', () => {
     expect(reactionActorName('  Alice\nSmith  ', 'fallback')).toBe('Alice Smith');
   });
 
+  it('preserves angle-bracket comparisons in plain note titles', () => {
+    expect(reactionNoteLabel('Compare 1 < 2 and 3 > 1', 'ignored')).toBe('Compare 1 < 2 and 3 > 1');
+  });
+
   it('uses a localized unlabeled-note body when title and content are empty', () => {
     const state = mergeReactionNotificationState(null, {
       actorKey: 'visitor:alpha',
@@ -105,7 +109,7 @@ describe('reaction notification presentation', () => {
   });
 
   it('rejects reaction details that normalize to empty', () => {
-    expect(canPresentDetailedReactionType(' \n\u0000<p></p> ')).toBe(false);
+    expect(canPresentDetailedReactionType(' \n\u0000\u200B ')).toBe(false);
   });
 
   it('strips unsafe format controls while preserving visible ZWJ emoji', () => {
@@ -127,8 +131,35 @@ describe('reaction notification presentation', () => {
     expect(state.reactionTypes.map((item) => item.label)).toEqual([england, scotland]);
   });
 
+  it('strips emoji tags outside a complete black-flag sequence', () => {
+    const heart = '❤️';
+    let state = mergeReactionNotificationState(null, {
+      actorKey: 'user:alice',
+      reactionType: heart,
+    });
+    state = mergeReactionNotificationState(state, {
+      actorKey: 'user:bob',
+      reactionType: `${heart}\u{E0067}`,
+    });
+    expect(state.reactionTypes).toHaveLength(1);
+    expect(state.reactionTypes[0].label).toBe(heart);
+  });
+
+  it('deduplicates canonically equivalent Unicode reaction types', () => {
+    let state = mergeReactionNotificationState(null, {
+      actorKey: 'user:alice',
+      reactionType: 'é',
+    });
+    state = mergeReactionNotificationState(state, {
+      actorKey: 'user:bob',
+      reactionType: 'e\u0301',
+    });
+    expect(state.reactionTypes).toHaveLength(1);
+    expect(state.reactionTypes[0].label).toBe('é');
+  });
+
   it('normalizes an invisible nickname before falling back to the username', () => {
-    expect(reactionActorName(' <b> </b>\u200B', 'Alice')).toBe('Alice');
+    expect(reactionActorName(' \u200B\u202E ', 'Alice')).toBe('Alice');
   });
 
   it('uses localized overflow bodies with the hidden count as a separate argument', () => {

--- a/server/push/reactionPresentation.test.ts
+++ b/server/push/reactionPresentation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import {
+  canPresentDetailedReactionType,
   mergeReactionNotificationState,
   reactionActorName,
   reactionNoteLabel,
@@ -67,5 +68,42 @@ describe('reaction notification presentation', () => {
       `${'记'.repeat(36)}…`
     );
     expect(reactionActorName('  Alice\nSmith  ', 'fallback')).toBe('Alice Smith');
+  });
+
+  it('uses a localized unlabeled-note body when title and content are empty', () => {
+    const state = mergeReactionNotificationState(null, {
+      actorKey: 'visitor:alpha',
+      reactionType: '❤️',
+      noteLabel: reactionNoteLabel(' ', '<p> </p>') ?? '',
+    });
+    expect(reactionNotificationPresentation(state)).toEqual({
+      titleLocKey: 'push.reaction.detail.anonymous.title',
+      bodyLocKey: 'push.reaction.detail.body.unlabeled',
+      titleLocArgs: [],
+      bodyLocArgs: ['❤️'],
+    });
+  });
+
+  it('truncates text on grapheme boundaries', () => {
+    const family = '👨‍👩‍👧‍👦';
+    expect(reactionActorName(family.repeat(40), 'fallback')).toBe(`${family.repeat(32)}…`);
+  });
+
+  it('deduplicates custom reactions by their full normalized identity', () => {
+    let state = mergeReactionNotificationState(null, {
+      actorKey: 'user:alice',
+      reactionType: 'abcdefghijkl-first',
+      noteLabel: 'Summer wind',
+    });
+    state = mergeReactionNotificationState(state, {
+      actorKey: 'user:bob',
+      reactionType: 'abcdefghijkl-second',
+      noteLabel: 'Summer wind',
+    });
+    expect(state.reactionTypes).toHaveLength(2);
+  });
+
+  it('rejects reaction details that normalize to empty', () => {
+    expect(canPresentDetailedReactionType(' \n\u0000<p></p> ')).toBe(false);
   });
 });

--- a/server/push/reactionPresentation.test.ts
+++ b/server/push/reactionPresentation.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  mergeReactionNotificationState,
+  reactionActorName,
+  reactionNoteLabel,
+  reactionNotificationPresentation,
+} from './reactionPresentation';
+
+describe('reaction notification presentation', () => {
+  it('uses the known actor, reaction, and note label for a single response', () => {
+    const state = mergeReactionNotificationState(null, {
+      actorKey: 'user:alice',
+      actorName: 'Alice',
+      reactionType: '❤️',
+      noteLabel: 'Summer wind',
+    });
+    expect(reactionNotificationPresentation(state)).toEqual({
+      titleLocKey: 'push.reaction.detail.known.title',
+      bodyLocKey: 'push.reaction.detail.body',
+      titleLocArgs: ['Alice'],
+      bodyLocArgs: ['❤️', 'Summer wind'],
+    });
+  });
+
+  it('aggregates unique actors and response types while preserving the first actor', () => {
+    const first = mergeReactionNotificationState(null, {
+      actorKey: 'user:alice',
+      actorName: 'Alice',
+      reactionType: '❤️',
+      noteLabel: 'Summer wind',
+    });
+    const repeatedActor = mergeReactionNotificationState(first, {
+      actorKey: 'user:alice',
+      actorName: 'Alice',
+      reactionType: '👍',
+      noteLabel: 'Summer wind',
+    });
+    const anotherActor = mergeReactionNotificationState(repeatedActor, {
+      actorKey: 'visitor:beta',
+      reactionType: '🎉',
+      noteLabel: 'Summer wind',
+    });
+    expect(reactionNotificationPresentation(anotherActor)).toEqual({
+      titleLocKey: 'push.reaction.detail.known_multiple.title',
+      bodyLocKey: 'push.reaction.detail.body',
+      titleLocArgs: ['Alice', '1'],
+      bodyLocArgs: ['❤️ 👍 🎉', 'Summer wind'],
+    });
+  });
+
+  it('uses localized anonymous titles without embedding a server-language label', () => {
+    const state = mergeReactionNotificationState(null, {
+      actorKey: 'visitor:alpha',
+      reactionType: '👏',
+      noteLabel: 'Summer wind',
+    });
+    expect(reactionNotificationPresentation(state)).toEqual({
+      titleLocKey: 'push.reaction.detail.anonymous.title',
+      bodyLocKey: 'push.reaction.detail.body',
+      titleLocArgs: [],
+      bodyLocArgs: ['👏', 'Summer wind'],
+    });
+  });
+
+  it('falls back to a bounded content excerpt when a note has no title', () => {
+    expect(reactionNoteLabel('  ', `  ${'记'.repeat(50)}\nnext line  `)).toBe(
+      `${'记'.repeat(36)}…`
+    );
+    expect(reactionActorName('  Alice\nSmith  ', 'fallback')).toBe('Alice Smith');
+  });
+});

--- a/server/push/reactionPresentation.test.ts
+++ b/server/push/reactionPresentation.test.ts
@@ -113,6 +113,20 @@ describe('reaction notification presentation', () => {
     expect(canPresentDetailedReactionType('👩‍💻')).toBe(true);
   });
 
+  it('preserves standardized emoji tag sequences as distinct reaction identities', () => {
+    const england = '\u{1F3F4}\u{E0067}\u{E0062}\u{E0065}\u{E006E}\u{E0067}\u{E007F}';
+    const scotland = '\u{1F3F4}\u{E0067}\u{E0062}\u{E0073}\u{E0063}\u{E0074}\u{E007F}';
+    let state = mergeReactionNotificationState(null, {
+      actorKey: 'user:alice',
+      reactionType: england,
+    });
+    state = mergeReactionNotificationState(state, {
+      actorKey: 'user:bob',
+      reactionType: scotland,
+    });
+    expect(state.reactionTypes.map((item) => item.label)).toEqual([england, scotland]);
+  });
+
   it('normalizes an invisible nickname before falling back to the username', () => {
     expect(reactionActorName(' <b> </b>\u200B', 'Alice')).toBe('Alice');
   });
@@ -138,7 +152,7 @@ describe('reaction notification presentation', () => {
     });
   });
 
-  it('bounds retained aggregate identities while keeping aggregate counts', () => {
+  it('bounds retained aggregate identities and switches saturated dimensions to many', () => {
     let state: ReturnType<typeof mergeReactionNotificationState> | null = null;
     for (let index = 0; index < 100; index += 1) {
       state = mergeReactionNotificationState(state, {
@@ -148,10 +162,45 @@ describe('reaction notification presentation', () => {
       });
     }
     expect(state.actorKeyHashes).toHaveLength(32);
-    expect(state.actorCount).toBe(100);
+    expect(state.actorsOverflowed).toBe(true);
     expect(state.reactionTypes).toHaveLength(8);
-    expect(state.reactionTypeCount).toBe(100);
+    expect(state.reactionTypesOverflowed).toBe(true);
     expect(Buffer.byteLength(JSON.stringify(state), 'utf8')).toBeLessThan(5_000);
+    expect(reactionNotificationPresentation(state)).toEqual({
+      titleLocKey: 'push.reaction.detail.anonymous_many.title',
+      bodyLocKey: 'push.reaction.detail.body.many',
+      titleLocArgs: [],
+      bodyLocArgs: ['custom-0 custom-1 custom-2', 'Summer wind'],
+    });
+  });
+
+  it('does not turn repeated overflow actors or types into unique counts', () => {
+    let state: ReturnType<typeof mergeReactionNotificationState> | null = null;
+    for (let index = 0; index < 32; index += 1) {
+      state = mergeReactionNotificationState(state, {
+        actorKey: `visitor:${index}`,
+        reactionType: `custom-${index % 8}`,
+      });
+    }
+    state = mergeReactionNotificationState(state, {
+      actorKey: 'visitor:overflow',
+      reactionType: 'custom-overflow',
+    });
+    const saturatedState = state;
+    for (let index = 0; index < 5; index += 1) {
+      state = mergeReactionNotificationState(state, {
+        actorKey: 'visitor:overflow',
+        reactionType: 'custom-overflow',
+      });
+    }
+    expect(state.actorKeyHashes).toEqual(saturatedState.actorKeyHashes);
+    expect(state.reactionTypes).toEqual(saturatedState.reactionTypes);
+    expect(reactionNotificationPresentation(state).titleLocKey).toBe(
+      'push.reaction.detail.anonymous_many.title'
+    );
+    expect(reactionNotificationPresentation(state).bodyLocKey).toBe(
+      'push.reaction.detail.body.unlabeled.many'
+    );
   });
 
   it('bounds pathological graphemes so the completed APNs payload remains below 4 KB', () => {

--- a/server/push/reactionPresentation.ts
+++ b/server/push/reactionPresentation.ts
@@ -3,18 +3,34 @@ const ACTOR_PREVIEW_LENGTH = 32;
 const REACTION_PREVIEW_LENGTH = 12;
 const MAX_VISIBLE_REACTION_TYPES = 3;
 
+type GraphemeSegmenter = {
+  segment(value: string): Iterable<{ segment: string }>;
+};
+
+type GraphemeSegmenterConstructor = new (
+  locales?: string | string[],
+  options?: { granularity: 'grapheme' }
+) => GraphemeSegmenter;
+
+const GraphemeSegmenter = (Intl as unknown as { Segmenter: GraphemeSegmenterConstructor })
+  .Segmenter;
+const graphemeSegmenter = new GraphemeSegmenter(undefined, { granularity: 'grapheme' });
+
 export type ReactionNotificationState = {
   actorKeys: string[];
   firstKnownActorName?: string;
-  reactionTypes: string[];
-  noteLabel: string;
+  reactionTypes: Array<{
+    identity: string;
+    label: string;
+  }>;
+  noteLabel?: string;
 };
 
 export type ReactionNotificationInput = {
   actorKey: string;
   actorName?: string;
   reactionType: string;
-  noteLabel: string;
+  noteLabel?: string;
 };
 
 export type ReactionNotificationPresentation = {
@@ -33,19 +49,26 @@ function normalizedText(value: string | null | undefined): string {
 }
 
 function truncated(value: string, maximumLength: number): string {
-  const characters = Array.from(value);
+  const characters = Array.from(graphemeSegmenter.segment(value), (segment) => segment.segment);
   if (characters.length <= maximumLength) return value;
   return `${characters.slice(0, maximumLength).join('')}…`;
 }
 
-export function reactionNoteLabel(title: string | null | undefined, content: string): string {
+export function reactionNoteLabel(
+  title: string | null | undefined,
+  content: string
+): string | undefined {
   const titleText = normalizedText(title);
-  const source = titleText || normalizedText(content) || 'Rote';
-  return truncated(source, NOTE_PREVIEW_LENGTH);
+  const source = titleText || normalizedText(content);
+  return source ? truncated(source, NOTE_PREVIEW_LENGTH) : undefined;
 }
 
 export function reactionActorName(nickname: string | null | undefined, username: string): string {
   return truncated(normalizedText(nickname) || normalizedText(username), ACTOR_PREVIEW_LENGTH);
+}
+
+export function canPresentDetailedReactionType(reactionType: string): boolean {
+  return normalizedText(reactionType).length > 0;
 }
 
 export function mergeReactionNotificationState(
@@ -55,10 +78,19 @@ export function mergeReactionNotificationState(
   const actorKeys = current?.actorKeys.includes(input.actorKey)
     ? current.actorKeys
     : [...(current?.actorKeys ?? []), input.actorKey];
-  const reactionType = truncated(normalizedText(input.reactionType), REACTION_PREVIEW_LENGTH);
-  const reactionTypes = current?.reactionTypes.includes(reactionType)
+  const reactionIdentity = normalizedText(input.reactionType);
+  const reactionTypes = current?.reactionTypes.some(
+    (reactionType) => reactionType.identity === reactionIdentity
+  )
     ? current.reactionTypes
-    : [...(current?.reactionTypes ?? []), reactionType];
+    : [
+        ...(current?.reactionTypes ?? []),
+        {
+          identity: reactionIdentity,
+          label: truncated(reactionIdentity, REACTION_PREVIEW_LENGTH),
+        },
+      ];
+  const nextNoteLabel = truncated(normalizedText(input.noteLabel), NOTE_PREVIEW_LENGTH);
   return {
     actorKeys,
     firstKnownActorName:
@@ -67,8 +99,7 @@ export function mergeReactionNotificationState(
         ? truncated(normalizedText(input.actorName), ACTOR_PREVIEW_LENGTH)
         : undefined),
     reactionTypes,
-    noteLabel:
-      current?.noteLabel || truncated(normalizedText(input.noteLabel), NOTE_PREVIEW_LENGTH),
+    noteLabel: current?.noteLabel || nextNoteLabel || undefined,
   };
 }
 
@@ -79,8 +110,15 @@ export function parseReactionNotificationState(value: unknown): ReactionNotifica
     !Array.isArray(state.actorKeys) ||
     state.actorKeys.some((item) => typeof item !== 'string') ||
     !Array.isArray(state.reactionTypes) ||
-    state.reactionTypes.some((item) => typeof item !== 'string') ||
-    typeof state.noteLabel !== 'string' ||
+    state.reactionTypes.some(
+      (item) =>
+        !item ||
+        typeof item !== 'object' ||
+        Array.isArray(item) ||
+        typeof item.identity !== 'string' ||
+        typeof item.label !== 'string'
+    ) ||
+    (state.noteLabel !== undefined && typeof state.noteLabel !== 'string') ||
     (state.firstKnownActorName !== undefined && typeof state.firstKnownActorName !== 'string')
   ) {
     return null;
@@ -88,10 +126,10 @@ export function parseReactionNotificationState(value: unknown): ReactionNotifica
   return state as ReactionNotificationState;
 }
 
-function reactionSummary(reactionTypes: string[]): string {
+function reactionSummary(reactionTypes: ReactionNotificationState['reactionTypes']): string {
   const visible = reactionTypes.slice(0, MAX_VISIBLE_REACTION_TYPES);
   const hiddenCount = reactionTypes.length - visible.length;
-  return `${visible.join(' ')}${hiddenCount > 0 ? ` +${hiddenCount}` : ''}`;
+  return `${visible.map((item) => item.label).join(' ')}${hiddenCount > 0 ? ` +${hiddenCount}` : ''}`;
 }
 
 export function reactionNotificationPresentation(
@@ -117,8 +155,12 @@ export function reactionNotificationPresentation(
   }
   return {
     titleLocKey,
-    bodyLocKey: 'push.reaction.detail.body',
+    bodyLocKey: state.noteLabel
+      ? 'push.reaction.detail.body'
+      : 'push.reaction.detail.body.unlabeled',
     titleLocArgs,
-    bodyLocArgs: [reactionSummary(state.reactionTypes), state.noteLabel],
+    bodyLocArgs: state.noteLabel
+      ? [reactionSummary(state.reactionTypes), state.noteLabel]
+      : [reactionSummary(state.reactionTypes)],
   };
 }

--- a/server/push/reactionPresentation.ts
+++ b/server/push/reactionPresentation.ts
@@ -9,7 +9,6 @@ const REACTION_PREVIEW_BYTES = 64;
 const MAX_VISIBLE_REACTION_TYPES = 3;
 const MAX_TRACKED_ACTORS = 32;
 const MAX_TRACKED_REACTION_TYPES = 8;
-const MAX_AGGREGATE_COUNT = 9_999;
 
 type GraphemeSegmenter = {
   segment(value: string): Iterable<{ segment: string }>;
@@ -27,13 +26,13 @@ const visibleReactionCharacter = /[\p{L}\p{N}\p{P}\p{S}]/u;
 
 export type ReactionNotificationState = {
   actorKeyHashes: string[];
-  actorCount: number;
+  actorsOverflowed: boolean;
   firstKnownActorName?: string;
   reactionTypes: Array<{
     identityHash: string;
     label: string;
   }>;
-  reactionTypeCount: number;
+  reactionTypesOverflowed: boolean;
   noteLabel?: string;
 };
 
@@ -55,7 +54,11 @@ function normalizedText(value: string | null | undefined): string {
   return (value ?? '')
     .replace(/<[^>]*>/g, ' ')
     .replace(/\p{Cc}/gu, ' ')
-    .replace(/\p{Cf}/gu, (character) => (character === '\u200D' ? character : ' '))
+    .replace(/\p{Cf}/gu, (character) => {
+      const codePoint = character.codePointAt(0) ?? 0;
+      const isEmojiTag = codePoint >= 0xe0020 && codePoint <= 0xe007f;
+      return character === '\u200D' || isEmojiTag ? character : ' ';
+    })
     .replace(/\s+/g, ' ')
     .trim();
 }
@@ -127,13 +130,13 @@ export function mergeReactionNotificationState(
 ): ReactionNotificationState {
   const actorKeyHash = identityHash(input.actorKey);
   const actorAlreadyTracked = current?.actorKeyHashes.includes(actorKeyHash) ?? false;
+  const canTrackActor = (current?.actorKeyHashes.length ?? 0) < MAX_TRACKED_ACTORS;
   const actorKeyHashes =
-    actorAlreadyTracked || (current?.actorKeyHashes.length ?? 0) >= MAX_TRACKED_ACTORS
+    actorAlreadyTracked || !canTrackActor
       ? (current?.actorKeyHashes ?? [])
       : [...(current?.actorKeyHashes ?? []), actorKeyHash];
-  const actorCount = actorAlreadyTracked
-    ? (current?.actorCount ?? 1)
-    : Math.min((current?.actorCount ?? 0) + 1, MAX_AGGREGATE_COUNT);
+  const actorsOverflowed =
+    current?.actorsOverflowed === true || (!actorAlreadyTracked && !canTrackActor);
 
   const reactionIdentity = normalizedText(input.reactionType);
   const reactionIdentityHash = identityHash(reactionIdentity);
@@ -146,10 +149,9 @@ export function mergeReactionNotificationState(
     REACTION_PREVIEW_LENGTH,
     REACTION_PREVIEW_BYTES
   );
+  const canTrackReactionType = (current?.reactionTypes.length ?? 0) < MAX_TRACKED_REACTION_TYPES;
   const reactionTypes =
-    reactionAlreadyTracked ||
-    !reactionLabel ||
-    (current?.reactionTypes.length ?? 0) >= MAX_TRACKED_REACTION_TYPES
+    reactionAlreadyTracked || !reactionLabel || !canTrackReactionType
       ? (current?.reactionTypes ?? [])
       : [
           ...(current?.reactionTypes ?? []),
@@ -158,10 +160,9 @@ export function mergeReactionNotificationState(
             label: reactionLabel,
           },
         ];
-  const reactionTypeCount =
-    reactionAlreadyTracked || !reactionLabel
-      ? (current?.reactionTypeCount ?? reactionTypes.length)
-      : Math.min((current?.reactionTypeCount ?? 0) + 1, MAX_AGGREGATE_COUNT);
+  const reactionTypesOverflowed =
+    current?.reactionTypesOverflowed === true ||
+    (!reactionAlreadyTracked && Boolean(reactionLabel) && !canTrackReactionType);
   const nextActorName = truncated(
     normalizedText(input.actorName),
     ACTOR_PREVIEW_LENGTH,
@@ -174,10 +175,10 @@ export function mergeReactionNotificationState(
   );
   return {
     actorKeyHashes,
-    actorCount,
+    actorsOverflowed,
     firstKnownActorName: current?.firstKnownActorName || nextActorName,
     reactionTypes,
-    reactionTypeCount,
+    reactionTypesOverflowed,
     noteLabel: current?.noteLabel || nextNoteLabel,
   };
 }
@@ -189,9 +190,8 @@ export function parseReactionNotificationState(value: unknown): ReactionNotifica
     !Array.isArray(state.actorKeyHashes) ||
     state.actorKeyHashes.length > MAX_TRACKED_ACTORS ||
     state.actorKeyHashes.some((item) => typeof item !== 'string') ||
-    !Number.isInteger(state.actorCount) ||
-    state.actorCount! < state.actorKeyHashes.length ||
-    state.actorCount! > MAX_AGGREGATE_COUNT ||
+    typeof state.actorsOverflowed !== 'boolean' ||
+    (state.actorsOverflowed && state.actorKeyHashes.length !== MAX_TRACKED_ACTORS) ||
     !Array.isArray(state.reactionTypes) ||
     state.reactionTypes.length > MAX_TRACKED_REACTION_TYPES ||
     state.reactionTypes.some(
@@ -202,9 +202,8 @@ export function parseReactionNotificationState(value: unknown): ReactionNotifica
         typeof item.identityHash !== 'string' ||
         typeof item.label !== 'string'
     ) ||
-    !Number.isInteger(state.reactionTypeCount) ||
-    state.reactionTypeCount! < state.reactionTypes.length ||
-    state.reactionTypeCount! > MAX_AGGREGATE_COUNT ||
+    typeof state.reactionTypesOverflowed !== 'boolean' ||
+    (state.reactionTypesOverflowed && state.reactionTypes.length !== MAX_TRACKED_REACTION_TYPES) ||
     (state.noteLabel !== undefined && typeof state.noteLabel !== 'string') ||
     (state.firstKnownActorName !== undefined && typeof state.firstKnownActorName !== 'string')
   ) {
@@ -223,29 +222,43 @@ function visibleReactionSummary(state: ReactionNotificationState): string {
 export function reactionNotificationPresentation(
   state: ReactionNotificationState
 ): ReactionNotificationPresentation {
+  const actorCount = state.actorKeyHashes.length;
   let titleLocKey: string;
   let titleLocArgs: string[];
   if (state.firstKnownActorName) {
-    if (state.actorCount > 1) {
+    if (state.actorsOverflowed) {
+      titleLocKey = 'push.reaction.detail.known_many.title';
+      titleLocArgs = [state.firstKnownActorName];
+    } else if (actorCount > 1) {
       titleLocKey = 'push.reaction.detail.known_multiple.title';
-      titleLocArgs = [state.firstKnownActorName, String(state.actorCount - 1)];
+      titleLocArgs = [state.firstKnownActorName, String(actorCount - 1)];
     } else {
       titleLocKey = 'push.reaction.detail.known.title';
       titleLocArgs = [state.firstKnownActorName];
     }
-  } else if (state.actorCount > 1) {
+  } else if (state.actorsOverflowed) {
+    titleLocKey = 'push.reaction.detail.anonymous_many.title';
+    titleLocArgs = [];
+  } else if (actorCount > 1) {
     titleLocKey = 'push.reaction.detail.anonymous_multiple.title';
-    titleLocArgs = [String(state.actorCount)];
+    titleLocArgs = [String(actorCount)];
   } else {
     titleLocKey = 'push.reaction.detail.anonymous.title';
     titleLocArgs = [];
   }
 
   const summary = visibleReactionSummary(state);
-  const hiddenReactionCount = Math.max(
-    0,
-    state.reactionTypeCount - Math.min(state.reactionTypes.length, MAX_VISIBLE_REACTION_TYPES)
-  );
+  if (state.reactionTypesOverflowed) {
+    return {
+      titleLocKey,
+      bodyLocKey: state.noteLabel
+        ? 'push.reaction.detail.body.many'
+        : 'push.reaction.detail.body.unlabeled.many',
+      titleLocArgs,
+      bodyLocArgs: state.noteLabel ? [summary, state.noteLabel] : [summary],
+    };
+  }
+  const hiddenReactionCount = Math.max(0, state.reactionTypes.length - MAX_VISIBLE_REACTION_TYPES);
   if (hiddenReactionCount > 0) {
     return {
       titleLocKey,

--- a/server/push/reactionPresentation.ts
+++ b/server/push/reactionPresentation.ts
@@ -1,7 +1,15 @@
+import { createHash } from 'node:crypto';
+
 const NOTE_PREVIEW_LENGTH = 36;
+const NOTE_PREVIEW_BYTES = 256;
 const ACTOR_PREVIEW_LENGTH = 32;
+const ACTOR_PREVIEW_BYTES = 160;
 const REACTION_PREVIEW_LENGTH = 12;
+const REACTION_PREVIEW_BYTES = 64;
 const MAX_VISIBLE_REACTION_TYPES = 3;
+const MAX_TRACKED_ACTORS = 32;
+const MAX_TRACKED_REACTION_TYPES = 8;
+const MAX_AGGREGATE_COUNT = 9_999;
 
 type GraphemeSegmenter = {
   segment(value: string): Iterable<{ segment: string }>;
@@ -15,14 +23,17 @@ type GraphemeSegmenterConstructor = new (
 const GraphemeSegmenter = (Intl as unknown as { Segmenter: GraphemeSegmenterConstructor })
   .Segmenter;
 const graphemeSegmenter = new GraphemeSegmenter(undefined, { granularity: 'grapheme' });
+const visibleReactionCharacter = /[\p{L}\p{N}\p{P}\p{S}]/u;
 
 export type ReactionNotificationState = {
-  actorKeys: string[];
+  actorKeyHashes: string[];
+  actorCount: number;
   firstKnownActorName?: string;
   reactionTypes: Array<{
-    identity: string;
+    identityHash: string;
     label: string;
   }>;
+  reactionTypeCount: number;
   noteLabel?: string;
 };
 
@@ -44,14 +55,42 @@ function normalizedText(value: string | null | undefined): string {
   return (value ?? '')
     .replace(/<[^>]*>/g, ' ')
     .replace(/\p{Cc}/gu, ' ')
+    .replace(/\p{Cf}/gu, (character) => (character === '\u200D' ? character : ' '))
     .replace(/\s+/g, ' ')
     .trim();
 }
 
-function truncated(value: string, maximumLength: number): string {
-  const characters = Array.from(graphemeSegmenter.segment(value), (segment) => segment.segment);
-  if (characters.length <= maximumLength) return value;
-  return `${characters.slice(0, maximumLength).join('')}…`;
+function identityHash(value: string): string {
+  return createHash('sha256').update(value).digest('base64url');
+}
+
+function truncated(
+  value: string,
+  maximumLength: number,
+  maximumUtf8Bytes: number
+): string | undefined {
+  if (!value) return undefined;
+  const segments: string[] = [];
+  let byteLength = 0;
+  let wasTruncated = false;
+  for (const { segment } of graphemeSegmenter.segment(value)) {
+    const segmentBytes = Buffer.byteLength(segment, 'utf8');
+    if (segments.length >= maximumLength || byteLength + segmentBytes > maximumUtf8Bytes) {
+      wasTruncated = true;
+      break;
+    }
+    segments.push(segment);
+    byteLength += segmentBytes;
+  }
+  if (!segments.length) return undefined;
+  if (!wasTruncated) return segments.join('');
+
+  const suffix = '…';
+  const suffixBytes = Buffer.byteLength(suffix, 'utf8');
+  while (segments.length && byteLength + suffixBytes > maximumUtf8Bytes) {
+    byteLength -= Buffer.byteLength(segments.pop()!, 'utf8');
+  }
+  return segments.length ? `${segments.join('')}${suffix}` : undefined;
 }
 
 export function reactionNoteLabel(
@@ -60,46 +99,86 @@ export function reactionNoteLabel(
 ): string | undefined {
   const titleText = normalizedText(title);
   const source = titleText || normalizedText(content);
-  return source ? truncated(source, NOTE_PREVIEW_LENGTH) : undefined;
+  return source ? truncated(source, NOTE_PREVIEW_LENGTH, NOTE_PREVIEW_BYTES) : undefined;
 }
 
-export function reactionActorName(nickname: string | null | undefined, username: string): string {
-  return truncated(normalizedText(nickname) || normalizedText(username), ACTOR_PREVIEW_LENGTH);
+export function reactionActorName(
+  nickname: string | null | undefined,
+  username: string
+): string | undefined {
+  return truncated(
+    normalizedText(nickname) || normalizedText(username),
+    ACTOR_PREVIEW_LENGTH,
+    ACTOR_PREVIEW_BYTES
+  );
 }
 
 export function canPresentDetailedReactionType(reactionType: string): boolean {
-  return normalizedText(reactionType).length > 0;
+  const normalized = normalizedText(reactionType);
+  return (
+    visibleReactionCharacter.test(normalized) &&
+    truncated(normalized, REACTION_PREVIEW_LENGTH, REACTION_PREVIEW_BYTES) !== undefined
+  );
 }
 
 export function mergeReactionNotificationState(
   current: ReactionNotificationState | null,
   input: ReactionNotificationInput
 ): ReactionNotificationState {
-  const actorKeys = current?.actorKeys.includes(input.actorKey)
-    ? current.actorKeys
-    : [...(current?.actorKeys ?? []), input.actorKey];
+  const actorKeyHash = identityHash(input.actorKey);
+  const actorAlreadyTracked = current?.actorKeyHashes.includes(actorKeyHash) ?? false;
+  const actorKeyHashes =
+    actorAlreadyTracked || (current?.actorKeyHashes.length ?? 0) >= MAX_TRACKED_ACTORS
+      ? (current?.actorKeyHashes ?? [])
+      : [...(current?.actorKeyHashes ?? []), actorKeyHash];
+  const actorCount = actorAlreadyTracked
+    ? (current?.actorCount ?? 1)
+    : Math.min((current?.actorCount ?? 0) + 1, MAX_AGGREGATE_COUNT);
+
   const reactionIdentity = normalizedText(input.reactionType);
-  const reactionTypes = current?.reactionTypes.some(
-    (reactionType) => reactionType.identity === reactionIdentity
-  )
-    ? current.reactionTypes
-    : [
-        ...(current?.reactionTypes ?? []),
-        {
-          identity: reactionIdentity,
-          label: truncated(reactionIdentity, REACTION_PREVIEW_LENGTH),
-        },
-      ];
-  const nextNoteLabel = truncated(normalizedText(input.noteLabel), NOTE_PREVIEW_LENGTH);
+  const reactionIdentityHash = identityHash(reactionIdentity);
+  const reactionAlreadyTracked =
+    current?.reactionTypes.some(
+      (reactionType) => reactionType.identityHash === reactionIdentityHash
+    ) ?? false;
+  const reactionLabel = truncated(
+    reactionIdentity,
+    REACTION_PREVIEW_LENGTH,
+    REACTION_PREVIEW_BYTES
+  );
+  const reactionTypes =
+    reactionAlreadyTracked ||
+    !reactionLabel ||
+    (current?.reactionTypes.length ?? 0) >= MAX_TRACKED_REACTION_TYPES
+      ? (current?.reactionTypes ?? [])
+      : [
+          ...(current?.reactionTypes ?? []),
+          {
+            identityHash: reactionIdentityHash,
+            label: reactionLabel,
+          },
+        ];
+  const reactionTypeCount =
+    reactionAlreadyTracked || !reactionLabel
+      ? (current?.reactionTypeCount ?? reactionTypes.length)
+      : Math.min((current?.reactionTypeCount ?? 0) + 1, MAX_AGGREGATE_COUNT);
+  const nextActorName = truncated(
+    normalizedText(input.actorName),
+    ACTOR_PREVIEW_LENGTH,
+    ACTOR_PREVIEW_BYTES
+  );
+  const nextNoteLabel = truncated(
+    normalizedText(input.noteLabel),
+    NOTE_PREVIEW_LENGTH,
+    NOTE_PREVIEW_BYTES
+  );
   return {
-    actorKeys,
-    firstKnownActorName:
-      current?.firstKnownActorName ||
-      (input.actorName
-        ? truncated(normalizedText(input.actorName), ACTOR_PREVIEW_LENGTH)
-        : undefined),
+    actorKeyHashes,
+    actorCount,
+    firstKnownActorName: current?.firstKnownActorName || nextActorName,
     reactionTypes,
-    noteLabel: current?.noteLabel || nextNoteLabel || undefined,
+    reactionTypeCount,
+    noteLabel: current?.noteLabel || nextNoteLabel,
   };
 }
 
@@ -107,17 +186,25 @@ export function parseReactionNotificationState(value: unknown): ReactionNotifica
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
   const state = value as Partial<ReactionNotificationState>;
   if (
-    !Array.isArray(state.actorKeys) ||
-    state.actorKeys.some((item) => typeof item !== 'string') ||
+    !Array.isArray(state.actorKeyHashes) ||
+    state.actorKeyHashes.length > MAX_TRACKED_ACTORS ||
+    state.actorKeyHashes.some((item) => typeof item !== 'string') ||
+    !Number.isInteger(state.actorCount) ||
+    state.actorCount! < state.actorKeyHashes.length ||
+    state.actorCount! > MAX_AGGREGATE_COUNT ||
     !Array.isArray(state.reactionTypes) ||
+    state.reactionTypes.length > MAX_TRACKED_REACTION_TYPES ||
     state.reactionTypes.some(
       (item) =>
         !item ||
         typeof item !== 'object' ||
         Array.isArray(item) ||
-        typeof item.identity !== 'string' ||
+        typeof item.identityHash !== 'string' ||
         typeof item.label !== 'string'
     ) ||
+    !Number.isInteger(state.reactionTypeCount) ||
+    state.reactionTypeCount! < state.reactionTypes.length ||
+    state.reactionTypeCount! > MAX_AGGREGATE_COUNT ||
     (state.noteLabel !== undefined && typeof state.noteLabel !== 'string') ||
     (state.firstKnownActorName !== undefined && typeof state.firstKnownActorName !== 'string')
   ) {
@@ -126,32 +213,50 @@ export function parseReactionNotificationState(value: unknown): ReactionNotifica
   return state as ReactionNotificationState;
 }
 
-function reactionSummary(reactionTypes: ReactionNotificationState['reactionTypes']): string {
-  const visible = reactionTypes.slice(0, MAX_VISIBLE_REACTION_TYPES);
-  const hiddenCount = reactionTypes.length - visible.length;
-  return `${visible.map((item) => item.label).join(' ')}${hiddenCount > 0 ? ` +${hiddenCount}` : ''}`;
+function visibleReactionSummary(state: ReactionNotificationState): string {
+  return state.reactionTypes
+    .slice(0, MAX_VISIBLE_REACTION_TYPES)
+    .map((item) => item.label)
+    .join(' ');
 }
 
 export function reactionNotificationPresentation(
   state: ReactionNotificationState
 ): ReactionNotificationPresentation {
-  const actorCount = state.actorKeys.length;
   let titleLocKey: string;
   let titleLocArgs: string[];
   if (state.firstKnownActorName) {
-    if (actorCount > 1) {
+    if (state.actorCount > 1) {
       titleLocKey = 'push.reaction.detail.known_multiple.title';
-      titleLocArgs = [state.firstKnownActorName, String(actorCount - 1)];
+      titleLocArgs = [state.firstKnownActorName, String(state.actorCount - 1)];
     } else {
       titleLocKey = 'push.reaction.detail.known.title';
       titleLocArgs = [state.firstKnownActorName];
     }
-  } else if (actorCount > 1) {
+  } else if (state.actorCount > 1) {
     titleLocKey = 'push.reaction.detail.anonymous_multiple.title';
-    titleLocArgs = [String(actorCount)];
+    titleLocArgs = [String(state.actorCount)];
   } else {
     titleLocKey = 'push.reaction.detail.anonymous.title';
     titleLocArgs = [];
+  }
+
+  const summary = visibleReactionSummary(state);
+  const hiddenReactionCount = Math.max(
+    0,
+    state.reactionTypeCount - Math.min(state.reactionTypes.length, MAX_VISIBLE_REACTION_TYPES)
+  );
+  if (hiddenReactionCount > 0) {
+    return {
+      titleLocKey,
+      bodyLocKey: state.noteLabel
+        ? 'push.reaction.detail.body.overflow'
+        : 'push.reaction.detail.body.unlabeled.overflow',
+      titleLocArgs,
+      bodyLocArgs: state.noteLabel
+        ? [summary, String(hiddenReactionCount), state.noteLabel]
+        : [summary, String(hiddenReactionCount)],
+    };
   }
   return {
     titleLocKey,
@@ -159,8 +264,6 @@ export function reactionNotificationPresentation(
       ? 'push.reaction.detail.body'
       : 'push.reaction.detail.body.unlabeled',
     titleLocArgs,
-    bodyLocArgs: state.noteLabel
-      ? [reactionSummary(state.reactionTypes), state.noteLabel]
-      : [reactionSummary(state.reactionTypes)],
+    bodyLocArgs: state.noteLabel ? [summary, state.noteLabel] : [summary],
   };
 }

--- a/server/push/reactionPresentation.ts
+++ b/server/push/reactionPresentation.ts
@@ -1,0 +1,124 @@
+const NOTE_PREVIEW_LENGTH = 36;
+const ACTOR_PREVIEW_LENGTH = 32;
+const REACTION_PREVIEW_LENGTH = 12;
+const MAX_VISIBLE_REACTION_TYPES = 3;
+
+export type ReactionNotificationState = {
+  actorKeys: string[];
+  firstKnownActorName?: string;
+  reactionTypes: string[];
+  noteLabel: string;
+};
+
+export type ReactionNotificationInput = {
+  actorKey: string;
+  actorName?: string;
+  reactionType: string;
+  noteLabel: string;
+};
+
+export type ReactionNotificationPresentation = {
+  titleLocKey: string;
+  bodyLocKey: string;
+  titleLocArgs: string[];
+  bodyLocArgs: string[];
+};
+
+function normalizedText(value: string | null | undefined): string {
+  return (value ?? '')
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/\p{Cc}/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function truncated(value: string, maximumLength: number): string {
+  const characters = Array.from(value);
+  if (characters.length <= maximumLength) return value;
+  return `${characters.slice(0, maximumLength).join('')}…`;
+}
+
+export function reactionNoteLabel(title: string | null | undefined, content: string): string {
+  const titleText = normalizedText(title);
+  const source = titleText || normalizedText(content) || 'Rote';
+  return truncated(source, NOTE_PREVIEW_LENGTH);
+}
+
+export function reactionActorName(nickname: string | null | undefined, username: string): string {
+  return truncated(normalizedText(nickname) || normalizedText(username), ACTOR_PREVIEW_LENGTH);
+}
+
+export function mergeReactionNotificationState(
+  current: ReactionNotificationState | null,
+  input: ReactionNotificationInput
+): ReactionNotificationState {
+  const actorKeys = current?.actorKeys.includes(input.actorKey)
+    ? current.actorKeys
+    : [...(current?.actorKeys ?? []), input.actorKey];
+  const reactionType = truncated(normalizedText(input.reactionType), REACTION_PREVIEW_LENGTH);
+  const reactionTypes = current?.reactionTypes.includes(reactionType)
+    ? current.reactionTypes
+    : [...(current?.reactionTypes ?? []), reactionType];
+  return {
+    actorKeys,
+    firstKnownActorName:
+      current?.firstKnownActorName ||
+      (input.actorName
+        ? truncated(normalizedText(input.actorName), ACTOR_PREVIEW_LENGTH)
+        : undefined),
+    reactionTypes,
+    noteLabel:
+      current?.noteLabel || truncated(normalizedText(input.noteLabel), NOTE_PREVIEW_LENGTH),
+  };
+}
+
+export function parseReactionNotificationState(value: unknown): ReactionNotificationState | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const state = value as Partial<ReactionNotificationState>;
+  if (
+    !Array.isArray(state.actorKeys) ||
+    state.actorKeys.some((item) => typeof item !== 'string') ||
+    !Array.isArray(state.reactionTypes) ||
+    state.reactionTypes.some((item) => typeof item !== 'string') ||
+    typeof state.noteLabel !== 'string' ||
+    (state.firstKnownActorName !== undefined && typeof state.firstKnownActorName !== 'string')
+  ) {
+    return null;
+  }
+  return state as ReactionNotificationState;
+}
+
+function reactionSummary(reactionTypes: string[]): string {
+  const visible = reactionTypes.slice(0, MAX_VISIBLE_REACTION_TYPES);
+  const hiddenCount = reactionTypes.length - visible.length;
+  return `${visible.join(' ')}${hiddenCount > 0 ? ` +${hiddenCount}` : ''}`;
+}
+
+export function reactionNotificationPresentation(
+  state: ReactionNotificationState
+): ReactionNotificationPresentation {
+  const actorCount = state.actorKeys.length;
+  let titleLocKey: string;
+  let titleLocArgs: string[];
+  if (state.firstKnownActorName) {
+    if (actorCount > 1) {
+      titleLocKey = 'push.reaction.detail.known_multiple.title';
+      titleLocArgs = [state.firstKnownActorName, String(actorCount - 1)];
+    } else {
+      titleLocKey = 'push.reaction.detail.known.title';
+      titleLocArgs = [state.firstKnownActorName];
+    }
+  } else if (actorCount > 1) {
+    titleLocKey = 'push.reaction.detail.anonymous_multiple.title';
+    titleLocArgs = [String(actorCount)];
+  } else {
+    titleLocKey = 'push.reaction.detail.anonymous.title';
+    titleLocArgs = [];
+  }
+  return {
+    titleLocKey,
+    bodyLocKey: 'push.reaction.detail.body',
+    titleLocArgs,
+    bodyLocArgs: [reactionSummary(state.reactionTypes), state.noteLabel],
+  };
+}

--- a/server/push/reactionPresentation.ts
+++ b/server/push/reactionPresentation.ts
@@ -23,6 +23,7 @@ const GraphemeSegmenter = (Intl as unknown as { Segmenter: GraphemeSegmenterCons
   .Segmenter;
 const graphemeSegmenter = new GraphemeSegmenter(undefined, { granularity: 'grapheme' });
 const visibleReactionCharacter = /[\p{L}\p{N}\p{P}\p{S}]/u;
+const emojiTagSequenceOrFormatCharacter = /\u{1F3F4}[\u{E0020}-\u{E007E}]+\u{E007F}|\p{Cf}/gu;
 
 export type ReactionNotificationState = {
   actorKeyHashes: string[];
@@ -52,15 +53,17 @@ export type ReactionNotificationPresentation = {
 
 function normalizedText(value: string | null | undefined): string {
   return (value ?? '')
-    .replace(/<[^>]*>/g, ' ')
     .replace(/\p{Cc}/gu, ' ')
-    .replace(/\p{Cf}/gu, (character) => {
-      const codePoint = character.codePointAt(0) ?? 0;
-      const isEmojiTag = codePoint >= 0xe0020 && codePoint <= 0xe007f;
-      return character === '\u200D' || isEmojiTag ? character : ' ';
-    })
+    .replace(emojiTagSequenceOrFormatCharacter, (sequence) =>
+      sequence === '\u200D' || sequence.startsWith('\u{1F3F4}') ? sequence : ' '
+    )
     .replace(/\s+/g, ' ')
-    .trim();
+    .trim()
+    .normalize('NFC');
+}
+
+function normalizedRichText(value: string | null | undefined): string {
+  return normalizedText((value ?? '').replace(/<[^>]*>/g, ' '));
 }
 
 function identityHash(value: string): string {
@@ -101,7 +104,7 @@ export function reactionNoteLabel(
   content: string
 ): string | undefined {
   const titleText = normalizedText(title);
-  const source = titleText || normalizedText(content);
+  const source = titleText || normalizedRichText(content);
   return source ? truncated(source, NOTE_PREVIEW_LENGTH, NOTE_PREVIEW_BYTES) : undefined;
 }
 

--- a/server/push/repository.integration.test.ts
+++ b/server/push/repository.integration.test.ts
@@ -589,6 +589,60 @@ databaseDescribe('push repository integration', () => {
     expect(nextWindow.filter((event) => event.payload.roteId === roteId)).toHaveLength(2);
   });
 
+  it('aggregates detailed reaction presentation without exposing queue metadata to APNs', async () => {
+    const { and, eq, sql } = await import('drizzle-orm');
+    const { addReaction } = await import('../utils/dbMethods/reaction');
+    const { prepareApnsPayload } = await import('./payload');
+    const roteId = randomUUID();
+    await database.insert(schema.rotes).values({
+      id: roteId,
+      authorid: userIds[0],
+      title: 'Summer wind',
+      content: 'A longer note body that should not replace its title.',
+    });
+    const previousPushEnabled = process.env.PUSH_NOTIFICATIONS_ENABLED;
+    process.env.PUSH_NOTIFICATIONS_ENABLED = 'true';
+    try {
+      await addReaction({
+        type: '❤️',
+        roteid: roteId,
+        userid: userIds[1],
+        actorName: 'Alice',
+      });
+      await addReaction({
+        type: '👍',
+        roteid: roteId,
+        userid: userIds[2],
+        actorName: 'Bob',
+      });
+
+      const matching = await database
+        .select()
+        .from(schema.pushEvents)
+        .where(
+          and(
+            eq(schema.pushEvents.userid, userIds[0]),
+            eq(schema.pushEvents.type, 'reaction.received'),
+            sql`${schema.pushEvents.payload}->>'roteId' = ${roteId}`
+          )
+        );
+      expect(matching).toHaveLength(1);
+      expect(matching[0].titleLocKey).toBe('push.reaction.detail.known_multiple.title');
+      expect(matching[0].bodyLocKey).toBe('push.reaction.detail.body');
+      expect(prepareApnsPayload(matching[0].payload)).toEqual({
+        payload: { roteId },
+        titleLocArgs: ['Alice', '1'],
+        bodyLocArgs: ['❤️ 👍', 'Summer wind'],
+      });
+    } finally {
+      if (previousPushEnabled === undefined) {
+        delete process.env.PUSH_NOTIFICATIONS_ENABLED;
+      } else {
+        process.env.PUSH_NOTIFICATIONS_ENABLED = previousPushEnabled;
+      }
+    }
+  });
+
   it('rolls back a reaction when its aggregated push event cannot be inserted', async () => {
     const { and, eq, sql } = await import('drizzle-orm');
     const { addReaction, removeReaction } = await import('../utils/dbMethods/reaction');

--- a/server/push/repository.integration.test.ts
+++ b/server/push/repository.integration.test.ts
@@ -643,6 +643,60 @@ databaseDescribe('push repository integration', () => {
     }
   });
 
+  it('downgrades a mixed reaction aggregate to the generic presentation', async () => {
+    const { and, eq, sql } = await import('drizzle-orm');
+    const { addReaction } = await import('../utils/dbMethods/reaction');
+    const { prepareApnsPayload } = await import('./payload');
+    const roteId = randomUUID();
+    await database.insert(schema.rotes).values({
+      id: roteId,
+      authorid: userIds[0],
+      title: 'Mixed response context',
+      content: 'The second reaction cannot be presented safely.',
+    });
+    const previousPushEnabled = process.env.PUSH_NOTIFICATIONS_ENABLED;
+    process.env.PUSH_NOTIFICATIONS_ENABLED = 'true';
+    try {
+      await addReaction({
+        type: '❤️',
+        roteid: roteId,
+        userid: userIds[1],
+        actorName: 'Alice',
+      });
+      await addReaction({
+        type: '\u200B\u202E',
+        roteid: roteId,
+        userid: userIds[2],
+        actorName: 'Bob',
+      });
+
+      const matching = await database
+        .select()
+        .from(schema.pushEvents)
+        .where(
+          and(
+            eq(schema.pushEvents.userid, userIds[0]),
+            eq(schema.pushEvents.type, 'reaction.received'),
+            sql`${schema.pushEvents.payload}->>'roteId' = ${roteId}`
+          )
+        );
+      expect(matching).toHaveLength(1);
+      expect(matching[0].titleLocKey).toBe('push.reaction.title');
+      expect(matching[0].bodyLocKey).toBe('push.reaction.body');
+      expect(prepareApnsPayload(matching[0].payload)).toEqual({
+        payload: { roteId },
+        titleLocArgs: undefined,
+        bodyLocArgs: undefined,
+      });
+    } finally {
+      if (previousPushEnabled === undefined) {
+        delete process.env.PUSH_NOTIFICATIONS_ENABLED;
+      } else {
+        process.env.PUSH_NOTIFICATIONS_ENABLED = previousPushEnabled;
+      }
+    }
+  });
+
   it('rolls back a reaction when its aggregated push event cannot be inserted', async () => {
     const { and, eq, sql } = await import('drizzle-orm');
     const { addReaction, removeReaction } = await import('../utils/dbMethods/reaction');

--- a/server/push/repository.ts
+++ b/server/push/repository.ts
@@ -457,7 +457,11 @@ export async function enqueueAggregatedReactionPushEventInTransaction(
     sql`SELECT pg_advisory_xact_lock(hashtext(${`push-reaction:${input.userid}:${input.roteId}`}))`
   );
   const [pending] = await transaction
-    .select({ id: pushEvents.id, payload: pushEvents.payload })
+    .select({
+      id: pushEvents.id,
+      titleLocKey: pushEvents.titleLocKey,
+      payload: pushEvents.payload,
+    })
     .from(pushEvents)
     .where(
       and(
@@ -475,7 +479,19 @@ export async function enqueueAggregatedReactionPushEventInTransaction(
     input.actorKey !== undefined &&
     input.noteContent !== undefined &&
     canPresentDetailedReactionType(input.reactionType);
-  if (pending && !hasDetailedContext) return;
+  if (pending?.titleLocKey === 'push.reaction.title') return;
+  if (pending && !hasDetailedContext) {
+    await transaction
+      .update(pushEvents)
+      .set({
+        titleLocKey: 'push.reaction.title',
+        bodyLocKey: 'push.reaction.body',
+        payload: { roteId: input.roteId },
+        updatedAt: new Date(),
+      })
+      .where(eq(pushEvents.id, pending.id));
+    return;
+  }
 
   let presentation:
     | {

--- a/server/push/repository.ts
+++ b/server/push/repository.ts
@@ -6,6 +6,7 @@ import type { ApnsEnvironment } from './config';
 import { PushApiError } from './errors';
 import { readPushPayloadMetadata, withPushPayloadMetadata } from './payload';
 import {
+  canPresentDetailedReactionType,
   mergeReactionNotificationState,
   parseReactionNotificationState,
   reactionNoteLabel,
@@ -472,7 +473,8 @@ export async function enqueueAggregatedReactionPushEventInTransaction(
   const hasDetailedContext =
     input.reactionType !== undefined &&
     input.actorKey !== undefined &&
-    input.noteContent !== undefined;
+    input.noteContent !== undefined &&
+    canPresentDetailedReactionType(input.reactionType);
   if (pending && !hasDetailedContext) return;
 
   let presentation:

--- a/server/push/repository.ts
+++ b/server/push/repository.ts
@@ -4,6 +4,13 @@ import { apnsDevices, pushDeliveries, pushEvents, pushPreferences } from '../dri
 import { db, withDatabaseAdvisoryLock } from '../utils/drizzle';
 import type { ApnsEnvironment } from './config';
 import { PushApiError } from './errors';
+import { readPushPayloadMetadata, withPushPayloadMetadata } from './payload';
+import {
+  mergeReactionNotificationState,
+  parseReactionNotificationState,
+  reactionNoteLabel,
+  reactionNotificationPresentation,
+} from './reactionPresentation';
 
 export type PushPreferencePatch = Partial<{
   reactionsEnabled: boolean;
@@ -437,6 +444,11 @@ export async function enqueueAggregatedReactionPushEventInTransaction(
   input: {
     userid: string;
     roteId: string;
+    reactionType?: string;
+    actorKey?: string;
+    actorName?: string;
+    noteTitle?: string | null;
+    noteContent?: string;
   }
 ): Promise<void> {
   const now = new Date();
@@ -444,7 +456,7 @@ export async function enqueueAggregatedReactionPushEventInTransaction(
     sql`SELECT pg_advisory_xact_lock(hashtext(${`push-reaction:${input.userid}:${input.roteId}`}))`
   );
   const [pending] = await transaction
-    .select({ id: pushEvents.id })
+    .select({ id: pushEvents.id, payload: pushEvents.payload })
     .from(pushEvents)
     .where(
       and(
@@ -456,17 +468,78 @@ export async function enqueueAggregatedReactionPushEventInTransaction(
       )
     )
     .limit(1);
-  if (pending) return;
+
+  const hasDetailedContext =
+    input.reactionType !== undefined &&
+    input.actorKey !== undefined &&
+    input.noteContent !== undefined;
+  if (pending && !hasDetailedContext) return;
+
+  let presentation:
+    | {
+        titleLocKey: string;
+        bodyLocKey: string;
+        titleLocArgs: string[];
+        bodyLocArgs: string[];
+        state: ReturnType<typeof mergeReactionNotificationState>;
+      }
+    | undefined;
+  if (hasDetailedContext) {
+    const currentMetadata = readPushPayloadMetadata(pending?.payload);
+    const state = mergeReactionNotificationState(
+      parseReactionNotificationState(currentMetadata.reaction),
+      {
+        actorKey: input.actorKey!,
+        actorName: input.actorName,
+        reactionType: input.reactionType!,
+        noteLabel: reactionNoteLabel(input.noteTitle, input.noteContent!),
+      }
+    );
+    presentation = { ...reactionNotificationPresentation(state), state };
+  }
+
+  if (pending && presentation) {
+    const currentMetadata = readPushPayloadMetadata(pending.payload);
+    await transaction
+      .update(pushEvents)
+      .set({
+        titleLocKey: presentation.titleLocKey,
+        bodyLocKey: presentation.bodyLocKey,
+        payload: withPushPayloadMetadata(
+          { ...pending.payload, roteId: input.roteId },
+          {
+            ...currentMetadata,
+            titleLocArgs: presentation.titleLocArgs,
+            bodyLocArgs: presentation.bodyLocArgs,
+            reaction: presentation.state,
+          }
+        ),
+        updatedAt: new Date(),
+      })
+      .where(eq(pushEvents.id, pending.id));
+    return;
+  }
+
+  const payload = presentation
+    ? withPushPayloadMetadata(
+        { roteId: input.roteId },
+        {
+          titleLocArgs: presentation.titleLocArgs,
+          bodyLocArgs: presentation.bodyLocArgs,
+          reaction: presentation.state,
+        }
+      )
+    : { roteId: input.roteId };
 
   await transaction.insert(pushEvents).values({
     userid: input.userid,
     type: 'reaction.received',
     category: 'reactions',
     dedupeKey: `reaction:${input.roteId}:${randomUUID()}`,
-    titleLocKey: 'push.reaction.title',
-    bodyLocKey: 'push.reaction.body',
+    titleLocKey: presentation?.titleLocKey ?? 'push.reaction.title',
+    bodyLocKey: presentation?.bodyLocKey ?? 'push.reaction.body',
     route: `rote://detail?id=${input.roteId}`,
-    payload: { roteId: input.roteId },
+    payload,
     availableAt: new Date(now.getTime() + 30_000),
     expiresAt: new Date(now.getTime() + 24 * 60 * 60 * 1000),
   });
@@ -475,6 +548,11 @@ export async function enqueueAggregatedReactionPushEventInTransaction(
 export async function enqueueAggregatedReactionPushEvent(input: {
   userid: string;
   roteId: string;
+  reactionType?: string;
+  actorKey?: string;
+  actorName?: string;
+  noteTitle?: string | null;
+  noteContent?: string;
 }): Promise<void> {
   await db.transaction(async (transaction) => {
     await enqueueAggregatedReactionPushEventInTransaction(transaction, input);

--- a/server/push/worker.ts
+++ b/server/push/worker.ts
@@ -2,6 +2,7 @@ import { and, eq, inArray, lte, or, sql } from 'drizzle-orm';
 import { apnsDevices, pushDeliveries, pushEvents, pushPreferences } from '../drizzle/schema';
 import { db, withDatabaseAdvisoryLock } from '../utils/drizzle';
 import { sendApns } from './apns';
+import { prepareApnsPayload } from './payload';
 import {
   DELIVERY_BATCH_SIZE,
   DELIVERY_CLAIM_LEASE_MS,
@@ -153,6 +154,7 @@ async function deliverClaimedItem(item: ClaimedDelivery): Promise<void> {
     return;
   }
   try {
+    const preparedPayload = prepareApnsPayload(item.event.payload);
     const response = await sendApns({
       token: item.device.token,
       environment: item.device.environment as 'sandbox' | 'production',
@@ -160,8 +162,10 @@ async function deliverClaimedItem(item: ClaimedDelivery): Promise<void> {
       body: item.event.body,
       titleLocKey: item.event.titleLocKey,
       bodyLocKey: item.event.bodyLocKey,
+      titleLocArgs: preparedPayload.titleLocArgs,
+      bodyLocArgs: preparedPayload.bodyLocArgs,
       route: item.event.route,
-      payload: item.event.payload,
+      payload: preparedPayload.payload,
       expiration: item.event.expiresAt,
       collapseId: item.event.dedupeKey.slice(0, 64),
     });

--- a/server/route/v2/reaction.ts
+++ b/server/route/v2/reaction.ts
@@ -56,6 +56,7 @@ reactionsRouter.post('/', async (c: HonoContext) => {
   if (user) {
     // 已登录用户
     reactionData.userid = user.id;
+    reactionData.actorName = user.nickname || user.username;
   } else {
     // 访客用户（visitorId 已在前面验证）
     reactionData.visitorId = visitorId;

--- a/server/route/v2/reaction.ts
+++ b/server/route/v2/reaction.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import type { User } from '../../drizzle/schema';
 import { optionalJWT } from '../../middleware/jwtAuth';
 import { mayAddReaction } from '../../reactions/policy';
+import { reactionActorName } from '../../push/reactionPresentation';
 import type { HonoContext, HonoVariables } from '../../types/hono';
 import { assertUsersMayInteract } from '../../userBlocks/service';
 import { addReaction, findRoteById, removeReaction } from '../../utils/dbMethods';
@@ -56,7 +57,7 @@ reactionsRouter.post('/', async (c: HonoContext) => {
   if (user) {
     // 已登录用户
     reactionData.userid = user.id;
-    reactionData.actorName = user.nickname || user.username;
+    reactionData.actorName = reactionActorName(user.nickname, user.username);
   } else {
     // 访客用户（visitorId 已在前面验证）
     reactionData.visitorId = visitorId;

--- a/server/utils/dbMethods/reaction.ts
+++ b/server/utils/dbMethods/reaction.ts
@@ -1,6 +1,7 @@
 import { and, eq, isNull, sql } from 'drizzle-orm';
-import { reactions, rotes } from '../../drizzle/schema';
+import { reactions, rotes, users } from '../../drizzle/schema';
 import { isPushNotificationsEnabled } from '../../push/config';
+import { reactionActorName } from '../../push/reactionPresentation';
 import { enqueueAggregatedReactionPushEventInTransaction } from '../../push/repository';
 import db from '../drizzle';
 import { createRoteChange } from './change';
@@ -35,6 +36,7 @@ export async function addReaction(data: {
   visitorId?: string;
   visitorInfo?: any;
   metadata?: any;
+  actorName?: string;
 }): Promise<any> {
   try {
     const insertedReaction = await db.transaction(async (transaction) => {
@@ -71,14 +73,33 @@ export async function addReaction(data: {
         : await transaction.insert(reactions).values(reactionValues).returning();
       if (!existing && isPushNotificationsEnabled()) {
         const [rote] = await transaction
-          .select({ id: rotes.id, authorid: rotes.authorid })
+          .select({
+            id: rotes.id,
+            authorid: rotes.authorid,
+            title: rotes.title,
+            content: rotes.content,
+          })
           .from(rotes)
           .where(eq(rotes.id, data.roteid))
           .limit(1);
         if (rote && rote.authorid !== data.userid) {
+          let actorName = data.actorName;
+          if (!actorName && data.userid) {
+            const [actor] = await transaction
+              .select({ nickname: users.nickname, username: users.username })
+              .from(users)
+              .where(eq(users.id, data.userid))
+              .limit(1);
+            if (actor) actorName = reactionActorName(actor.nickname, actor.username);
+          }
           await enqueueAggregatedReactionPushEventInTransaction(transaction, {
             userid: rote.authorid,
             roteId: rote.id,
+            reactionType: data.type,
+            actorKey: data.userid ? `user:${data.userid}` : `visitor:${data.visitorId}`,
+            actorName,
+            noteTitle: rote.title,
+            noteContent: rote.content,
           });
         }
       }


### PR DESCRIPTION
## Summary

- add detailed reaction notifications with localized actor, reaction-type, exact overflow-count, saturation, and note previews
- keep queue-only aggregation metadata out of the device payload and downgrade mixed-context windows to the generic presentation
- bound aggregate state, grapheme work, and UTF-8 argument sizes; normalize Unicode canonically, preserve valid emoji sequences, and strip unsafe controls
- reuse the existing transaction and first-event aggregation window; the authenticated reaction path adds no extra database query

Follow-up to merged PR #327.

## Validation

- `bun run lint`
- `bun run build`
- `bun test push billing` — 86 passed, 25 database-gated tests skipped
- PostgreSQL 17 migration plus `push/repository.integration.test.ts` — 16 passed
- isolated PostgreSQL 17 `billing/grantRepository.integration.test.ts` — 5 passed
- pathological Unicode payload remains within the APNs 4 KB limit
- targeted sandbox notifications delivered to Huawei Air and accepted for copy, routing, and stability

## Delivery

No production deployment or environment change is included in this PR.