### PR TITLE
Clean up stale profile media

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -5,6 +5,14 @@ npm v9.5.1
 
 ## Other Operations
 
+### Unbound attachment cleanup
+
+The resource maintenance worker scans at most 100 unbound attachments per minute after a fixed
+seven-day retention period. `UNBOUND_ATTACHMENT_CLEANUP_MODE` defaults to `observe`, which only
+logs aggregate candidate counts and declared bytes. Set it to `enforce` only after reviewing those
+aggregates; deletion then updates the storage ledger transactionally and uses the cleanup Outbox for
+physical object retries.
+
 ### Steps after updating schema
 
 ```bash

--- a/server/attachments/unboundCleanup.test.ts
+++ b/server/attachments/unboundCleanup.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'bun:test';
+
+process.env.POSTGRESQL_URL ||= 'postgres://test:test@localhost:5432/rote_test';
+const {
+  attachmentDeclaredBytes,
+  resolveUnboundAttachmentCleanupMode,
+  UNBOUND_ATTACHMENT_CLEANUP_BATCH_SIZE,
+  UNBOUND_ATTACHMENT_RETENTION_MS,
+} = await import('./unboundCleanup');
+
+describe('unbound attachment cleanup policy', () => {
+  it('defaults to observe and requires an explicit enforce value', () => {
+    expect(resolveUnboundAttachmentCleanupMode(undefined)).toBe('observe');
+    expect(resolveUnboundAttachmentCleanupMode('observe')).toBe('observe');
+    expect(resolveUnboundAttachmentCleanupMode('ENFORCE')).toBe('enforce');
+    expect(resolveUnboundAttachmentCleanupMode('unexpected')).toBe('observe');
+  });
+
+  it('uses the agreed seven-day retention and bounded batch size', () => {
+    expect(UNBOUND_ATTACHMENT_RETENTION_MS).toBe(7 * 24 * 60 * 60 * 1000);
+    expect(UNBOUND_ATTACHMENT_CLEANUP_BATCH_SIZE).toBe(100);
+  });
+
+  it('reports only safe declared byte counts', () => {
+    expect(attachmentDeclaredBytes({ size: 123 })).toBe(123n);
+    expect(attachmentDeclaredBytes({ size: -1 })).toBe(0n);
+    expect(attachmentDeclaredBytes({ size: Number.MAX_SAFE_INTEGER + 1 })).toBe(0n);
+    expect(attachmentDeclaredBytes(null)).toBe(0n);
+  });
+});

--- a/server/attachments/unboundCleanup.ts
+++ b/server/attachments/unboundCleanup.ts
@@ -1,0 +1,141 @@
+import { and, eq, isNotNull, isNull, lte, sql } from 'drizzle-orm';
+import { attachments, users } from '../drizzle/schema';
+import {
+  collectOwnedAttachmentObjectKeys,
+  enqueueStorageObjectCleanup,
+  releaseStorageObjectReferences,
+} from '../resources/service';
+import db from '../utils/drizzle';
+
+export const UNBOUND_ATTACHMENT_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+export const UNBOUND_ATTACHMENT_CLEANUP_BATCH_SIZE = 100;
+
+export type UnboundAttachmentCleanupMode = 'observe' | 'enforce';
+export type UnboundAttachmentCleanupResult = {
+  mode: UnboundAttachmentCleanupMode;
+  scanned: number;
+  deleted: number;
+  declaredBytes: bigint;
+};
+
+type CleanupCandidate = {
+  id: string;
+  userId: string;
+  details: unknown;
+};
+
+export function resolveUnboundAttachmentCleanupMode(
+  value = process.env.UNBOUND_ATTACHMENT_CLEANUP_MODE
+): UnboundAttachmentCleanupMode {
+  return value?.toLowerCase() === 'enforce' ? 'enforce' : 'observe';
+}
+
+export function attachmentDeclaredBytes(details: unknown): bigint {
+  if (!details || typeof details !== 'object' || Array.isArray(details)) return BigInt(0);
+  const size = (details as Record<string, unknown>).size;
+  if (typeof size !== 'number' || !Number.isSafeInteger(size) || size <= 0) return BigInt(0);
+  return BigInt(size);
+}
+
+function isNotReferencedByProfile() {
+  return sql`NOT EXISTS (
+    SELECT 1
+    FROM ${users}
+    WHERE ${users.avatar} = ${attachments.url}
+       OR ${users.avatar} = ${attachments.compressUrl}
+       OR ${users.cover} = ${attachments.url}
+       OR ${users.cover} = ${attachments.compressUrl}
+  )`;
+}
+
+function eligibleUnboundAttachment(cutoff: Date) {
+  return and(
+    isNull(attachments.roteid),
+    isNotNull(attachments.userid),
+    lte(attachments.updatedAt, cutoff),
+    isNotReferencedByProfile()
+  );
+}
+
+async function deleteCandidate(candidate: CleanupCandidate, cutoff: Date): Promise<boolean> {
+  return await db.transaction(async (transaction) => {
+    await transaction
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.id, candidate.userId))
+      .limit(1)
+      .for('update');
+
+    const [locked] = (await transaction
+      .select({
+        id: attachments.id,
+        userId: attachments.userid,
+        details: attachments.details,
+      })
+      .from(attachments)
+      .where(and(eq(attachments.id, candidate.id), eligibleUnboundAttachment(cutoff)))
+      .limit(1)
+      .for('update')) as CleanupCandidate[];
+    if (!locked || locked.userId !== candidate.userId) return false;
+
+    const objectKeys = collectOwnedAttachmentObjectKeys(locked.details, locked.userId);
+    const trackedKeys = new Set(
+      await releaseStorageObjectReferences(locked.userId, objectKeys, transaction)
+    );
+    await enqueueStorageObjectCleanup(
+      transaction,
+      objectKeys.filter((key) => !trackedKeys.has(key))
+    );
+    const deleted = await transaction
+      .delete(attachments)
+      .where(
+        and(
+          eq(attachments.id, locked.id),
+          eq(attachments.userid, locked.userId),
+          isNull(attachments.roteid)
+        )
+      )
+      .returning({ id: attachments.id });
+    return deleted.length === 1;
+  });
+}
+
+export async function runUnboundAttachmentCleanup(
+  now = new Date(),
+  mode = resolveUnboundAttachmentCleanupMode()
+): Promise<UnboundAttachmentCleanupResult> {
+  const cutoff = new Date(now.getTime() - UNBOUND_ATTACHMENT_RETENTION_MS);
+  const candidates = (await db
+    .select({
+      id: attachments.id,
+      userId: attachments.userid,
+      details: attachments.details,
+    })
+    .from(attachments)
+    .where(eligibleUnboundAttachment(cutoff))
+    .orderBy(attachments.updatedAt, attachments.id)
+    .limit(UNBOUND_ATTACHMENT_CLEANUP_BATCH_SIZE)) as CleanupCandidate[];
+  const declaredBytes = candidates.reduce(
+    (total, candidate) => total + attachmentDeclaredBytes(candidate.details),
+    BigInt(0)
+  );
+
+  let deleted = 0;
+  if (mode === 'enforce') {
+    for (const candidate of candidates) {
+      if (await deleteCandidate(candidate, cutoff)) deleted += 1;
+    }
+  }
+
+  if (candidates.length > 0) {
+    // Aggregate only: never log attachment, user, or object identifiers.
+    // eslint-disable-next-line no-console
+    console.info('[managed-storage] unbound_attachment_cleanup', {
+      mode,
+      scanned: candidates.length,
+      deleted,
+      declaredBytes: declaredBytes.toString(),
+    });
+  }
+  return { mode, scanned: candidates.length, deleted, declaredBytes };
+}

--- a/server/mcp/toolDefinitions.json
+++ b/server/mcp/toolDefinitions.json
@@ -427,8 +427,16 @@
         "avatar": {
           "type": "string"
         },
+        "avatarAttachmentId": {
+          "type": "string",
+          "format": "uuid"
+        },
         "cover": {
           "type": "string"
+        },
+        "coverAttachmentId": {
+          "type": "string",
+          "format": "uuid"
         }
       },
       "required": [],

--- a/server/profile/mediaLifecycle.test.ts
+++ b/server/profile/mediaLifecycle.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'bun:test';
+
+process.env.POSTGRESQL_URL ||= 'postgres://test:test@localhost:5432/rote_test';
+const {
+  attachmentMatchesUrl,
+  profileAttachmentUrl,
+  profileReferencesAttachment,
+  resolveProfileAttachmentUrl,
+  resolveProfileMediaUpdate,
+} = await import('./mediaLifecycle');
+
+const attachment = {
+  id: 'attachment-1',
+  url: 'https://storage.example/original.jpg',
+  compressUrl: 'https://storage.example/compressed.webp',
+  details: {},
+};
+
+function transactionReturning(rows: unknown[]) {
+  return {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: () => ({
+            for: async () => rows,
+          }),
+        }),
+      }),
+    }),
+  };
+}
+
+describe('profile media lifecycle', () => {
+  it('derives a profile URL from the compressed asset when available', () => {
+    expect(profileAttachmentUrl(attachment)).toBe(attachment.compressUrl);
+    expect(profileAttachmentUrl({ ...attachment, compressUrl: '' })).toBe(attachment.url);
+  });
+
+  it('accepts either stored URL and rejects a mismatched submitted URL', () => {
+    expect(attachmentMatchesUrl(attachment, attachment.url)).toBe(true);
+    expect(attachmentMatchesUrl(attachment, attachment.compressUrl)).toBe(true);
+    expect(resolveProfileAttachmentUrl('avatar', attachment, attachment.url)).toBe(
+      attachment.compressUrl
+    );
+    expect(() =>
+      resolveProfileAttachmentUrl('avatar', attachment, 'https://storage.example/other.jpg')
+    ).toThrow('avatar URL does not match the supplied attachment');
+  });
+
+  it('keeps an attachment while either resulting profile field references it', () => {
+    expect(profileReferencesAttachment({ avatar: attachment.url, cover: null }, attachment)).toBe(
+      true
+    );
+    expect(
+      profileReferencesAttachment({ avatar: null, cover: attachment.compressUrl }, attachment)
+    ).toBe(true);
+    expect(
+      profileReferencesAttachment(
+        { avatar: 'https://external.example/avatar.jpg', cover: null },
+        attachment
+      )
+    ).toBe(false);
+  });
+
+  it('keeps URL-only profile requests compatible with existing clients', async () => {
+    await expect(
+      resolveProfileMediaUpdate(transactionReturning([]), 'user-1', {
+        avatar: 'https://external.example/avatar.jpg',
+        cover: null,
+      })
+    ).resolves.toEqual({
+      avatar: 'https://external.example/avatar.jpg',
+      cover: null,
+    });
+  });
+
+  it('derives both profile fields when one owned unbound attachment is shared', async () => {
+    await expect(
+      resolveProfileMediaUpdate(transactionReturning([attachment]), 'user-1', {
+        avatarAttachmentId: 'ce77f797-8a90-4868-b24c-a3ab0f498085',
+        coverAttachmentId: 'ce77f797-8a90-4868-b24c-a3ab0f498085',
+      })
+    ).resolves.toEqual({
+      avatar: attachment.compressUrl,
+      cover: attachment.compressUrl,
+    });
+  });
+
+  it('rejects attachments that are not visible as owned and unbound', async () => {
+    await expect(
+      resolveProfileMediaUpdate(transactionReturning([]), 'user-1', {
+        avatarAttachmentId: 'ce77f797-8a90-4868-b24c-a3ab0f498085',
+      })
+    ).rejects.toThrow('Invalid avatar attachment');
+  });
+
+  it('rejects a supplied URL that does not match the attachment record', async () => {
+    await expect(
+      resolveProfileMediaUpdate(transactionReturning([attachment]), 'user-1', {
+        avatar: 'https://external.example/avatar.jpg',
+        avatarAttachmentId: 'ce77f797-8a90-4868-b24c-a3ab0f498085',
+      })
+    ).rejects.toThrow('avatar URL does not match the supplied attachment');
+  });
+});

--- a/server/profile/mediaLifecycle.ts
+++ b/server/profile/mediaLifecycle.ts
@@ -1,0 +1,188 @@
+import { and, eq, inArray, isNull, or } from 'drizzle-orm';
+import { attachments } from '../drizzle/schema';
+import {
+  collectOwnedAttachmentObjectKeys,
+  enqueueStorageObjectCleanup,
+  releaseStorageObjectReferences,
+} from '../resources/service';
+import { DatabaseError } from '../utils/dbMethods/common';
+
+export type ProfileMediaUpdateInput = {
+  avatar?: string | null;
+  avatarAttachmentId?: string | null;
+  cover?: string | null;
+  coverAttachmentId?: string | null;
+};
+
+export type ProfileMediaValues = {
+  avatar: string | null;
+  cover: string | null;
+};
+
+type ProfileAttachment = Pick<
+  typeof attachments.$inferSelect,
+  'id' | 'url' | 'compressUrl' | 'details'
+>;
+
+type ResolvedProfileMediaUpdate = {
+  avatar?: string | null;
+  cover?: string | null;
+};
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function profileAttachmentUrl(attachment: ProfileAttachment): string {
+  return attachment.compressUrl || attachment.url;
+}
+
+export function attachmentMatchesUrl(
+  attachment: ProfileAttachment,
+  url: string | null | undefined
+): boolean {
+  return Boolean(url && (attachment.url === url || attachment.compressUrl === url));
+}
+
+export function profileReferencesAttachment(
+  profile: ProfileMediaValues,
+  attachment: ProfileAttachment
+): boolean {
+  return (
+    attachmentMatchesUrl(attachment, profile.avatar) ||
+    attachmentMatchesUrl(attachment, profile.cover)
+  );
+}
+
+export function resolveProfileAttachmentUrl(
+  field: 'avatar' | 'cover',
+  attachment: ProfileAttachment,
+  submittedUrl: string | null | undefined
+): string {
+  if (submittedUrl !== undefined && !attachmentMatchesUrl(attachment, submittedUrl)) {
+    throw new DatabaseError(`${field} URL does not match the supplied attachment`);
+  }
+  return profileAttachmentUrl(attachment);
+}
+
+async function resolveAttachmentUrl(
+  transaction: any,
+  userId: string,
+  field: 'avatar' | 'cover',
+  attachmentId: string,
+  submittedUrl: string | null | undefined
+): Promise<string> {
+  if (!UUID_PATTERN.test(attachmentId)) {
+    throw new DatabaseError(`Invalid ${field} attachment`);
+  }
+  const [attachment] = (await transaction
+    .select({
+      id: attachments.id,
+      url: attachments.url,
+      compressUrl: attachments.compressUrl,
+      details: attachments.details,
+    })
+    .from(attachments)
+    .where(
+      and(
+        eq(attachments.id, attachmentId),
+        eq(attachments.userid, userId),
+        isNull(attachments.roteid)
+      )
+    )
+    .limit(1)
+    .for('update')) as ProfileAttachment[];
+
+  if (!attachment) {
+    throw new DatabaseError(`Invalid ${field} attachment`);
+  }
+  return resolveProfileAttachmentUrl(field, attachment, submittedUrl);
+}
+
+export async function resolveProfileMediaUpdate(
+  transaction: any,
+  userId: string,
+  input: ProfileMediaUpdateInput
+): Promise<ResolvedProfileMediaUpdate> {
+  const resolved: ResolvedProfileMediaUpdate = {};
+
+  if (input.avatarAttachmentId) {
+    resolved.avatar = await resolveAttachmentUrl(
+      transaction,
+      userId,
+      'avatar',
+      input.avatarAttachmentId,
+      input.avatar
+    );
+  } else if (input.avatar !== undefined) {
+    resolved.avatar = input.avatar || null;
+  }
+
+  if (input.coverAttachmentId) {
+    resolved.cover = await resolveAttachmentUrl(
+      transaction,
+      userId,
+      'cover',
+      input.coverAttachmentId,
+      input.cover
+    );
+  } else if (input.cover !== undefined) {
+    resolved.cover = input.cover || null;
+  }
+
+  return resolved;
+}
+
+export async function releaseReplacedProfileAttachments(
+  transaction: any,
+  userId: string,
+  previous: ProfileMediaValues,
+  current: ProfileMediaValues
+): Promise<number> {
+  const replacedUrls = [previous.avatar, previous.cover].filter((url): url is string =>
+    Boolean(url)
+  );
+  if (replacedUrls.length === 0) return 0;
+
+  const candidates = (await transaction
+    .select({
+      id: attachments.id,
+      url: attachments.url,
+      compressUrl: attachments.compressUrl,
+      details: attachments.details,
+    })
+    .from(attachments)
+    .where(
+      and(
+        eq(attachments.userid, userId),
+        isNull(attachments.roteid),
+        or(inArray(attachments.url, replacedUrls), inArray(attachments.compressUrl, replacedUrls))
+      )
+    )
+    .for('update')) as ProfileAttachment[];
+
+  const removable = candidates.filter(
+    (attachment) => !profileReferencesAttachment(current, attachment)
+  );
+  if (removable.length === 0) return 0;
+
+  const objectKeys = removable.flatMap((attachment) =>
+    collectOwnedAttachmentObjectKeys(attachment.details, userId)
+  );
+  const trackedKeys = new Set(
+    await releaseStorageObjectReferences(userId, objectKeys, transaction)
+  );
+  await enqueueStorageObjectCleanup(
+    transaction,
+    objectKeys.filter((key) => !trackedKeys.has(key))
+  );
+  await transaction.delete(attachments).where(
+    and(
+      eq(attachments.userid, userId),
+      isNull(attachments.roteid),
+      inArray(
+        attachments.id,
+        removable.map((attachment) => attachment.id)
+      )
+    )
+  );
+  return removable.length;
+}

--- a/server/resources/service.ts
+++ b/server/resources/service.ts
@@ -78,7 +78,7 @@ export function collectOwnedAttachmentObjectKeys(details: unknown, userId: strin
   ];
 }
 
-async function enqueueCleanupKeys(
+export async function enqueueStorageObjectCleanup(
   transaction: any,
   objectKeys: readonly string[],
   nextAttemptAt = new Date()
@@ -122,7 +122,7 @@ export async function cancelPendingUploadReservationsForUser(
       )
       .for('update');
     if (pendingReservations.length === 0) return;
-    await enqueueCleanupKeys(
+    await enqueueStorageObjectCleanup(
       transaction,
       pendingReservations.flatMap(({ manifest }: { manifest: unknown }) =>
         reservationCleanupKeys(manifest as UploadReservationManifestItem[], true)
@@ -522,7 +522,7 @@ export async function appendUploadReservation(params: {
           updatedAt: now,
         })
         .where(eq(resourceStorageAccounts.userId, params.userId));
-      await enqueueCleanupKeys(
+      await enqueueStorageObjectCleanup(
         transaction,
         reservationCleanupKeys(existing.manifest as UploadReservationManifestItem[], true)
       );
@@ -558,7 +558,7 @@ export async function appendUploadReservation(params: {
             updatedAt: now,
           })
           .where(eq(resourceStorageAccounts.userId, params.userId));
-        await enqueueCleanupKeys(
+        await enqueueStorageObjectCleanup(
           transaction,
           reservationCleanupKeys(existing.manifest as UploadReservationManifestItem[], true)
         );
@@ -651,7 +651,7 @@ export async function cancelUploadReservation(userId: string, id: string) {
       .update(resourceUploadReservations)
       .set({ status: 'cancelled', completedAt: new Date() })
       .where(eq(resourceUploadReservations.id, id));
-    await enqueueCleanupKeys(
+    await enqueueStorageObjectCleanup(
       transaction,
       reservationCleanupKeys(reservation.manifest as UploadReservationManifestItem[], true)
     );
@@ -715,7 +715,7 @@ export async function getPendingUploadReservation(
             updatedAt: new Date(),
           })
           .where(eq(resourceStorageAccounts.userId, userId));
-        await enqueueCleanupKeys(
+        await enqueueStorageObjectCleanup(
           transactionOverride,
           reservationCleanupKeys(reservation.manifest as UploadReservationManifestItem[], true)
         );
@@ -829,7 +829,7 @@ export async function completeUploadReservation(
           set: { actualBytes: object.actualBytes, updatedAt: new Date() },
         });
     }
-    await enqueueCleanupKeys(
+    await enqueueStorageObjectCleanup(
       transaction,
       params.objects
         .filter((object) => object.stagingKey !== object.finalKey)
@@ -837,7 +837,7 @@ export async function completeUploadReservation(
       reservation.credentialExpiresAt ?? new Date()
     );
     const submittedStagingKeys = new Set(params.objects.map((object) => object.stagingKey));
-    await enqueueCleanupKeys(
+    await enqueueStorageObjectCleanup(
       transaction,
       (reservation.manifest as UploadReservationManifestItem[])
         .filter((object) => !submittedStagingKeys.has(object.stagingKey))
@@ -955,7 +955,7 @@ export async function prepareAccountResourceDeletion(userId: string, transaction
       .select({ details: attachments.details })
       .from(attachments)
       .where(eq(attachments.userid, userId))) as Array<{ details: unknown }>;
-    await enqueueCleanupKeys(
+    await enqueueStorageObjectCleanup(
       transaction,
       legacyAttachments
         .flatMap(({ details }) => collectOwnedAttachmentObjectKeys(details, userId))

--- a/server/resources/worker.test.ts
+++ b/server/resources/worker.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from 'bun:test';
 
 process.env.POSTGRESQL_URL ||= 'postgres://test:test@localhost:5432/rote_test';
-const { attachmentObjects, inspectReconciledObjects, isolateReconciliationFailure } =
-  await import('./worker');
+const {
+  attachmentObjects,
+  cleanupRetryDelaySeconds,
+  inspectReconciledObjects,
+  isolateReconciliationFailure,
+} = await import('./worker');
 
 describe('resource maintenance isolation', () => {
   it('counts a Live Photo original reused as its browser cover only once', () => {
@@ -63,5 +67,11 @@ describe('resource maintenance isolation', () => {
         async () => ({ contentLength: null, contentType: null, etag: null })
       )
     ).rejects.toThrow('storage_object_size_unknown');
+  });
+
+  it('backs off failed outbox deletes and caps retries at the existing maximum', () => {
+    expect(cleanupRetryDelaySeconds(1)).toBe(2);
+    expect(cleanupRetryDelaySeconds(10)).toBe(1024);
+    expect(cleanupRetryDelaySeconds(20)).toBe(1024);
   });
 });

--- a/server/resources/worker.ts
+++ b/server/resources/worker.ts
@@ -12,6 +12,7 @@ import db from '../utils/drizzle';
 import { getObjectInfo, r2deletehandler } from '../utils/r2';
 import type { UploadReservationManifestItem } from './service';
 import { billingConfig } from '../billing/runtimeConfig';
+import { runUnboundAttachmentCleanup } from '../attachments/unboundCleanup';
 
 export type ReconciledObject = {
   key: string;
@@ -24,6 +25,10 @@ type InspectedObject = ReconciledObject & { actualBytes: bigint };
 
 const RECONCILIATION_HEAD_CONCURRENCY = 8;
 const RECONCILIATION_USERS_PER_RUN = 100;
+
+export function cleanupRetryDelaySeconds(attempts: number): number {
+  return Math.min(3600, 2 ** Math.min(attempts, 10));
+}
 
 export async function inspectReconciledObjects(
   objects: readonly ReconciledObject[],
@@ -263,6 +268,18 @@ export async function runResourceMaintenance(now = new Date()) {
       );
     }
   );
+  await isolateReconciliationFailure(
+    async () => {
+      await runUnboundAttachmentCleanup(now);
+    },
+    (error) => {
+      // eslint-disable-next-line no-console
+      console.error(
+        '[managed-storage] unbound_attachment_cleanup_failed',
+        error instanceof Error ? error.name : 'unknown'
+      );
+    }
+  );
   const expired = await db
     .select()
     .from(resourceUploadReservations)
@@ -325,7 +342,7 @@ export async function runResourceMaintenance(now = new Date()) {
       continue;
     }
     const attempts = item.attempts + 1;
-    const delaySeconds = Math.min(3600, 2 ** Math.min(attempts, 10));
+    const delaySeconds = cleanupRetryDelaySeconds(attempts);
     await db
       .update(resourceCleanupOutbox)
       .set({
@@ -387,7 +404,6 @@ export async function runResourceMaintenance(now = new Date()) {
 
 export async function startResourceMaintenanceWorker() {
   if (started) return;
-  if (!billingConfig.enabled) return;
   started = true;
   const run = () => {
     if (maintenanceInFlight) return;

--- a/server/utils/dbMethods/attachment.ts
+++ b/server/utils/dbMethods/attachment.ts
@@ -1,12 +1,13 @@
 import { and, desc, eq, inArray, isNull, or, sql } from 'drizzle-orm';
 import { attachments, rotes, users } from '../../drizzle/schema';
+import { profileReferencesAttachment } from '../../profile/mediaLifecycle';
+import { releaseStorageObjectReferences } from '../../resources/service';
 import { UploadResult } from '../../types/main';
 import { validateRoteAttachmentDetails } from '../fileValidation';
 import db from '../drizzle';
 import { r2deletehandler } from '../r2';
 import { createRoteChange } from './change';
 import { DatabaseError } from './common';
-import { releaseStorageObjectReferences } from '../../resources/service';
 
 function collectAttachmentObjectKeys(details: any): string[] {
   if (!details || typeof details !== 'object') {
@@ -216,7 +217,19 @@ export async function bindAttachmentsToRote(
     }
 
     const result = await db.transaction(async (tx) => {
-      // 先严格校验：必须都是当前用户、且尚未绑定
+      // 与资料更新和孤儿附件回收使用相同的锁顺序：先用户、后附件。
+      // 这样在并发绑定时，回收任务会在重新校验前等待，而不会删除正在绑定的附件。
+      const [lockedUser] = await tx
+        .select({ id: users.id })
+        .from(users)
+        .where(eq(users.id, userid))
+        .limit(1)
+        .for('update');
+      if (!lockedUser) {
+        throw new DatabaseError('User not found');
+      }
+
+      // 严格校验：必须都是当前用户、且尚未绑定，并锁定到事务结束。
       const candidates = await tx
         .select({ id: attachments.id, details: attachments.details })
         .from(attachments)
@@ -226,7 +239,8 @@ export async function bindAttachmentsToRote(
             eq(attachments.userid, userid),
             isNull(attachments.roteid)
           )
-        );
+        )
+        .for('update');
 
       if (candidates.length !== attachmentIds.length) {
         throw new DatabaseError(
@@ -425,9 +439,19 @@ export async function deleteAttachments(
 ): Promise<any> {
   try {
     const deleted = await db.transaction(async (tx) => {
-      await tx.select({ id: users.id }).from(users).where(eq(users.id, userid)).for('update');
+      const [profile] = await tx
+        .select({ id: users.id, avatar: users.avatar, cover: users.cover })
+        .from(users)
+        .where(eq(users.id, userid))
+        .for('update');
       const dbAttachments = await tx
-        .select({ id: attachments.id, details: attachments.details, roteid: attachments.roteid })
+        .select({
+          id: attachments.id,
+          url: attachments.url,
+          compressUrl: attachments.compressUrl,
+          details: attachments.details,
+          roteid: attachments.roteid,
+        })
         .from(attachments)
         .where(
           and(
@@ -442,9 +466,15 @@ export async function deleteAttachments(
       if (dbAttachments.length !== attachmentsData.length) {
         throw new DatabaseError('Some attachments not found or unauthorized');
       }
+      const removableAttachments = profile
+        ? dbAttachments.filter((attachment) => !profileReferencesAttachment(profile, attachment))
+        : dbAttachments;
+      if (removableAttachments.length === 0) {
+        return { dbAttachments: [], result: [], roteIds: [], tracked: [] };
+      }
       const tracked = await releaseStorageObjectReferences(
         userid,
-        dbAttachments.flatMap(({ details }) => collectAttachmentObjectKeys(details)),
+        removableAttachments.flatMap(({ details }) => collectAttachmentObjectKeys(details)),
         tx
       );
       const result = await tx
@@ -453,19 +483,21 @@ export async function deleteAttachments(
           and(
             inArray(
               attachments.id,
-              attachmentsData.map((e) => e.id)
+              removableAttachments.map((attachment) => attachment.id)
             ),
             eq(attachments.userid, userid)
           )
         )
         .returning();
       const roteIds = [
-        ...new Set(dbAttachments.map((a) => a.roteid).filter((id): id is string => id !== null)),
+        ...new Set(
+          removableAttachments.map((a) => a.roteid).filter((id): id is string => id !== null)
+        ),
       ];
       for (const roteid of roteIds) {
         await tx.update(rotes).set({ updatedAt: new Date() }).where(eq(rotes.id, roteid));
       }
-      return { dbAttachments, result, roteIds, tracked };
+      return { dbAttachments: removableAttachments, result, roteIds, tracked };
     });
 
     // 更新相关 rote 的 updatedAt 并记录变更历史
@@ -507,13 +539,16 @@ export async function deleteAttachments(
       .forEach((key) => deleteAttachmentObjects({ key }));
 
     // 兼容性：如果请求体传入了 key，但 DB 没有 details（历史数据），也尝试删除
-    attachmentsData.forEach(({ key }) => {
-      if (key) {
-        r2deletehandler(key).catch((err) => {
-          console.error(`Failed to delete attachment (compat) from R2: ${key}`, err);
-        });
-      }
-    });
+    const deletedIds = new Set(deleted.result.map(({ id }) => id));
+    attachmentsData
+      .filter(({ id }) => deletedIds.has(id))
+      .forEach(({ key }) => {
+        if (key) {
+          r2deletehandler(key).catch((err) => {
+            console.error(`Failed to delete attachment (compat) from R2: ${key}`, err);
+          });
+        }
+      });
 
     return { count: deleted.result.length };
   } catch (error) {
@@ -524,14 +559,27 @@ export async function deleteAttachments(
 export async function deleteAttachment(id: string, userid: string): Promise<any> {
   try {
     const deleted = await db.transaction(async (tx) => {
-      await tx.select({ id: users.id }).from(users).where(eq(users.id, userid)).for('update');
+      const [profile] = await tx
+        .select({ id: users.id, avatar: users.avatar, cover: users.cover })
+        .from(users)
+        .where(eq(users.id, userid))
+        .for('update');
       const [record] = await tx
-        .select({ id: attachments.id, details: attachments.details, roteid: attachments.roteid })
+        .select({
+          id: attachments.id,
+          url: attachments.url,
+          compressUrl: attachments.compressUrl,
+          details: attachments.details,
+          roteid: attachments.roteid,
+        })
         .from(attachments)
         .where(and(eq(attachments.id, id), eq(attachments.userid, userid)))
         .limit(1)
         .for('update');
       if (!record) return { record: null, result: [], tracked: [] };
+      if (profile && profileReferencesAttachment(profile, record)) {
+        return { record: null, result: [], tracked: [] };
+      }
       const tracked = await releaseStorageObjectReferences(
         userid,
         collectAttachmentObjectKeys(record.details),

--- a/server/utils/dbMethods/userProfile.ts
+++ b/server/utils/dbMethods/userProfile.ts
@@ -1,5 +1,9 @@
 import { and, eq, ne } from 'drizzle-orm';
 import { users } from '../../drizzle/schema';
+import {
+  releaseReplacedProfileAttachments,
+  resolveProfileMediaUpdate,
+} from '../../profile/mediaLifecycle';
 import db from '../drizzle';
 import { DatabaseError } from './common';
 import { getUserOAuthBindings } from './userOAuth';
@@ -9,9 +13,11 @@ export async function editMyProfile(
   userid: string,
   data: {
     avatar?: string | null;
+    avatarAttachmentId?: string | null;
     nickname?: string | null;
     description?: string | null;
     cover?: string | null;
+    coverAttachmentId?: string | null;
     username?: string;
   }
 ): Promise<{
@@ -27,36 +33,56 @@ export async function editMyProfile(
   updatedAt: Date;
 }> {
   try {
-    // 如果提供了新用户名，检查是否已被其他用户使用
-    if (data.username !== undefined) {
-      const existingUser = await db
+    const user = await db.transaction(async (transaction) => {
+      const [currentUser] = await transaction
         .select()
         .from(users)
-        .where(and(eq(users.username, data.username), ne(users.id, userid)))
-        .limit(1);
+        .where(eq(users.id, userid))
+        .limit(1)
+        .for('update');
+      if (!currentUser) throw new DatabaseError('User not found');
 
-      if (existingUser.length > 0) {
-        throw new DatabaseError('Username already exists', new Error('Username already exists'));
+      if (data.username !== undefined) {
+        const existingUser = await transaction
+          .select({ id: users.id })
+          .from(users)
+          .where(and(eq(users.username, data.username), ne(users.id, userid)))
+          .limit(1);
+        if (existingUser.length > 0) {
+          throw new DatabaseError('Username already exists', new Error('Username already exists'));
+        }
       }
-    }
 
-    const updateData: {
-      avatar?: string | null;
-      nickname?: string | null;
-      description?: string | null;
-      cover?: string | null;
-      username?: string;
-      updatedAt: Date;
-    } = {
-      updatedAt: new Date(),
-    };
-    if (data.avatar !== undefined) updateData.avatar = data.avatar || null;
-    if (data.nickname !== undefined) updateData.nickname = data.nickname || null;
-    if (data.description !== undefined) updateData.description = data.description || null;
-    if (data.cover !== undefined) updateData.cover = data.cover || null;
-    if (data.username !== undefined) updateData.username = data.username;
+      const resolvedMedia = await resolveProfileMediaUpdate(transaction, userid, data);
+      const updateData: {
+        avatar?: string | null;
+        nickname?: string | null;
+        description?: string | null;
+        cover?: string | null;
+        username?: string;
+        updatedAt: Date;
+      } = {
+        updatedAt: new Date(),
+      };
+      if (resolvedMedia.avatar !== undefined) updateData.avatar = resolvedMedia.avatar;
+      if (data.nickname !== undefined) updateData.nickname = data.nickname || null;
+      if (data.description !== undefined) updateData.description = data.description || null;
+      if (resolvedMedia.cover !== undefined) updateData.cover = resolvedMedia.cover;
+      if (data.username !== undefined) updateData.username = data.username;
 
-    const [user] = await db.update(users).set(updateData).where(eq(users.id, userid)).returning();
+      const [updatedUser] = await transaction
+        .update(users)
+        .set(updateData)
+        .where(eq(users.id, userid))
+        .returning();
+      await releaseReplacedProfileAttachments(
+        transaction,
+        userid,
+        { avatar: currentUser.avatar, cover: currentUser.cover },
+        { avatar: updatedUser.avatar, cover: updatedUser.cover }
+      );
+      return updatedUser;
+    });
 
     return {
       id: user.id,

--- a/web/src/pages/profile/index.tsx
+++ b/web/src/pages/profile/index.tsx
@@ -13,7 +13,7 @@ import {
   patchProfileAtom,
   profileAtom,
 } from '@/state/profile';
-import type { OpenKeys, Profile } from '@/types/main';
+import type { Attachment, OpenKeys, Profile } from '@/types/main';
 import { get, post } from '@/utils/api';
 import { useAPIGet } from '@/utils/fetcher';
 import { isHeicFile } from '@/utils/uploadHelpers';
@@ -31,7 +31,26 @@ import OpenKeySection from './components/OpenKeySection';
 import ProfileHeader from './components/ProfileHeader';
 import ProfileSidebar from './components/ProfileSidebar';
 import { getUploadErrorMessage } from '@/utils/directUpload';
-import { createCroppedImage, uploadAvatar, uploadCover } from './utils/avatarUpload';
+import {
+  createCroppedImage,
+  deletePendingProfileAttachment,
+  profileAttachmentUrl,
+  uploadAvatar,
+  uploadCover,
+} from './utils/avatarUpload';
+
+async function deletePendingAttachmentQuietly(attachmentId: string) {
+  try {
+    await deletePendingProfileAttachment(attachmentId);
+  } catch (error) {
+    // The server's seven-day orphan cleanup is the durable fallback.
+    // eslint-disable-next-line no-console
+    console.warn(
+      '[profile] pending attachment cleanup failed',
+      error instanceof Error ? error.name : 'unknown'
+    );
+  }
+}
 
 function ProfilePage() {
   const { data: siteStatus } = useSiteStatus();
@@ -40,6 +59,11 @@ function ProfilePage() {
   const [searchParams] = useSearchParams();
   const inputAvatarRef = useRef<HTMLInputElement>(null);
   const inputCoverRef = useRef<HTMLInputElement>(null);
+  const isMountedRef = useRef(true);
+  const profileEditorSessionRef = useRef(0);
+  const avatarUploadGenerationRef = useRef(0);
+  const coverUploadGenerationRef = useRef(0);
+  const pendingAvatarAttachmentRef = useRef<Attachment | null>(null);
 
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [isAvatarModalOpen, setIsAvatarModalOpen] = useState<boolean>(false);
@@ -81,6 +105,7 @@ function ProfilePage() {
 
   const [editProfile, setEditProfile] = useState<Partial<Profile>>(profile ?? {});
   const [avatarFile, setAvatarFile] = useState<File | null>(null);
+  const [pendingAvatarAttachment, setPendingAvatarAttachment] = useState<Attachment | null>(null);
 
   const [avatarUploading, setAvatarUploading] = useState(false);
   const [profileEditing, setProfileEditing] = useState(false);
@@ -90,6 +115,74 @@ function ProfilePage() {
       setEditProfile(profile);
     }
   }, [profile]);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+      avatarUploadGenerationRef.current += 1;
+      coverUploadGenerationRef.current += 1;
+      const pending = pendingAvatarAttachmentRef.current;
+      pendingAvatarAttachmentRef.current = null;
+      if (pending) void deletePendingAttachmentQuietly(pending.id);
+    };
+  }, []);
+
+  async function discardPendingAvatarAttachment() {
+    const pending = pendingAvatarAttachmentRef.current;
+    pendingAvatarAttachmentRef.current = null;
+    if (isMountedRef.current) setPendingAvatarAttachment(null);
+    if (pending) await deletePendingAttachmentQuietly(pending.id);
+  }
+
+  async function acceptPendingAvatarAttachment(
+    attachment: Attachment,
+    session: number,
+    generation: number
+  ): Promise<boolean> {
+    if (
+      !isMountedRef.current ||
+      session !== profileEditorSessionRef.current ||
+      generation !== avatarUploadGenerationRef.current
+    ) {
+      await deletePendingAttachmentQuietly(attachment.id);
+      return false;
+    }
+    const previous = pendingAvatarAttachmentRef.current;
+    if (previous && previous.id !== attachment.id) {
+      await deletePendingAttachmentQuietly(previous.id);
+    }
+    if (
+      !isMountedRef.current ||
+      session !== profileEditorSessionRef.current ||
+      generation !== avatarUploadGenerationRef.current
+    ) {
+      await deletePendingAttachmentQuietly(attachment.id);
+      return false;
+    }
+    pendingAvatarAttachmentRef.current = attachment;
+    setPendingAvatarAttachment(attachment);
+    return true;
+  }
+
+  function openProfileEditor() {
+    profileEditorSessionRef.current += 1;
+    setEditProfile(profile ?? {});
+    setIsModalOpen(true);
+  }
+
+  function changeProfileEditorOpen(open: boolean) {
+    if (open) {
+      openProfileEditor();
+      return;
+    }
+    if (profileEditing) return;
+    profileEditorSessionRef.current += 1;
+    avatarUploadGenerationRef.current += 1;
+    setIsModalOpen(false);
+    setEditProfile(profile ?? {});
+    void discardPendingAvatarAttachment();
+  }
 
   function generateOpenKeyFun() {
     if (displayedResourceState?.openKey.canCreate === false) {
@@ -133,14 +226,21 @@ function ProfilePage() {
     }
 
     try {
+      const session = profileEditorSessionRef.current;
+      const generation = ++avatarUploadGenerationRef.current;
       setAvatarUploading(true);
       const croppedImage = await createCroppedImage(avatarFile, croppedAreaPixels);
-      const avatarUrl = await uploadAvatar(croppedImage);
+      const attachment = await uploadAvatar(croppedImage);
+      const accepted = await acceptPendingAvatarAttachment(attachment, session, generation);
+      if (!accepted) {
+        setAvatarUploading(false);
+        return;
+      }
 
-      setEditProfile({
-        ...editProfile,
-        avatar: avatarUrl,
-      });
+      setEditProfile((current) => ({
+        ...current,
+        avatar: profileAttachmentUrl(attachment),
+      }));
       setAvatarUploading(false);
       setIsAvatarModalOpen(false);
       setAvatarFile(null);
@@ -151,7 +251,7 @@ function ProfilePage() {
     }
   }
 
-  function saveProfile() {
+  async function saveProfile() {
     if (!profile || !editProfile) return;
 
     if (editProfile.username !== undefined && editProfile.username !== profile.username) {
@@ -174,31 +274,39 @@ function ProfilePage() {
     }
 
     setProfileEditing(true);
-    patchProfile(editProfile as Partial<NonNullable<Profile>>)
-      .then(() => {
-        toast.success(t('editSuccess'));
-        setIsModalOpen(false);
-        setProfileEditing(false);
-      })
-      .catch((error: any) => {
-        const errorMessage =
-          error?.response?.data?.message ||
-          error?.message ||
-          error?.response?.data?.error ||
-          t('editFailed');
-
-        if (
-          errorMessage.includes('username') ||
-          errorMessage.includes('Username') ||
-          errorMessage.includes('already exists')
-        ) {
-          toast.error(tLogin('usernameConflict') || errorMessage);
-        } else {
-          toast.error(errorMessage);
-        }
-        setIsModalOpen(false);
-        setProfileEditing(false);
+    try {
+      await patchProfile({
+        ...(editProfile as Partial<NonNullable<Profile>>),
+        ...(pendingAvatarAttachment ? { avatarAttachmentId: pendingAvatarAttachment.id } : {}),
       });
+      pendingAvatarAttachmentRef.current = null;
+      setPendingAvatarAttachment(null);
+      profileEditorSessionRef.current += 1;
+      toast.success(t('editSuccess'));
+      setIsModalOpen(false);
+    } catch (error: any) {
+      const errorMessage =
+        error?.response?.data?.message ||
+        error?.message ||
+        error?.response?.data?.error ||
+        t('editFailed');
+
+      if (
+        errorMessage.includes('username') ||
+        errorMessage.includes('Username') ||
+        errorMessage.includes('already exists')
+      ) {
+        toast.error(tLogin('usernameConflict') || errorMessage);
+      } else {
+        toast.error(errorMessage);
+      }
+      profileEditorSessionRef.current += 1;
+      setIsModalOpen(false);
+      setEditProfile(profile ?? {});
+      await discardPendingAvatarAttachment();
+    } finally {
+      setProfileEditing(false);
+    }
   }
 
   async function changeCover(event: React.ChangeEvent<HTMLInputElement>) {
@@ -212,16 +320,30 @@ function ProfilePage() {
       return;
     }
 
+    const generation = ++coverUploadGenerationRef.current;
     setCoverChangeing(true);
+    let uploadedAttachment: Attachment | null = null;
     try {
-      const coverUrl = await uploadCover(selectedFile);
+      uploadedAttachment = await uploadCover(selectedFile);
+      if (!isMountedRef.current || generation !== coverUploadGenerationRef.current) {
+        await deletePendingAttachmentQuietly(uploadedAttachment.id);
+        return;
+      }
       await patchProfile({
-        cover: coverUrl,
+        cover: profileAttachmentUrl(uploadedAttachment),
+        coverAttachmentId: uploadedAttachment.id,
       });
-      setCoverChangeing(false);
     } catch (_error: any) {
-      setCoverChangeing(false);
-      toast.error(`${t('uploadFailed')}: ${getUploadErrorMessage(_error)}`);
+      if (uploadedAttachment) {
+        await deletePendingAttachmentQuietly(uploadedAttachment.id);
+      }
+      if (isMountedRef.current && generation === coverUploadGenerationRef.current) {
+        toast.error(`${t('uploadFailed')}: ${getUploadErrorMessage(_error)}`);
+      }
+    } finally {
+      if (isMountedRef.current && generation === coverUploadGenerationRef.current) {
+        setCoverChangeing(false);
+      }
     }
   }
 
@@ -250,7 +372,7 @@ function ProfilePage() {
           inputCoverRef={inputCoverRef}
           inputAvatarRef={inputAvatarRef}
           onChangeCover={changeCover}
-          onOpenEditProfile={() => setIsModalOpen(true)}
+          onOpenEditProfile={openProfileEditor}
         />
 
         <OpenKeySection
@@ -264,7 +386,7 @@ function ProfilePage() {
 
         <EditProfileDialog
           isOpen={isModalOpen}
-          onOpenChange={setIsModalOpen}
+          onOpenChange={changeProfileEditorOpen}
           editProfile={editProfile}
           onProfileChange={setEditProfile}
           onSave={saveProfile}

--- a/web/src/pages/profile/utils/avatarUpload.ts
+++ b/web/src/pages/profile/utils/avatarUpload.ts
@@ -1,6 +1,12 @@
+import type { Attachment } from '@/types/main';
+import { del } from '@/utils/api';
 import { finalize, presign, uploadToSignedUrl } from '@/utils/directUpload';
 import { maybeCompressToWebp } from '@/utils/uploadHelpers';
 import type { Area } from 'react-easy-crop';
+
+export function profileAttachmentUrl(attachment: Attachment): string {
+  return attachment.compressUrl || attachment.url;
+}
 
 // 生成裁剪后的图片
 export async function createCroppedImage(imageSrc: File | Blob, pixelCrop: Area): Promise<Blob> {
@@ -54,7 +60,7 @@ export async function createCroppedImage(imageSrc: File | Blob, pixelCrop: Area)
 export async function uploadAvatar(
   croppedImageBlob: Blob,
   options?: { maxWidthOrHeight?: number; initialQuality?: number }
-): Promise<string> {
+): Promise<Attachment> {
   // 将 Blob 转换为 File
   const croppedFile = new File([croppedImageBlob], 'cropped_image.png', {
     type: 'image/png',
@@ -110,15 +116,14 @@ export async function uploadAvatar(
   ]);
 
   if (finalized && finalized.length > 0) {
-    const attachment = finalized[0];
-    return attachment.compressUrl || attachment.url;
+    return finalized[0] as Attachment;
   } else {
     throw new Error('Failed to finalize upload');
   }
 }
 
 // 上传封面
-export async function uploadCover(file: File): Promise<string> {
+export async function uploadCover(file: File): Promise<Attachment> {
   // 获取预签名 URL
   const signItems = await presign([
     {
@@ -169,9 +174,12 @@ export async function uploadCover(file: File): Promise<string> {
   ]);
 
   if (finalized && finalized.length > 0) {
-    const attachment = finalized[0];
-    return attachment.compressUrl || attachment.url;
+    return finalized[0] as Attachment;
   } else {
     throw new Error('Failed to finalize upload');
   }
+}
+
+export async function deletePendingProfileAttachment(attachmentId: string): Promise<void> {
+  await del(`/attachments/${attachmentId}`);
 }

--- a/web/src/state/profile.ts
+++ b/web/src/state/profile.ts
@@ -4,6 +4,11 @@ import { isTokenValid } from '@/utils/main';
 import { atom, useAtomValue, useSetAtom } from 'jotai';
 import { selectAtom } from 'jotai/utils';
 
+export type ProfileUpdateRequest = Partial<NonNullable<Profile>> & {
+  avatarAttachmentId?: string | null;
+  coverAttachmentId?: string | null;
+};
+
 // 全局 Profile 状态（初始为 undefined，沿用现有 Profile 类型定义）
 export const profileAtom = atom<Profile>(undefined as Profile);
 export const authReadyAtom = atom(false);
@@ -66,14 +71,10 @@ export const loadUserSettingsAtom = atom(null, async (_get, set) => {
 });
 
 // 局部更新 Profile（先请求后本地合并）
-export const patchProfileAtom = atom(
-  null,
-  async (get, set, patch: Partial<NonNullable<Profile>>) => {
-    await put('/users/me/profile', patch as any);
-    const cur = get(profileAtom);
-    if (cur) set(profileAtom, { ...cur, ...patch } as Profile);
-  }
-);
+export const patchProfileAtom = atom(null, async (_get, set, patch: ProfileUpdateRequest) => {
+  const response = await put('/users/me/profile', patch);
+  set(profileAtom, response.data as Profile);
+});
 
 // 字段级选择器：组件只订阅自身关心的字段，减少不必要渲染
 export const selectProfile = <T>(


### PR DESCRIPTION
## Summary
- bind uploaded avatar and cover attachments atomically during profile updates while preserving URL-only clients
- delete replaced profile media only when no resulting profile field references it
- add seven-day observe/enforce cleanup for unbound attachments with transactional ledger updates and Outbox deletion
- clean pending Web profile uploads across replacement, close, failure, and unmount races

## Validation
- bun test profile/mediaLifecycle.test.ts attachments/unboundCleanup.test.ts resources/service.test.ts resources/worker.test.ts (23 passed)
- bun run lint and bun run build in server
- bun run test (164 passed), bun run lint, and bun run build in web
- full bun test reaches unrelated integration suites that require a running local PostgreSQL/API and fails with ECONNREFUSED; all runnable unit suites before that point pass