### PR TITLE
Make note writes atomic

### DIFF
--- a/server/mcp/notes.ts
+++ b/server/mcp/notes.ts
@@ -11,33 +11,21 @@ import {
   parseArchived,
   parseOptionalInteger,
   parseOptionalLimit,
-  processTags,
   requireAuth,
 } from './shared';
 import type { McpTool } from './types';
 
 async function createNote(c: HonoContext, args: Record<string, any>) {
   const auth = requireAuth(c);
-  NoteCreateZod.parse(args);
-  return await createUserNote(auth.userId, {
-    content: args.content,
-    title: args.title || '',
-    state: args.state || 'private',
-    type: args.type || 'rote',
-    tags: processTags(args.tags),
-    pin: !!args.pin,
-    archived: !!args.archived,
-    editor: args.editor,
-    articleId: args.articleId,
-    articleIds: args.articleIds,
-  });
+  const input = NoteCreateZod.parse(args);
+  return await createUserNote(auth.userId, input);
 }
 
 async function updateNote(c: HonoContext, args: Record<string, any>) {
   const auth = requireAuth(c);
   const id = assertUuid(args.id, 'note_id');
-  NoteUpdateZod.parse(args);
-  return await updateUserNote(auth.userId, id, args);
+  const input = NoteUpdateZod.parse(args);
+  return await updateUserNote(auth.userId, id, input);
 }
 
 export const noteTools: McpTool[] = [

--- a/server/notes/actions.integration.test.ts
+++ b/server/notes/actions.integration.test.ts
@@ -1,0 +1,264 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+
+const databaseUrl = process.env.NOTE_ACTIONS_TEST_DATABASE_URL;
+const databaseDescribe = databaseUrl ? describe : describe.skip;
+
+databaseDescribe('note write transactions', () => {
+  const ownerId = randomUUID();
+  const otherUserId = randomUUID();
+  const ownedArticleId = randomUUID();
+  const otherArticleId = randomUUID();
+  const outboxKeys: string[] = [];
+  let database: typeof import('../utils/drizzle').default;
+  let schema: typeof import('../drizzle/schema');
+  let actions: typeof import('./actions');
+  let operators: typeof import('drizzle-orm');
+
+  beforeAll(async () => {
+    process.env.POSTGRESQL_URL = databaseUrl;
+    [schema, actions, operators, { default: database }] = await Promise.all([
+      import('../drizzle/schema'),
+      import('./actions'),
+      import('drizzle-orm'),
+      import('../utils/drizzle'),
+    ]);
+    await database.insert(schema.users).values([
+      {
+        id: ownerId,
+        email: `note-actions-${ownerId}@example.test`,
+        username: `note-actions-${ownerId}`,
+      },
+      {
+        id: otherUserId,
+        email: `note-actions-${otherUserId}@example.test`,
+        username: `note-actions-${otherUserId}`,
+      },
+    ]);
+    await database.insert(schema.articles).values([
+      { id: ownedArticleId, authorId: ownerId, content: 'owned article' },
+      { id: otherArticleId, authorId: otherUserId, content: 'other article' },
+    ]);
+  });
+
+  afterAll(async () => {
+    const { inArray } = operators;
+    await database
+      .delete(schema.attachments)
+      .where(inArray(schema.attachments.userid, [ownerId, otherUserId]));
+    await database
+      .delete(schema.roteChanges)
+      .where(inArray(schema.roteChanges.userid, [ownerId, otherUserId]));
+    await database
+      .delete(schema.resourceStorageObjects)
+      .where(inArray(schema.resourceStorageObjects.ownerId, [ownerId, otherUserId]));
+    if (outboxKeys.length > 0) {
+      await database
+        .delete(schema.resourceCleanupOutbox)
+        .where(inArray(schema.resourceCleanupOutbox.objectKey, outboxKeys));
+    }
+    await database.delete(schema.users).where(inArray(schema.users.id, [ownerId, otherUserId]));
+    const { closeDatabase } = await import('../utils/drizzle');
+    await closeDatabase();
+  });
+
+  it('rolls back creation when the article is not owned by the author', async () => {
+    const attachmentId = randomUUID();
+    const content = `invalid-article-${randomUUID()}`;
+    await database.insert(schema.attachments).values({
+      id: attachmentId,
+      userid: ownerId,
+      roteid: null,
+      storage: 'R2',
+      url: 'https://example.test/image.png',
+      details: {
+        key: `users/${ownerId}/uploads/${attachmentId}.png`,
+        mimetype: 'image/png',
+      },
+    });
+
+    await expect(
+      actions.createUserNote(ownerId, {
+        content,
+        attachmentIds: [attachmentId],
+        articleId: otherArticleId,
+      })
+    ).rejects.toThrow('Article not found');
+
+    const [note] = await database
+      .select()
+      .from(schema.rotes)
+      .where(operators.eq(schema.rotes.content, content));
+    const [attachment] = await database
+      .select({ roteid: schema.attachments.roteid })
+      .from(schema.attachments)
+      .where(operators.eq(schema.attachments.id, attachmentId));
+    expect(note).toBeUndefined();
+    expect(attachment?.roteid).toBeNull();
+  });
+
+  it('rolls back creation when an attachment is not owned by the author', async () => {
+    const attachmentId = randomUUID();
+    const content = `invalid-attachment-${randomUUID()}`;
+    await database.insert(schema.attachments).values({
+      id: attachmentId,
+      userid: otherUserId,
+      roteid: null,
+      storage: 'R2',
+      url: 'https://example.test/foreign.png',
+      details: {
+        key: `users/${otherUserId}/uploads/${attachmentId}.png`,
+        mimetype: 'image/png',
+      },
+    });
+
+    await expect(
+      actions.createUserNote(ownerId, { content, attachmentIds: [attachmentId] })
+    ).rejects.toThrow('Some attachments not found');
+
+    const [note] = await database
+      .select()
+      .from(schema.rotes)
+      .where(operators.eq(schema.rotes.content, content));
+    expect(note).toBeUndefined();
+  });
+
+  it('creates the note, attachment binding, article binding, and one change together', async () => {
+    const attachmentId = randomUUID();
+    await database.insert(schema.attachments).values({
+      id: attachmentId,
+      userid: ownerId,
+      roteid: null,
+      storage: 'R2',
+      url: 'https://example.test/bound.png',
+      details: {
+        key: `users/${ownerId}/uploads/${attachmentId}.png`,
+        mimetype: 'image/png',
+      },
+    });
+
+    const note = await actions.createUserNote(ownerId, {
+      content: `atomic-create-${randomUUID()}`,
+      attachmentIds: [attachmentId],
+      articleId: ownedArticleId,
+    });
+    const [attachment] = await database
+      .select({ roteid: schema.attachments.roteid })
+      .from(schema.attachments)
+      .where(operators.eq(schema.attachments.id, attachmentId));
+    const changes = await database
+      .select()
+      .from(schema.roteChanges)
+      .where(operators.eq(schema.roteChanges.originid, note.id));
+
+    expect(note.articleId).toBe(ownedArticleId);
+    expect(attachment?.roteid).toBe(note.id);
+    expect(changes.map(({ action }) => action)).toEqual(['CREATE']);
+  });
+
+  it('rolls back note fields when an update references another users article', async () => {
+    const noteId = randomUUID();
+    await database.insert(schema.rotes).values({
+      id: noteId,
+      authorid: ownerId,
+      content: 'original content',
+      title: 'original title',
+    });
+
+    await expect(
+      actions.updateUserNote(ownerId, noteId, {
+        title: 'must not persist',
+        articleId: otherArticleId,
+      })
+    ).rejects.toThrow('Article not found');
+
+    const [note] = await database
+      .select({ articleId: schema.rotes.articleId, title: schema.rotes.title })
+      .from(schema.rotes)
+      .where(operators.eq(schema.rotes.id, noteId));
+    const changes = await database
+      .select()
+      .from(schema.roteChanges)
+      .where(
+        operators.and(
+          operators.eq(schema.roteChanges.originid, noteId),
+          operators.eq(schema.roteChanges.action, 'UPDATE')
+        )
+      );
+    expect(note).toEqual({ articleId: null, title: 'original title' });
+    expect(changes).toHaveLength(0);
+  });
+
+  it('deletes note data and persists cleanup jobs and the delete change atomically', async () => {
+    const noteId = randomUUID();
+    const attachmentId = randomUUID();
+    const trackedKey = `users/${ownerId}/uploads/${randomUUID()}.png`;
+    const legacyKey = `users/${ownerId}/compressed/${randomUUID()}.webp`;
+    outboxKeys.push(trackedKey, legacyKey);
+
+    await database.insert(schema.resourceStorageAccounts).values({
+      userId: ownerId,
+      usedBytes: 10n,
+    });
+    await database.insert(schema.resourceStorageObjects).values({
+      ownerId,
+      storageIdentity: 'primary',
+      objectKey: trackedKey,
+      role: 'original',
+      actualBytes: 10n,
+      billable: true,
+    });
+    await database.insert(schema.rotes).values({
+      id: noteId,
+      authorid: ownerId,
+      content: 'delete me',
+    });
+    await database.insert(schema.attachments).values({
+      id: attachmentId,
+      userid: ownerId,
+      roteid: noteId,
+      storage: 'R2',
+      url: 'https://example.test/delete.png',
+      compressUrl: 'https://example.test/delete.webp',
+      details: {
+        key: trackedKey,
+        compressKey: legacyKey,
+        mimetype: 'image/png',
+      },
+    });
+
+    const deleted = await actions.deleteUserNote(ownerId, noteId);
+
+    const [note] = await database
+      .select()
+      .from(schema.rotes)
+      .where(operators.eq(schema.rotes.id, noteId));
+    const [attachment] = await database
+      .select()
+      .from(schema.attachments)
+      .where(operators.eq(schema.attachments.id, attachmentId));
+    const [change] = await database
+      .select()
+      .from(schema.roteChanges)
+      .where(
+        operators.and(
+          operators.eq(schema.roteChanges.originid, noteId),
+          operators.eq(schema.roteChanges.action, 'DELETE')
+        )
+      );
+    const jobs = await database
+      .select({ objectKey: schema.resourceCleanupOutbox.objectKey })
+      .from(schema.resourceCleanupOutbox)
+      .where(operators.inArray(schema.resourceCleanupOutbox.objectKey, [trackedKey, legacyKey]));
+
+    expect(deleted.id).toBe(noteId);
+    expect(note).toBeUndefined();
+    expect(attachment).toBeUndefined();
+    expect(change?.roteid).toBeNull();
+    expect(jobs.map(({ objectKey }) => objectKey).sort()).toEqual([legacyKey, trackedKey].sort());
+  });
+
+  it('does not report success for a missing note', async () => {
+    await expect(actions.deleteUserNote(ownerId, randomUUID())).rejects.toThrow('Note not found');
+  });
+});

--- a/server/notes/actions.ts
+++ b/server/notes/actions.ts
@@ -1,115 +1,277 @@
+import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
+import type { z } from 'zod';
+import { articles, attachments, roteChanges, rotes, users, type Rote } from '../drizzle/schema';
 import {
-  createRote,
+  collectOwnedAttachmentObjectKeys,
+  enqueueStorageObjectCleanup,
+  releaseStorageObjectReferences,
+} from '../resources/service';
+import { notifyPublicNoteCreated } from '../utils/adminHooks';
+import { trackBackgroundTask } from '../utils/backgroundTask';
+import {
   deleteEmbeddingsForSource,
-  deleteRote,
-  deleteRoteAttachmentsByRoteId,
   deleteRoteLinkPreviewsByRoteId,
-  editRote,
   enqueueEmbeddingJob,
   findRoteById,
-  setNoteArticleId,
 } from '../utils/dbMethods';
-import { extractUrlsFromContent, parseAndStoreRoteLinkPreviews } from '../utils/linkPreview';
-import { trackBackgroundTask } from '../utils/backgroundTask';
+import db from '../utils/drizzle';
+import { validateRoteAttachmentDetails } from '../utils/fileValidation';
+import { parseAndStoreRoteLinkPreviews } from '../utils/linkPreview';
+import { NoteCreateZod, NoteUpdateZod } from '../utils/zod';
 
-type CreateUserNoteInput = {
-  content: string;
-  title?: string;
-  state?: string;
-  type?: string;
-  tags: string[];
-  pin?: boolean;
-  archived?: boolean;
-  editor?: string;
-  articleId?: string | null;
-  articleIds?: string[];
-};
+export type CreateUserNoteInput = z.infer<typeof NoteCreateZod>;
+export type UpdateUserNoteInput = z.infer<typeof NoteUpdateZod>;
 
-type UpdateUserNoteInput = Record<string, any> & {
-  articleId?: string | null;
-  articleIds?: string[];
-};
+type WritableNoteFields = Pick<
+  Rote,
+  'archived' | 'content' | 'editor' | 'pin' | 'state' | 'tags' | 'title' | 'type'
+>;
 
-function firstArticleId(input: { articleId?: unknown; articleIds?: unknown }): string | null {
+function createArticleId(input: CreateUserNoteInput): string | null {
   if (typeof input.articleId === 'string') return input.articleId;
-  if (Array.isArray(input.articleIds) && input.articleIds.length > 0) return input.articleIds[0];
-  return null;
+  return input.articleIds?.[0] ?? null;
+}
+
+function updatedArticleId(input: UpdateUserNoteInput): string | null | undefined {
+  if (Object.prototype.hasOwnProperty.call(input, 'articleId')) {
+    return input.articleId ?? null;
+  }
+  if (Object.prototype.hasOwnProperty.call(input, 'articleIds')) {
+    return input.articleIds?.[0] ?? null;
+  }
+  return undefined;
+}
+
+function updateFields(input: UpdateUserNoteInput): Partial<WritableNoteFields> {
+  return {
+    ...(input.archived !== undefined ? { archived: input.archived } : {}),
+    ...(input.content !== undefined ? { content: input.content } : {}),
+    ...(input.editor !== undefined ? { editor: input.editor } : {}),
+    ...(input.pin !== undefined ? { pin: input.pin } : {}),
+    ...(input.state !== undefined ? { state: input.state } : {}),
+    ...(input.tags !== undefined ? { tags: input.tags } : {}),
+    ...(input.title !== undefined ? { title: input.title } : {}),
+    ...(input.type !== undefined ? { type: input.type } : {}),
+  };
+}
+
+async function assertOwnedArticle(
+  transaction: Parameters<Parameters<typeof db.transaction>[0]>[0],
+  userId: string,
+  articleId: string | null | undefined
+) {
+  if (!articleId) return;
+  const [article] = await transaction
+    .select({ id: articles.id })
+    .from(articles)
+    .where(and(eq(articles.id, articleId), eq(articles.authorId, userId)))
+    .limit(1);
+  if (!article) throw new Error('Article not found or permission denied');
+}
+
+function scheduleCreatedEffects(note: Rote) {
+  trackBackgroundTask(
+    enqueueEmbeddingJob('rote', note.id, note.authorid),
+    'rote_embedding_enqueue_failed'
+  );
+  if (!note.articleId) {
+    trackBackgroundTask(
+      parseAndStoreRoteLinkPreviews(note.id, note.content),
+      'link_preview_create_failed'
+    );
+  }
+  if (note.state === 'public') {
+    trackBackgroundTask(notifyPublicNoteCreated(note), 'admin_hook_public_note_failed');
+  }
+}
+
+function scheduleUpdatedEffects(note: Rote, previousState: string, refreshLinkPreviews: boolean) {
+  trackBackgroundTask(
+    enqueueEmbeddingJob('rote', note.id, note.authorid),
+    'rote_embedding_enqueue_failed'
+  );
+  if (refreshLinkPreviews) {
+    trackBackgroundTask(
+      (async () => {
+        await deleteRoteLinkPreviewsByRoteId(note.id);
+        if (!note.articleId) await parseAndStoreRoteLinkPreviews(note.id, note.content);
+      })(),
+      'link_preview_update_failed'
+    );
+  }
+  if (previousState !== 'public' && note.state === 'public') {
+    trackBackgroundTask(notifyPublicNoteCreated(note), 'admin_hook_public_note_failed');
+  }
 }
 
 export async function createUserNote(userId: string, input: CreateUserNoteInput) {
-  const result = await createRote({
-    content: input.content,
-    title: input.title || '',
-    state: input.state || 'private',
-    type: input.type || 'rote',
-    tags: input.tags,
-    pin: !!input.pin,
-    archived: !!input.archived,
-    editor: input.editor,
-    authorid: userId,
+  const articleId = createArticleId(input);
+  const attachmentIds = input.attachmentIds ?? [];
+  const rote = await db.transaction(async (transaction) => {
+    const [user] = await transaction
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.id, userId))
+      .limit(1)
+      .for('update');
+    if (!user) throw new Error('User not found');
+
+    await assertOwnedArticle(transaction, userId, articleId);
+
+    const attachmentRows =
+      attachmentIds.length > 0
+        ? await transaction
+            .select({ id: attachments.id, details: attachments.details })
+            .from(attachments)
+            .where(
+              and(
+                inArray(attachments.id, attachmentIds),
+                eq(attachments.userid, userId),
+                isNull(attachments.roteid)
+              )
+            )
+            .for('update')
+        : [];
+    if (attachmentRows.length !== attachmentIds.length) {
+      throw new Error('Some attachments not found or permission denied');
+    }
+    validateRoteAttachmentDetails(attachmentRows);
+
+    const [created] = await transaction
+      .insert(rotes)
+      .values({
+        articleId,
+        archived: input.archived ?? false,
+        authorid: userId,
+        content: input.content,
+        editor: input.editor ?? 'normal',
+        pin: input.pin ?? false,
+        state: input.state ?? 'private',
+        tags: input.tags ?? [],
+        title: input.title ?? '',
+        type: input.type ?? 'rote',
+        createdAt: sql`now()`,
+        updatedAt: sql`now()`,
+      })
+      .returning();
+    if (!created) throw new Error('Failed to create note');
+
+    await Promise.all(
+      attachmentIds.map((attachmentId, sortIndex) =>
+        transaction
+          .update(attachments)
+          .set({ roteid: created.id, sortIndex, updatedAt: new Date() })
+          .where(eq(attachments.id, attachmentId))
+      )
+    );
+    await transaction.insert(roteChanges).values({
+      originid: created.id,
+      roteid: created.id,
+      action: 'CREATE',
+      userid: userId,
+      createdAt: sql`now()`,
+    });
+    return created;
   });
 
-  trackBackgroundTask(
-    enqueueEmbeddingJob('rote', result.id, userId),
-    'rote_embedding_enqueue_failed'
-  );
-
-  const articleId = firstArticleId(input);
-  if (articleId) {
-    await setNoteArticleId(result.id, articleId, userId);
-    return result;
-  }
-
-  trackBackgroundTask(
-    parseAndStoreRoteLinkPreviews(result.id, result.content),
-    'link_preview_create_failed'
-  );
-  return result;
+  const note = (await findRoteById(rote.id, userId)) ?? rote;
+  scheduleCreatedEffects(note);
+  return note;
 }
 
 export async function updateUserNote(userId: string, id: string, input: UpdateUserNoteInput) {
-  await editRote({ ...input, id, authorid: userId });
-  trackBackgroundTask(enqueueEmbeddingJob('rote', id, userId), 'rote_embedding_enqueue_failed');
+  const articleId = updatedArticleId(input);
+  const fields = updateFields(input);
+  const result = await db.transaction(async (transaction) => {
+    const [existing] = await transaction
+      .select()
+      .from(rotes)
+      .where(and(eq(rotes.id, id), eq(rotes.authorid, userId)))
+      .limit(1)
+      .for('update');
+    if (!existing) throw new Error('Note not found');
 
-  let articleIdToSet: string | null | undefined;
-  if ('articleId' in input) {
-    articleIdToSet =
-      typeof input.articleId === 'string' ? input.articleId : (input.articleId ?? null);
-  } else if (Array.isArray(input.articleIds)) {
-    articleIdToSet = input.articleIds.length > 0 ? input.articleIds[0] : null;
-  }
+    await assertOwnedArticle(transaction, userId, articleId);
+    const [updated] = await transaction
+      .update(rotes)
+      .set({
+        ...fields,
+        ...(articleId !== undefined ? { articleId } : {}),
+        updatedAt: new Date(),
+      })
+      .where(and(eq(rotes.id, id), eq(rotes.authorid, userId)))
+      .returning();
+    if (!updated) throw new Error('Note not found');
 
-  if (articleIdToSet !== undefined) {
-    await setNoteArticleId(id, articleIdToSet, userId);
-  }
+    await transaction.insert(roteChanges).values({
+      originid: id,
+      roteid: id,
+      action: 'UPDATE',
+      userid: userId,
+      createdAt: sql`now()`,
+    });
+    return { note: updated, previousState: existing.state };
+  });
 
-  const data = await findRoteById(id, userId);
-  const hasArticle = Boolean(data?.articleId || data?.article);
-  const contentProvided = Object.prototype.hasOwnProperty.call(input, 'content');
-  const contentForPreview = contentProvided ? input.content : data?.content;
-
-  if (hasArticle && articleIdToSet !== undefined) {
-    await deleteRoteLinkPreviewsByRoteId(id);
-  } else if (
-    (contentProvided || articleIdToSet !== undefined) &&
-    typeof contentForPreview === 'string'
-  ) {
-    const urls = extractUrlsFromContent(contentForPreview);
-    await deleteRoteLinkPreviewsByRoteId(id);
-    if (urls.length > 0 && !hasArticle) {
-      trackBackgroundTask(
-        parseAndStoreRoteLinkPreviews(id, contentForPreview),
-        'link_preview_update_failed'
-      );
-    }
-  }
-
-  return data;
+  const note = (await findRoteById(id, userId)) ?? result.note;
+  scheduleUpdatedEffects(
+    note,
+    result.previousState,
+    input.content !== undefined || articleId !== undefined
+  );
+  return note;
 }
 
 export async function deleteUserNote(userId: string, id: string) {
-  const data = await deleteRote({ id, authorid: userId });
-  await deleteRoteAttachmentsByRoteId(id, userId);
+  const deleted = await db.transaction(async (transaction) => {
+    const [user] = await transaction
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.id, userId))
+      .limit(1)
+      .for('update');
+    if (!user) throw new Error('User not found');
+
+    const [note] = await transaction
+      .select()
+      .from(rotes)
+      .where(and(eq(rotes.id, id), eq(rotes.authorid, userId)))
+      .limit(1)
+      .for('update');
+    if (!note) throw new Error('Note not found');
+
+    const attachmentRows = await transaction
+      .select({ details: attachments.details })
+      .from(attachments)
+      .where(eq(attachments.roteid, id))
+      .for('update');
+    const objectKeys = attachmentRows.flatMap(({ details }) =>
+      collectOwnedAttachmentObjectKeys(details, userId)
+    );
+    const trackedKeys = new Set(
+      await releaseStorageObjectReferences(userId, objectKeys, transaction)
+    );
+    await enqueueStorageObjectCleanup(
+      transaction,
+      objectKeys.filter((key) => !trackedKeys.has(key))
+    );
+
+    await transaction.insert(roteChanges).values({
+      originid: id,
+      roteid: id,
+      action: 'DELETE',
+      userid: userId,
+      createdAt: sql`now()`,
+    });
+    await transaction.delete(attachments).where(eq(attachments.roteid, id));
+    const [removed] = await transaction
+      .delete(rotes)
+      .where(and(eq(rotes.id, id), eq(rotes.authorid, userId)))
+      .returning();
+    if (!removed) throw new Error('Note not found');
+    return removed;
+  });
+
   trackBackgroundTask(deleteEmbeddingsForSource('rote', id), 'rote_embedding_delete_failed');
-  return data;
+  return deleted;
 }

--- a/server/route/v2/note.ts
+++ b/server/route/v2/note.ts
@@ -1,16 +1,9 @@
 import { Hono } from 'hono';
 import type { User } from '../../drizzle/schema';
 import { authenticateJWT, optionalJWT } from '../../middleware/jwtAuth';
+import { createUserNote, deleteUserNote, updateUserNote } from '../../notes/actions';
 import type { HonoContext, HonoVariables } from '../../types/hono';
 import {
-  bindAttachmentsToRote,
-  createRote,
-  deleteEmbeddingsForSource,
-  deleteRote,
-  deleteRoteAttachmentsByRoteId,
-  deleteRoteLinkPreviewsByRoteId,
-  editRote,
-  enqueueEmbeddingJob,
   findMyRandomRote,
   findMyRote,
   findPublicRote,
@@ -22,9 +15,7 @@ import {
   searchMyRotes,
   searchPublicRotes,
   searchUserPublicRotes,
-  setNoteArticleId,
 } from '../../utils/dbMethods';
-import { extractUrlsFromContent, parseAndStoreRoteLinkPreviews } from '../../utils/linkPreview';
 import { bodyTypeCheck, createResponse, isValidUUID } from '../../utils/main';
 import { NoteCreateZod, NoteUpdateZod, SearchKeywordZod } from '../../utils/zod';
 
@@ -34,68 +25,10 @@ const notesRouter = new Hono<{ Variables: HonoVariables }>();
 // 创建笔记
 notesRouter.post('/', authenticateJWT, bodyTypeCheck, async (c: HonoContext) => {
   const body = await c.req.json();
-  // 验证输入长度
-  NoteCreateZod.parse(body);
-
-  const { title, content, type, tags, state, archived, pin, editor, attachmentIds } = body as {
-    title?: string;
-    content: string;
-    type?: string;
-    tags?: string[];
-    state?: string;
-    archived?: boolean;
-    pin?: boolean;
-    editor?: string;
-    attachmentIds?: string[];
-    articleId?: string;
-    articleIds?: string[]; // 兼容旧客户端：严格单篇后最多 1 个
-  };
+  const input = NoteCreateZod.parse(body);
   const user = c.get('user') as User;
-
-  if (!content) {
-    throw new Error('Content is required');
-  }
-
-  const rote = await createRote({
-    title,
-    content,
-    type,
-    tags,
-    state,
-    pin: !!pin,
-    editor,
-    archived: !!archived,
-    authorid: user.id,
-  });
-
-  // 如果传入了附件ID，则绑定到新建的笔记
-  if (Array.isArray(attachmentIds) && attachmentIds.length > 0) {
-    await bindAttachmentsToRote(user.id, rote.id, attachmentIds);
-  }
-
-  // 绑定文章（优先 articleId；兼容 articleIds，取第一个）
-  const articleIdToSet =
-    typeof (body as any).articleId === 'string'
-      ? (body as any).articleId
-      : Array.isArray((body as any).articleIds) && (body as any).articleIds.length > 0
-        ? (body as any).articleIds[0]
-        : null;
-  if (articleIdToSet) {
-    await setNoteArticleId(rote.id, articleIdToSet, user.id);
-  }
-
-  if (!articleIdToSet) {
-    void parseAndStoreRoteLinkPreviews(rote.id, rote.content).catch((error) => {
-      console.error('Failed to parse link previews:', error);
-    });
-  }
-
-  // 重新查询以获取最新关联数据（附件/文章等）
-  const fullRote = await findRoteById(rote.id, user.id);
-  void enqueueEmbeddingJob('rote', rote.id, user.id).catch((error) => {
-    console.error('Failed to enqueue rote embedding job:', error);
-  });
-  return c.json(createResponse(fullRote), 201);
+  const note = await createUserNote(user.id, input);
+  return c.json(createResponse(note), 201);
 });
 
 // 获取随机笔记 - 移到前面避免被当作ID匹配
@@ -525,51 +458,8 @@ notesRouter.put('/:id', authenticateJWT, bodyTypeCheck, async (c: HonoContext) =
     throw new Error('Invalid or missing ID');
   }
 
-  // 验证输入长度
-  NoteUpdateZod.parse(body);
-
-  // 确保使用路由参数中的 id，而不是 body 中的 id（防止不一致）
-  await editRote({ ...body, id, authorid: user.id });
-
-  // 更新文章绑定（优先 articleId；兼容 articleIds，取第一个）
-  let articleIdToSet: string | null | undefined;
-  if ('articleId' in (body as any)) {
-    const articleId = (body as any).articleId;
-    articleIdToSet = typeof articleId === 'string' ? articleId : (articleId ?? null);
-  } else if (Array.isArray((body as any).articleIds)) {
-    articleIdToSet = (body as any).articleIds.length > 0 ? (body as any).articleIds[0] : null;
-  }
-
-  if (articleIdToSet !== undefined) {
-    await setNoteArticleId(id, articleIdToSet, user.id);
-  }
-
-  // 重新获取最新数据（包含更新后的 article）
-  const data = await findRoteById(id, user.id);
-  void enqueueEmbeddingJob('rote', id, user.id).catch((error) => {
-    console.error('Failed to enqueue rote embedding job:', error);
-  });
-
-  const hasArticle = Boolean(data?.articleId || data?.article);
-  const contentProvided = Object.prototype.hasOwnProperty.call(body, 'content');
-  const contentForPreview = contentProvided ? (body as any).content : data?.content;
-
-  if (hasArticle && articleIdToSet !== undefined) {
-    await deleteRoteLinkPreviewsByRoteId(id);
-  } else if (
-    (contentProvided || articleIdToSet !== undefined) &&
-    typeof contentForPreview === 'string'
-  ) {
-    const urls = extractUrlsFromContent(contentForPreview);
-    if (urls.length === 0 || hasArticle) {
-      await deleteRoteLinkPreviewsByRoteId(id);
-    } else {
-      await deleteRoteLinkPreviewsByRoteId(id);
-      void parseAndStoreRoteLinkPreviews(id, contentForPreview).catch((error) => {
-        console.error('Failed to parse link previews:', error);
-      });
-    }
-  }
+  const input = NoteUpdateZod.parse(body);
+  const data = await updateUserNote(user.id, id, input);
 
   return c.json(createResponse(data), 200);
 });
@@ -578,12 +468,11 @@ notesRouter.put('/:id', authenticateJWT, bodyTypeCheck, async (c: HonoContext) =
 notesRouter.delete('/:id', authenticateJWT, async (c: HonoContext) => {
   const user = c.get('user') as User;
   const id = c.req.param('id');
+  if (!id || !isValidUUID(id)) {
+    throw new Error('Invalid or missing ID');
+  }
 
-  const data = await deleteRote({ id, authorid: user.id });
-  await deleteRoteAttachmentsByRoteId(id, user.id);
-  void deleteEmbeddingsForSource('rote', id).catch((error) => {
-    console.error('Failed to delete rote embeddings:', error);
-  });
+  const data = await deleteUserNote(user.id, id);
 
   return c.json(createResponse(data), 200);
 });


### PR DESCRIPTION
## Summary
- route REST and MCP note writes through one application service
- commit note rows, article and attachment ownership checks, bindings, and change history atomically
- enqueue tracked and legacy attachment objects through the existing persistent resource cleanup outbox before deleting attachment rows
- run link previews, embeddings, and public-note notifications only after commit

## Tests
- `bun run lint`
- `bun run build`
- `NOTE_ACTIONS_TEST_DATABASE_URL=... bun test notes/actions.integration.test.ts resources/worker.test.ts resources/service.test.ts utils/dbMethods/noteHooks.test.ts` (24 passed)

## Notes
- no database migration is needed because `develop` already provides `resource_cleanup_outbox`
- the broad `bun test` command also enters live AI/pgvector acceptance tests; those report environment-dependent failures unrelated to this change