### PR TITLE
Add unlimited storage capability

### DIFF
--- a/server/authz/capabilities.ts
+++ b/server/authz/capabilities.ts
@@ -1,6 +1,11 @@
 import { UserRole } from '../types/main';
 
-export const CAPABILITY_KEYS = ['attachment.upload', 'attachment.video.upload', 'ai.chat'] as const;
+export const CAPABILITY_KEYS = [
+  'attachment.upload',
+  'attachment.video.upload',
+  'ai.chat',
+  'resource.storage.unlimited',
+] as const;
 
 export type CapabilityKey = (typeof CAPABILITY_KEYS)[number];
 export type CapabilityEffect = 'allow' | 'deny';
@@ -25,12 +30,14 @@ const USER_DEFAULTS: Record<CapabilityKey, boolean> = {
   'attachment.upload': true,
   'attachment.video.upload': false,
   'ai.chat': false,
+  'resource.storage.unlimited': false,
 };
 
 const ADMIN_DEFAULTS: Record<CapabilityKey, boolean> = {
   'attachment.upload': true,
   'attachment.video.upload': true,
   'ai.chat': true,
+  'resource.storage.unlimited': true,
 };
 
 export const ROLE_DEFAULT_CAPABILITIES: Record<string, Record<CapabilityKey, boolean>> = {

--- a/server/authz/capabilities.ts
+++ b/server/authz/capabilities.ts
@@ -26,6 +26,12 @@ export type EffectiveCapability = {
 
 export type EffectiveCapabilities = Record<CapabilityKey, EffectiveCapability>;
 
+export type RoleCapabilitySettings = {
+  role: string;
+  capabilities: Record<CapabilityKey, CapabilityOverride>;
+  effective: EffectiveCapabilities;
+};
+
 const USER_DEFAULTS: Record<CapabilityKey, boolean> = {
   'attachment.upload': true,
   'attachment.video.upload': false,
@@ -139,6 +145,36 @@ export function resolveEffectiveCapabilities(params: {
   }
 
   return capabilities;
+}
+
+export function buildRoleCapabilitySettings(
+  policies: readonly { role: string; permission: string; effect: string }[]
+): RoleCapabilitySettings[] {
+  const explicit = new Map(
+    policies
+      .filter(
+        (policy): policy is { role: string; permission: CapabilityKey; effect: CapabilityEffect } =>
+          isCapabilityKey(policy.permission) && isCapabilityEffect(policy.effect)
+      )
+      .map((policy) => [`${policy.role}:${policy.permission}`, policy.effect])
+  );
+
+  return Object.values(UserRole).map((role) => {
+    const rolePolicies = Object.fromEntries(
+      CAPABILITY_KEYS.flatMap((capability) => {
+        const effect = explicit.get(`${role}:${capability}`);
+        return effect ? [[capability, effect]] : [];
+      })
+    ) as Partial<Record<CapabilityKey, CapabilityEffect>>;
+
+    return {
+      role,
+      capabilities: Object.fromEntries(
+        CAPABILITY_KEYS.map((capability) => [capability, rolePolicies[capability] ?? 'inherit'])
+      ) as Record<CapabilityKey, CapabilityOverride>,
+      effective: resolveEffectiveCapabilities({ role, rolePolicies }),
+    };
+  });
 }
 
 function getSubscriptionValidUntil(

--- a/server/authz/capabilityService.ts
+++ b/server/authz/capabilityService.ts
@@ -6,7 +6,7 @@ import { UserRole } from '../types/main';
 import db from '../utils/drizzle';
 import {
   CAPABILITY_KEYS,
-  getRoleDefaultCapability,
+  buildRoleCapabilitySettings,
   isCapabilityEffect,
   isCapabilityKey,
   resolveEffectiveCapabilities,
@@ -127,30 +127,27 @@ export async function getRoleCapabilityPolicies() {
       effect: rolePermissionPolicies.effect,
     })
     .from(rolePermissionPolicies);
-  const explicit = new Map(
-    policies.map((policy) => [`${policy.role}:${policy.permission}`, policy.effect])
-  );
-
-  return Object.values(UserRole).map((role) => ({
-    role,
-    capabilities: Object.fromEntries(
-      CAPABILITY_KEYS.map((capability) => {
-        const effect = explicit.get(`${role}:${capability}`) as CapabilityEffect | undefined;
-        return [
-          capability,
-          effect || (getRoleDefaultCapability(role, capability) ? 'allow' : 'deny'),
-        ];
-      })
-    ) as Record<CapabilityKey, CapabilityEffect>,
-  }));
+  return buildRoleCapabilitySettings(policies);
 }
 
 export async function setRoleCapabilityPolicies(
   role: UserRole,
-  capabilities: Partial<Record<CapabilityKey, CapabilityEffect>>
+  capabilities: Partial<Record<CapabilityKey, CapabilityOverride>>
 ) {
   await db.transaction(async (tx) => {
     for (const [permission, effect] of Object.entries(capabilities)) {
+      if (effect === 'inherit') {
+        await tx
+          .delete(rolePermissionPolicies)
+          .where(
+            and(
+              eq(rolePermissionPolicies.role, role),
+              eq(rolePermissionPolicies.permission, permission)
+            )
+          );
+        continue;
+      }
+
       await tx
         .insert(rolePermissionPolicies)
         .values({ role, permission, effect })

--- a/server/authz/capabilityService.ts
+++ b/server/authz/capabilityService.ts
@@ -7,6 +7,8 @@ import db from '../utils/drizzle';
 import {
   CAPABILITY_KEYS,
   getRoleDefaultCapability,
+  isCapabilityEffect,
+  isCapabilityKey,
   resolveEffectiveCapabilities,
   type CapabilityEffect,
   type CapabilityKey,
@@ -14,8 +16,62 @@ import {
   type EffectiveCapabilities,
 } from './capabilities';
 
-function isActiveOverride(expiresAt: Date | null): boolean {
-  return !expiresAt || expiresAt.getTime() > Date.now();
+function isActiveOverride(expiresAt: Date | null, now = new Date()): boolean {
+  return !expiresAt || expiresAt.getTime() > now.getTime();
+}
+
+export function resolveCapabilitiesFromRecords(params: {
+  role: string;
+  rolePolicies: readonly { permission: string; effect: string }[];
+  userOverrides: readonly { permission: string; effect: string; expiresAt: Date | null }[];
+  billingGrant?: {
+    status: unknown;
+    capabilities: unknown;
+    leaseExpiresAt: Date | null;
+  } | null;
+  now?: Date;
+}): EffectiveCapabilities {
+  const now = params.now ?? new Date();
+  const rolePolicies = Object.fromEntries(
+    params.rolePolicies
+      .filter(
+        (policy): policy is { permission: CapabilityKey; effect: CapabilityEffect } =>
+          isCapabilityKey(policy.permission) && isCapabilityEffect(policy.effect)
+      )
+      .map((policy) => [policy.permission, policy.effect])
+  ) as Partial<Record<CapabilityKey, CapabilityEffect>>;
+  const userOverrides = Object.fromEntries(
+    params.userOverrides
+      .filter(
+        (
+          override
+        ): override is {
+          permission: CapabilityKey;
+          effect: CapabilityEffect;
+          expiresAt: Date | null;
+        } =>
+          isCapabilityKey(override.permission) &&
+          isCapabilityEffect(override.effect) &&
+          isActiveOverride(override.expiresAt, now)
+      )
+      .map((override) => [override.permission, override.effect])
+  ) as Partial<Record<CapabilityKey, CapabilityEffect>>;
+
+  return resolveEffectiveCapabilities({
+    role: params.role,
+    rolePolicies,
+    userOverrides,
+    ...(params.billingGrant
+      ? {
+          subscription: {
+            status: params.billingGrant.status,
+            capabilities: params.billingGrant.capabilities,
+            validUntil: params.billingGrant.leaseExpiresAt?.toISOString(),
+          },
+        }
+      : {}),
+    now,
+  });
 }
 
 export async function getEffectiveCapabilitiesForUser(userId: string): Promise<{
@@ -48,30 +104,11 @@ export async function getEffectiveCapabilitiesForUser(userId: string): Promise<{
     billingConfig.enabled ? billingGrantRepository.findGrantForUser(userId) : Promise.resolve(null),
   ]);
 
-  const rolePolicyMap = new Map(rolePolicies.map((policy) => [policy.permission, policy.effect]));
-  const userOverrideMap = new Map(
-    userOverrides
-      .filter((override) => isActiveOverride(override.expiresAt))
-      .map((override) => [override.permission, override.effect])
-  );
-
-  const capabilities = resolveEffectiveCapabilities({
+  const capabilities = resolveCapabilitiesFromRecords({
     role: user.role,
-    rolePolicies: Object.fromEntries(rolePolicyMap) as Partial<
-      Record<CapabilityKey, CapabilityEffect>
-    >,
-    userOverrides: Object.fromEntries(userOverrideMap) as Partial<
-      Record<CapabilityKey, CapabilityEffect>
-    >,
-    ...(billingGrant
-      ? {
-          subscription: {
-            status: billingGrant.status,
-            capabilities: billingGrant.capabilities,
-            validUntil: billingGrant.leaseExpiresAt?.toISOString(),
-          },
-        }
-      : {}),
+    rolePolicies,
+    userOverrides,
+    billingGrant,
   });
 
   return { role: user.role, capabilities };

--- a/server/resources/service.test.ts
+++ b/server/resources/service.test.ts
@@ -6,6 +6,7 @@ import {
   reportedOfficialUsedBytes,
   reservationCleanupKeys,
   resolveOfficialStorageState,
+  storageReservationDependsOnPro,
   type UploadReservationManifestItem,
 } from './service';
 
@@ -155,5 +156,32 @@ describe('official storage limits', () => {
       overLimit: false,
       canUpload: true,
     });
+  });
+
+  it('only binds a reservation to Pro when its storage quota depends on Pro', () => {
+    const unlimited = resolveOfficialStorageState({
+      enforcement: 'enforce',
+      reportedUsedBytes: '12000000000',
+      usedBytes: 12_000_000_000n,
+      reservedBytes: 0n,
+      limitBytes: 10_000_000_000n,
+      unlimited: true,
+    });
+    const bounded = resolveOfficialStorageState({
+      enforcement: 'enforce',
+      reportedUsedBytes: '500000000',
+      usedBytes: 500_000_000n,
+      reservedBytes: 0n,
+      limitBytes: 10_000_000_000n,
+      unlimited: false,
+    });
+
+    expect(storageReservationDependsOnPro({ source: 'official_pro', storage: unlimited })).toBe(
+      false
+    );
+    expect(storageReservationDependsOnPro({ source: 'official_pro', storage: bounded })).toBe(true);
+    expect(storageReservationDependsOnPro({ source: 'official_free', storage: bounded })).toBe(
+      false
+    );
   });
 });

--- a/server/resources/service.test.ts
+++ b/server/resources/service.test.ts
@@ -5,6 +5,7 @@ import {
   effectiveOfficialStorageEnforcement,
   reportedOfficialUsedBytes,
   reservationCleanupKeys,
+  resolveOfficialStorageState,
   type UploadReservationManifestItem,
 } from './service';
 
@@ -100,5 +101,59 @@ describe('resource cleanup helpers', () => {
     expect(countObjectKeyReferences([...first, ...second])).toEqual(
       new Map([['users/user/uploads/shared.jpg', 2]])
     );
+  });
+});
+
+describe('official storage limits', () => {
+  it('keeps unlimited users uploadable after they exceed either free or Pro quotas', () => {
+    for (const limitBytes of [500_000_000n, 10_000_000_000n]) {
+      expect(
+        resolveOfficialStorageState({
+          enforcement: 'enforce',
+          reportedUsedBytes: '12000000000',
+          usedBytes: 12_000_000_000n,
+          reservedBytes: 1_000n,
+          limitBytes,
+          unlimited: true,
+        })
+      ).toEqual({
+        enforcement: 'enforce',
+        usedBytes: '12000000000',
+        reservedBytes: '1000',
+        limitBytes: null,
+        overLimit: false,
+        canUpload: true,
+      });
+    }
+  });
+
+  it('restores enforcement against the supplied free or Pro quota after unlimited is revoked', () => {
+    const free = resolveOfficialStorageState({
+      enforcement: 'enforce',
+      reportedUsedBytes: '500000000',
+      usedBytes: 500_000_000n,
+      reservedBytes: 0n,
+      limitBytes: 500_000_000n,
+      unlimited: false,
+    });
+    const pro = resolveOfficialStorageState({
+      enforcement: 'enforce',
+      reportedUsedBytes: '500000000',
+      usedBytes: 500_000_000n,
+      reservedBytes: 0n,
+      limitBytes: 10_000_000_000n,
+      unlimited: false,
+    });
+
+    expect(free).toMatchObject({
+      limitBytes: '500000000',
+      overLimit: true,
+      canUpload: false,
+    });
+    expect(pro).toMatchObject({
+      limitBytes: '10000000000',
+      overLimit: false,
+      canUpload: true,
+    });
   });
 });

--- a/server/resources/service.ts
+++ b/server/resources/service.ts
@@ -212,6 +212,12 @@ export function resolveOfficialStorageState(params: {
   };
 }
 
+export function storageReservationDependsOnPro(
+  state: Pick<ResourceState, 'source' | 'storage'>
+): boolean {
+  return state.source === 'official_pro' && state.storage.limitBytes !== null;
+}
+
 function grantIsUsable(grant: typeof billingGrants.$inferSelect | null, now: Date): boolean {
   return Boolean(
     grant &&
@@ -459,7 +465,7 @@ export async function createUploadReservation(params: {
       id: params.id,
       userId: params.userId,
       grantRevision: grant?.revision ?? null,
-      grantProDerived: state.source === 'official_pro',
+      grantProDerived: storageReservationDependsOnPro(state),
       grantEntitlementExpiresAt: grant?.entitlementExpiresAt ?? null,
       manifest: params.manifest,
       reservedBytes,
@@ -601,7 +607,7 @@ export async function appendUploadReservation(params: {
         reservedBytes: params.reserveBytes,
         expiresAt: params.expiresAt,
         grantRevision: grant?.revision ?? null,
-        grantProDerived: state.source === 'official_pro',
+        grantProDerived: storageReservationDependsOnPro(state),
         grantEntitlementExpiresAt: grant?.entitlementExpiresAt ?? null,
       });
     }

--- a/server/resources/service.ts
+++ b/server/resources/service.ts
@@ -8,11 +8,14 @@ import {
   resourceStorageObjects,
   resourceCleanupOutbox,
   resourceUploadReservations,
+  rolePermissionPolicies,
+  userPermissionOverrides,
   userOpenKeys,
   users,
 } from '../drizzle/schema';
 import db from '../utils/drizzle';
 import { billingConfig } from '../billing/runtimeConfig';
+import { resolveCapabilitiesFromRecords } from '../authz/capabilityService';
 import { RESOURCE_ERROR_CODES, ResourcePolicyError } from './errors';
 
 export const OFFICIAL_FREE_STORAGE_BYTES = BigInt(500_000_000);
@@ -179,6 +182,36 @@ export function reportedOfficialUsedBytes(
   return null;
 }
 
+export function resolveOfficialStorageState(params: {
+  enforcement: 'observe' | 'enforce';
+  reportedUsedBytes: string | null;
+  usedBytes: bigint;
+  reservedBytes: bigint;
+  limitBytes: bigint;
+  unlimited: boolean;
+}): ResourceState['storage'] {
+  if (params.unlimited) {
+    return {
+      enforcement: params.enforcement,
+      usedBytes: params.reportedUsedBytes,
+      reservedBytes: params.reservedBytes.toString(),
+      limitBytes: null,
+      overLimit: false,
+      canUpload: true,
+    };
+  }
+
+  const overLimit = params.usedBytes + params.reservedBytes >= params.limitBytes;
+  return {
+    enforcement: params.enforcement,
+    usedBytes: params.reportedUsedBytes,
+    reservedBytes: params.reservedBytes.toString(),
+    limitBytes: params.limitBytes.toString(),
+    overLimit,
+    canUpload: params.enforcement !== 'enforce' || !overLimit,
+  };
+}
+
 function grantIsUsable(grant: typeof billingGrants.$inferSelect | null, now: Date): boolean {
   return Boolean(
     grant &&
@@ -195,23 +228,39 @@ async function resolveStateWithExecutor(
   now: Date
 ): Promise<ResourceState> {
   if (billingConfig.enabled) {
-    const [[grant], [account], [keyCount], [managementState]] = await Promise.all([
-      executor.select().from(billingGrants).where(eq(billingGrants.userId, user.id)).limit(1),
-      executor
-        .select()
-        .from(resourceStorageAccounts)
-        .where(eq(resourceStorageAccounts.userId, user.id))
-        .limit(1),
-      executor
-        .select({ value: count() })
-        .from(userOpenKeys)
-        .where(eq(userOpenKeys.userid, user.id)),
-      executor
-        .select({ reconciliationStatus: resourceManagementState.reconciliationStatus })
-        .from(resourceManagementState)
-        .where(eq(resourceManagementState.id, 'official'))
-        .limit(1),
-    ]);
+    const [[grant], [account], [keyCount], [managementState], rolePolicies, userOverrides] =
+      await Promise.all([
+        executor.select().from(billingGrants).where(eq(billingGrants.userId, user.id)).limit(1),
+        executor
+          .select()
+          .from(resourceStorageAccounts)
+          .where(eq(resourceStorageAccounts.userId, user.id))
+          .limit(1),
+        executor
+          .select({ value: count() })
+          .from(userOpenKeys)
+          .where(eq(userOpenKeys.userid, user.id)),
+        executor
+          .select({ reconciliationStatus: resourceManagementState.reconciliationStatus })
+          .from(resourceManagementState)
+          .where(eq(resourceManagementState.id, 'official'))
+          .limit(1),
+        executor
+          .select({
+            permission: rolePermissionPolicies.permission,
+            effect: rolePermissionPolicies.effect,
+          })
+          .from(rolePermissionPolicies)
+          .where(eq(rolePermissionPolicies.role, user.role)),
+        executor
+          .select({
+            permission: userPermissionOverrides.permission,
+            effect: userPermissionOverrides.effect,
+            expiresAt: userPermissionOverrides.expiresAt,
+          })
+          .from(userPermissionOverrides)
+          .where(eq(userPermissionOverrides.userid, user.id)),
+      ]);
     const existingCount = Number(keyCount?.value ?? 0);
     const enforcement = effectiveOfficialStorageEnforcement(
       requestedOfficialStorageEnforcement(),
@@ -221,45 +270,40 @@ async function resolveStateWithExecutor(
       account ?? null,
       managementState?.reconciliationStatus
     );
-    if (isRoleExempt(user.role)) {
-      return {
-        management: 'official',
-        source: 'role_exempt',
-        storage: {
-          enforcement,
-          usedBytes: reportedUsed,
-          reservedBytes: (account?.reservedBytes ?? BigInt(0)).toString(),
-          limitBytes: null,
-          overLimit: false,
-          canUpload: true,
-        },
-        openKey: { policy: 'unlimited', creationThreshold: null, existingCount, canCreate: true },
-      };
-    }
     const pro = grantIsUsable(grant ?? null, now);
     const limit = pro ? BigInt(grant!.benefits!.storage.quotaBytes) : OFFICIAL_FREE_STORAGE_BYTES;
     const used = account?.usedBytes ?? BigInt(0);
     const reserved = account?.reservedBytes ?? BigInt(0);
-    const overLimit = used + reserved >= limit;
+    const capabilities = resolveCapabilitiesFromRecords({
+      role: user.role,
+      rolePolicies,
+      userOverrides,
+      billingGrant: grant ?? null,
+      now,
+    });
+    const unlimitedStorage = capabilities['resource.storage.unlimited'].allowed;
+    const roleExempt = isRoleExempt(user.role);
     return {
       management: 'official',
-      source: pro ? 'official_pro' : 'official_free',
-      storage: {
+      source:
+        roleExempt && unlimitedStorage ? 'role_exempt' : pro ? 'official_pro' : 'official_free',
+      storage: resolveOfficialStorageState({
         enforcement,
-        usedBytes: reportedUsed,
-        reservedBytes: reserved.toString(),
-        limitBytes: limit.toString(),
-        overLimit,
-        canUpload: enforcement !== 'enforce' || !overLimit,
-      },
-      openKey: pro
-        ? { policy: 'unlimited', creationThreshold: null, existingCount, canCreate: true }
-        : {
-            policy: 'threshold',
-            creationThreshold: OFFICIAL_FREE_OPENKEY_CREATION_THRESHOLD,
-            existingCount,
-            canCreate: existingCount < OFFICIAL_FREE_OPENKEY_CREATION_THRESHOLD,
-          },
+        reportedUsedBytes: reportedUsed,
+        usedBytes: used,
+        reservedBytes: reserved,
+        limitBytes: limit,
+        unlimited: unlimitedStorage,
+      }),
+      openKey:
+        roleExempt || pro
+          ? { policy: 'unlimited', creationThreshold: null, existingCount, canCreate: true }
+          : {
+              policy: 'threshold',
+              creationThreshold: OFFICIAL_FREE_OPENKEY_CREATION_THRESHOLD,
+              existingCount,
+              canCreate: existingCount < OFFICIAL_FREE_OPENKEY_CREATION_THRESHOLD,
+            },
     };
   }
 

--- a/server/route/v2/adminPermissions.ts
+++ b/server/route/v2/adminPermissions.ts
@@ -1,9 +1,7 @@
 import { Hono } from 'hono';
 import {
   CAPABILITY_KEYS,
-  isCapabilityEffect,
   isCapabilityOverride,
-  type CapabilityEffect,
   type CapabilityKey,
   type CapabilityOverride,
 } from '../../authz/capabilities';
@@ -54,9 +52,9 @@ adminPermissionsRouter.put(
       throw new Error('Invalid role');
     }
     const body = await c.req.json();
-    const capabilities = parseCapabilities<CapabilityEffect>(
+    const capabilities = parseCapabilities<CapabilityOverride>(
       body?.capabilities,
-      isCapabilityEffect
+      isCapabilityOverride
     );
     return c.json(createResponse(await setRoleCapabilityPolicies(role, capabilities)), 200);
   }

--- a/server/route/v2/permissions.test.ts
+++ b/server/route/v2/permissions.test.ts
@@ -50,6 +50,11 @@ function appWithAiCapability(aiChat: EffectiveCapability) {
             role: UserRole.USER,
           },
           'ai.chat': aiChat,
+          'resource.storage.unlimited': {
+            allowed: false,
+            source: 'role_default',
+            role: UserRole.USER,
+          },
         },
       }),
     })

--- a/server/tests/capabilities.test.ts
+++ b/server/tests/capabilities.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import { UserRole } from '../types/main';
-import { resolveEffectiveCapabilities } from '../authz/capabilities';
+import { buildRoleCapabilitySettings, resolveEffectiveCapabilities } from '../authz/capabilities';
 
 describe('capability resolution', () => {
   it('keeps AI chat denied for users and allowed for admins by default', () => {
@@ -23,6 +23,35 @@ describe('capability resolution', () => {
     expect(
       resolveEffectiveCapabilities({ role: UserRole.ADMIN })['resource.storage.unlimited']
     ).toEqual({ allowed: true, source: 'role_default', role: UserRole.ADMIN });
+  });
+
+  it('preserves inherit for missing role policies while reporting the effective default', () => {
+    const settings = buildRoleCapabilitySettings([
+      {
+        role: UserRole.USER,
+        permission: 'resource.storage.unlimited',
+        effect: 'allow',
+      },
+    ]);
+    const user = settings.find((setting) => setting.role === UserRole.USER)!;
+    const moderator = settings.find((setting) => setting.role === UserRole.MODERATOR)!;
+    const admin = settings.find((setting) => setting.role === UserRole.ADMIN)!;
+
+    expect(user.capabilities['resource.storage.unlimited']).toBe('allow');
+    expect(user.effective['resource.storage.unlimited']).toMatchObject({
+      allowed: true,
+      source: 'role_policy',
+    });
+    expect(moderator.capabilities['resource.storage.unlimited']).toBe('inherit');
+    expect(moderator.effective['resource.storage.unlimited']).toMatchObject({
+      allowed: false,
+      source: 'role_default',
+    });
+    expect(admin.capabilities['resource.storage.unlimited']).toBe('inherit');
+    expect(admin.effective['resource.storage.unlimited']).toMatchObject({
+      allowed: true,
+      source: 'role_default',
+    });
   });
 
   it('applies unlimited storage role policies and user overrides in priority order', () => {

--- a/server/tests/capabilities.test.ts
+++ b/server/tests/capabilities.test.ts
@@ -13,6 +13,75 @@ describe('capability resolution', () => {
     expect(adminCapabilities['ai.chat'].allowed).toBe(true);
   });
 
+  it('denies unlimited storage for users and moderators but allows it for admins by default', () => {
+    expect(
+      resolveEffectiveCapabilities({ role: UserRole.USER })['resource.storage.unlimited']
+    ).toEqual({ allowed: false, source: 'role_default', role: UserRole.USER });
+    expect(
+      resolveEffectiveCapabilities({ role: UserRole.MODERATOR })['resource.storage.unlimited']
+    ).toEqual({ allowed: false, source: 'role_default', role: UserRole.MODERATOR });
+    expect(
+      resolveEffectiveCapabilities({ role: UserRole.ADMIN })['resource.storage.unlimited']
+    ).toEqual({ allowed: true, source: 'role_default', role: UserRole.ADMIN });
+  });
+
+  it('applies unlimited storage role policies and user overrides in priority order', () => {
+    const roleAllowed = resolveEffectiveCapabilities({
+      role: UserRole.USER,
+      rolePolicies: { 'resource.storage.unlimited': 'allow' },
+    });
+    const userDenied = resolveEffectiveCapabilities({
+      role: UserRole.USER,
+      rolePolicies: { 'resource.storage.unlimited': 'allow' },
+      userOverrides: { 'resource.storage.unlimited': 'deny' },
+    });
+    const userAllowed = resolveEffectiveCapabilities({
+      role: UserRole.USER,
+      rolePolicies: { 'resource.storage.unlimited': 'deny' },
+      userOverrides: { 'resource.storage.unlimited': 'allow' },
+    });
+
+    expect(roleAllowed['resource.storage.unlimited'].source).toBe('role_policy');
+    expect(roleAllowed['resource.storage.unlimited'].allowed).toBe(true);
+    expect(userDenied['resource.storage.unlimited'].source).toBe('user_override');
+    expect(userDenied['resource.storage.unlimited'].allowed).toBe(false);
+    expect(userAllowed['resource.storage.unlimited'].source).toBe('user_override');
+    expect(userAllowed['resource.storage.unlimited'].allowed).toBe(true);
+  });
+
+  it('does not include unlimited storage in an ordinary Pro capability grant', () => {
+    const capabilities = resolveEffectiveCapabilities({
+      role: UserRole.USER,
+      subscription: {
+        status: 'active',
+        capabilities: ['attachment.video.upload', 'ai.chat'],
+        validUntil: '2026-08-08T00:00:00.000Z',
+      },
+      now: new Date('2026-08-07T00:00:00.000Z'),
+    });
+
+    expect(capabilities['resource.storage.unlimited']).toEqual({
+      allowed: false,
+      source: 'role_default',
+      role: UserRole.USER,
+    });
+  });
+
+  it('does not grant unrelated capabilities with unlimited storage', () => {
+    const capabilities = resolveEffectiveCapabilities({
+      role: UserRole.USER,
+      rolePolicies: {
+        'attachment.upload': 'deny',
+        'resource.storage.unlimited': 'allow',
+      },
+    });
+
+    expect(capabilities['resource.storage.unlimited'].allowed).toBe(true);
+    expect(capabilities['attachment.upload'].allowed).toBe(false);
+    expect(capabilities['attachment.video.upload'].allowed).toBe(false);
+    expect(capabilities['ai.chat'].allowed).toBe(false);
+  });
+
   it('uses user overrides before role policies', () => {
     const capabilities = resolveEffectiveCapabilities({
       role: UserRole.USER,
@@ -46,8 +115,11 @@ describe('capability resolution', () => {
   it('does not allow policies or overrides to reduce super admin permissions', () => {
     const capabilities = resolveEffectiveCapabilities({
       role: UserRole.SUPER_ADMIN,
-      rolePolicies: { 'ai.chat': 'deny' },
-      userOverrides: { 'attachment.upload': 'deny' },
+      rolePolicies: { 'ai.chat': 'deny', 'resource.storage.unlimited': 'deny' },
+      userOverrides: {
+        'attachment.upload': 'deny',
+        'resource.storage.unlimited': 'deny',
+      },
     });
 
     expect(Object.values(capabilities).every((capability) => capability.allowed)).toBe(true);

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1778,6 +1778,10 @@
           "ai.chat": {
             "label": "AI Chat",
             "description": "Allow AI chat and memory tools when the system memory runtime is ready."
+          },
+          "resource.storage.unlimited": {
+            "label": "Unlimited Storage",
+            "description": "Remove the user's total storage quota without changing upload permissions or per-file size limits."
           }
         },
         "userDialog": {

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -1782,6 +1782,10 @@
           "ai.chat": {
             "label": "AI チャット",
             "description": "AI チャットを許可し、システムのメモリー実行環境が準備できていればメモリーツールも利用できます。"
+          },
+          "resource.storage.unlimited": {
+            "label": "ストレージ無制限",
+            "description": "アップロード権限やファイル単位のサイズ上限を変更せず、ユーザーのストレージ総容量制限を解除します。"
           }
         },
         "userDialog": {

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1764,6 +1764,10 @@
           "ai.chat": {
             "label": "AI 对话",
             "description": "允许使用 AI 对话；系统记忆运行环境就绪时也可使用记忆工具。"
+          },
+          "resource.storage.unlimited": {
+            "label": "无限存储空间",
+            "description": "取消用户的存储总额度限制，不改变上传权限和单文件大小限制。"
           }
         },
         "userDialog": {

--- a/web/src/pages/admin/components/PermissionsTab.test.tsx
+++ b/web/src/pages/admin/components/PermissionsTab.test.tsx
@@ -1,0 +1,83 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import PermissionsTab from './PermissionsTab';
+
+const { mutate, put, useSWR } = vi.hoisted(() => ({
+  mutate: vi.fn(),
+  put: vi.fn(),
+  useSWR: vi.fn(),
+}));
+
+vi.mock('swr', () => ({ default: useSWR }));
+vi.mock('@/utils/api', () => ({ get: vi.fn(), put }));
+vi.mock('@/state/profile', () => ({
+  useProfile: () => ({ role: 'super_admin' }),
+}));
+vi.mock('./PermissionSettingRow', () => ({
+  default: ({
+    capability,
+    value,
+    options,
+    effective,
+  }: {
+    capability: string;
+    value: string;
+    options: readonly string[];
+    effective?: { allowed: boolean };
+  }) => (
+    <div data-testid={`permission-${capability}`} data-options={options.join(',')}>
+      <span>{value}</span>
+      <span>{effective?.allowed ? 'effective.allowed' : 'effective.denied'}</span>
+    </div>
+  ),
+}));
+
+const capabilities = {
+  'attachment.upload': 'allow',
+  'attachment.video.upload': 'deny',
+  'ai.chat': 'deny',
+  'resource.storage.unlimited': 'inherit',
+} as const;
+
+const effective = {
+  'attachment.upload': { allowed: true, source: 'role_policy', role: 'user' },
+  'attachment.video.upload': { allowed: false, source: 'role_policy', role: 'user' },
+  'ai.chat': { allowed: false, source: 'role_policy', role: 'user' },
+  'resource.storage.unlimited': { allowed: false, source: 'role_default', role: 'user' },
+} as const;
+
+const policies = ['user', 'moderator', 'admin'].map((role) => ({
+  role,
+  capabilities,
+  effective: Object.fromEntries(
+    Object.entries(effective).map(([key, capability]) => [key, { ...capability, role }])
+  ),
+}));
+
+describe('PermissionsTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mutate.mockResolvedValue(undefined);
+    put.mockResolvedValue({});
+    useSWR.mockReturnValue({ data: policies, isLoading: false, mutate });
+  });
+
+  it('shows inherited unlimited storage with its effective state and preserves it on save', async () => {
+    render(<PermissionsTab />);
+
+    const userSection = screen.getByText('roles.user.label').closest('section');
+    expect(userSection).not.toBeNull();
+    const row = within(userSection as HTMLElement).getByTestId(
+      'permission-resource.storage.unlimited'
+    );
+    expect(row).toHaveAttribute('data-options', 'inherit,allow,deny');
+    expect(within(row).getByText('inherit')).toBeVisible();
+    expect(within(row).getByText('effective.denied')).toBeVisible();
+
+    fireEvent.click(within(userSection as HTMLElement).getByRole('button', { name: 'saveRole' }));
+
+    await waitFor(() =>
+      expect(put).toHaveBeenCalledWith('/admin/permissions/roles/user', { capabilities })
+    );
+  });
+});

--- a/web/src/pages/admin/components/PermissionsTab.tsx
+++ b/web/src/pages/admin/components/PermissionsTab.tsx
@@ -5,8 +5,8 @@ import { useProfile } from '@/state/profile';
 import {
   CAPABILITY_KEYS,
   MANAGEABLE_ROLES,
-  type CapabilityEffect,
   type CapabilityKey,
+  type CapabilityOverride,
   type ManageableRole,
   type RoleCapabilityPolicy,
 } from '@/types/permissions';
@@ -19,7 +19,7 @@ import { toast } from 'sonner';
 import useSWR from 'swr';
 import PermissionSettingRow from './PermissionSettingRow';
 
-type RoleDrafts = Partial<Record<ManageableRole, Record<CapabilityKey, CapabilityEffect>>>;
+type RoleDrafts = Partial<Record<ManageableRole, Record<CapabilityKey, CapabilityOverride>>>;
 
 export default function PermissionsTab() {
   const { t } = useTranslation('translation', { keyPrefix: 'pages.admin.permissions' });
@@ -49,14 +49,14 @@ export default function PermissionsTab() {
   const updateRoleCapability = (
     role: ManageableRole,
     capability: CapabilityKey,
-    effect: CapabilityEffect
+    effect: CapabilityOverride
   ) => {
     setDrafts((current) => ({
       ...current,
       [role]: {
         ...current[role],
         [capability]: effect,
-      } as Record<CapabilityKey, CapabilityEffect>,
+      } as Record<CapabilityKey, CapabilityOverride>,
     }));
   };
 
@@ -94,6 +94,7 @@ export default function PermissionsTab() {
         ) : (
           MANAGEABLE_ROLES.map((role) => {
             const capabilities = drafts[role];
+            const effective = data?.find((policy) => policy.role === role)?.effective;
             return (
               <section key={role} className="border">
                 <div className="flex flex-wrap items-center justify-between gap-3 border-b p-4">
@@ -125,10 +126,11 @@ export default function PermissionsTab() {
                         key={capability}
                         capability={capability}
                         value={capabilities[capability]}
-                        options={['allow', 'deny']}
+                        options={['inherit', 'allow', 'deny']}
                         disabled={!isSuperAdmin}
+                        effective={effective?.[capability]}
                         onChange={(effect) =>
-                          updateRoleCapability(role, capability, effect as CapabilityEffect)
+                          updateRoleCapability(role, capability, effect as CapabilityOverride)
                         }
                       />
                     ))}

--- a/web/src/pages/admin/components/UserPermissionsDialog.test.tsx
+++ b/web/src/pages/admin/components/UserPermissionsDialog.test.tsx
@@ -1,0 +1,75 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import UserPermissionsDialog from './UserPermissionsDialog';
+
+const { mutate, put, useSWR } = vi.hoisted(() => ({
+  mutate: vi.fn(),
+  put: vi.fn(),
+  useSWR: vi.fn(),
+}));
+
+vi.mock('swr', () => ({ default: useSWR }));
+vi.mock('@/utils/api', () => ({ get: vi.fn(), put }));
+
+const permissions = {
+  role: 'user',
+  capabilities: {
+    'attachment.upload': { allowed: true, source: 'role_default', role: 'user' },
+    'attachment.video.upload': { allowed: false, source: 'role_default', role: 'user' },
+    'ai.chat': { allowed: false, source: 'role_default', role: 'user' },
+    'resource.storage.unlimited': { allowed: true, source: 'user_override', role: 'user' },
+  },
+  overrides: {
+    'attachment.upload': 'inherit',
+    'attachment.video.upload': 'inherit',
+    'ai.chat': 'inherit',
+    'resource.storage.unlimited': 'allow',
+  },
+} as const;
+
+describe('UserPermissionsDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mutate.mockResolvedValue(undefined);
+    put.mockResolvedValue({});
+    useSWR.mockReturnValue({ data: permissions, isLoading: false, mutate });
+  });
+
+  it('loads the unlimited storage row and shows its effective state', () => {
+    render(
+      <UserPermissionsDialog
+        user={{ id: 'user-1', username: 'alice', role: 'user' }}
+        onClose={vi.fn()}
+        canManage
+      />
+    );
+
+    const label = screen.getByText('capabilities.resource.storage.unlimited.label');
+    const row = label.closest('[data-slot="dialog-content"]')
+      ? label.parentElement?.parentElement?.parentElement
+      : null;
+    expect(row).not.toBeNull();
+    expect(
+      within(row as HTMLElement).getByText('capabilities.resource.storage.unlimited.description')
+    ).toBeVisible();
+    expect(within(row as HTMLElement).getByText('effective.allowed')).toBeVisible();
+  });
+
+  it('saves the unlimited storage override through the existing user permissions endpoint', async () => {
+    render(
+      <UserPermissionsDialog
+        user={{ id: 'user-1', username: 'alice', role: 'user' }}
+        onClose={vi.fn()}
+        canManage
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'userDialog.save' }));
+
+    await waitFor(() =>
+      expect(put).toHaveBeenCalledWith('/admin/permissions/users/user-1', {
+        capabilities: permissions.overrides,
+      })
+    );
+  });
+});

--- a/web/src/types/permissions.ts
+++ b/web/src/types/permissions.ts
@@ -23,7 +23,8 @@ export type ManageableRole = (typeof MANAGEABLE_ROLES)[number];
 
 export type RoleCapabilityPolicy = {
   role: string;
-  capabilities: Record<CapabilityKey, CapabilityEffect>;
+  capabilities: Record<CapabilityKey, CapabilityOverride>;
+  effective: EffectiveCapabilities;
 };
 
 export type EffectivePermissionsResponse = {

--- a/web/src/types/permissions.ts
+++ b/web/src/types/permissions.ts
@@ -1,4 +1,9 @@
-export const CAPABILITY_KEYS = ['attachment.upload', 'attachment.video.upload', 'ai.chat'] as const;
+export const CAPABILITY_KEYS = [
+  'attachment.upload',
+  'attachment.video.upload',
+  'ai.chat',
+  'resource.storage.unlimited',
+] as const;
 
 export type CapabilityKey = (typeof CAPABILITY_KEYS)[number];
 export type CapabilityEffect = 'allow' | 'deny';
@@ -6,8 +11,9 @@ export type CapabilityOverride = CapabilityEffect | 'inherit';
 
 export type EffectiveCapability = {
   allowed: boolean;
-  source: 'user_override' | 'role_policy' | 'role_default' | 'dependency';
+  source: 'user_override' | 'subscription' | 'role_policy' | 'role_default' | 'dependency';
   role: string;
+  validUntil?: string;
 };
 
 export type EffectiveCapabilities = Record<CapabilityKey, EffectiveCapability>;


### PR DESCRIPTION
## What

- add `resource.storage.unlimited` to the existing role and user capability system
- resolve storage exemptions through the full effective-permission precedence chain
- keep Pro entitlements, OpenKey, media/AI permissions, attachment permissions, and per-file limits independent
- expose the capability automatically in the current Web permission editors with localized copy

## Validation

- Server capability/resource/permission tests: 21 passed
- Web tests: 163 passed
- Server and Web lint/build passed

The broad Server live API runner still requires a local PostgreSQL instance and API server; the affected Server suites pass directly.