### PR TITLE
feat: add OrcaRouter as an AI provider preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The iOS app can connect to your self-hosted backend.
 
 ### Memory
 
-Memory is optional and disabled by default. It is available in the `develop` image and will be available in stable images after the next release that includes Memory. Administrators can enable it from `Admin -> AI Settings` after configuring chat and embedding providers. Rote supports OpenAI-compatible providers, including OpenAI, OpenRouter, Ollama / LM Studio, DeepSeek, SiliconFlow, DashScope / Qwen, Zhipu GLM, Moonshot / Kimi, Volcengine Ark, Tencent Hunyuan, Baidu Qianfan, and custom OpenAI-compatible endpoints.
+Memory is optional and disabled by default. It is available in the `develop` image and will be available in stable images after the next release that includes Memory. Administrators can enable it from `Admin -> AI Settings` after configuring chat and embedding providers. Rote supports OpenAI-compatible providers, including OpenAI, OpenRouter, OrcaRouter, Ollama / LM Studio, DeepSeek, SiliconFlow, DashScope / Qwen, Zhipu GLM, Moonshot / Kimi, Volcengine Ark, Tencent Hunyuan, Baidu Qianfan, and custom OpenAI-compatible endpoints.
 
 AI access is controlled by the `ai.chat` permission, which administrators can grant by role or per user. AI conversations stay in the current browser session and are not persisted to the database. Notes and articles are indexed only for users with AI chat permission when AI vector storage and automatic indexing are enabled by an administrator.
 

--- a/doc/README.zh.md
+++ b/doc/README.zh.md
@@ -106,7 +106,7 @@ iOS App 支持连接到你自部署的后端。
 
 ### 记忆
 
-记忆是可选能力，默认关闭。它已经可以在 `develop` 镜像中使用，并会在包含记忆的下一个稳定版发布后进入稳定镜像。管理员可以在 `管理 -> AI 相关` 配置对话模型和向量模型后启用。Rote 支持 OpenAI-compatible 供应商，包括 OpenAI、OpenRouter、Ollama / LM Studio、DeepSeek、SiliconFlow、DashScope / Qwen、Zhipu GLM、Moonshot / Kimi、Volcengine Ark、Tencent Hunyuan、Baidu Qianfan，以及自定义 OpenAI-compatible 接口。
+记忆是可选能力，默认关闭。它已经可以在 `develop` 镜像中使用，并会在包含记忆的下一个稳定版发布后进入稳定镜像。管理员可以在 `管理 -> AI 相关` 配置对话模型和向量模型后启用。Rote 支持 OpenAI-compatible 供应商，包括 OpenAI、OpenRouter、OrcaRouter、Ollama / LM Studio、DeepSeek、SiliconFlow、DashScope / Qwen、Zhipu GLM、Moonshot / Kimi、Volcengine Ark、Tencent Hunyuan、Baidu Qianfan，以及自定义 OpenAI-compatible 接口。
 
 只有已登录且已认证的用户可以使用 AI 功能。AI 对话只保存在当前浏览器会话中，不会持久化写入数据库。只有在管理员开启 AI 向量存储和自动索引后，笔记与文章才会进入向量索引。
 

--- a/server/utils/ai/providers.ts
+++ b/server/utils/ai/providers.ts
@@ -37,6 +37,16 @@ export const AI_PROVIDER_PRESETS: AiProviderPreset[] = [
     requiresApiKey: true,
   },
   {
+    id: 'orcarouter',
+    name: 'OrcaRouter',
+    apiFormat: 'openai_compatible',
+    baseUrl: 'https://api.orcarouter.ai/v1',
+    capabilities: ['chat', 'embedding'],
+    chatModels: ['orcarouter/auto', 'anthropic/claude-sonnet-4.6'],
+    embeddingModels: ['openai/text-embedding-3-small', 'openai/text-embedding-3-large'],
+    requiresApiKey: true,
+  },
+  {
     id: 'ollama',
     name: 'Ollama / LM Studio',
     apiFormat: 'openai_compatible',


### PR DESCRIPTION
## Description

Adds [OrcaRouter](https://www.orcarouter.ai) as a model provider. OrcaRouter is an OpenAI-compatible model routing gateway that exposes 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax, xAI and others behind a single endpoint and API key. It also provides gateway-level security controls for AI agents.

I'm an engineer on the OrcaRouter team.

Registers OrcaRouter as a named preset in `AI_PROVIDER_PRESETS` (`server/utils/ai/providers.ts`), mirroring the existing OpenRouter entry, so it appears in `Admin -> AI Settings` alongside the other OpenAI-compatible providers. The preset ships a fixed base URL (`https://api.orcarouter.ai/v1`), chat and embedding capabilities, example models (`orcarouter/auto` as the default, plus `anthropic/claude-sonnet-4.6`), and an API key requirement. No client or schema changes are needed, since Rote's AI client already speaks generic OpenAI-compatible.

Also updated the provider list in `README.md` and `doc/README.zh.md`.

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Code passes ESLint checks (`bun run lint`)
- [x] Code builds successfully:
  - [x] Backend: `cd server && bun run build`
  - [ ] Frontend: `cd web && bun run build` (no frontend changes; the admin dropdown consumes the preset list from the server)
- [x] Functionality works correctly: loaded `AI_PROVIDER_PRESETS` and confirmed the `orcarouter` preset resolves with the correct base URL, capabilities, and model lists
- [x] No existing functionality is broken: the preset list is data-driven and the AI client is unchanged

Live verification against `https://api.orcarouter.ai/v1` with a valid key: `GET /models` returns 207 models including `orcarouter/auto`; a chat completion via `orcarouter/auto` succeeds; `POST /embeddings` with `openai/text-embedding-3-small` returns a 1536-dim vector.

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (no new logic, data only)
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (n/a for a data addition; CI lint/build pass)
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Add screenshots to help explain your changes.

## Additional Notes

The preset is a pure data addition: the admin provider dropdown and the `/ai/providers` endpoint consume `AI_PROVIDER_PRESETS` directly, so no other wiring is required.
