### PR TITLE
Fix OpenKey review regressions

### DIFF
--- a/doc/userguide/API-KEY-GUIDE.md
+++ b/doc/userguide/API-KEY-GUIDE.md
@@ -100,7 +100,7 @@ The legacy GET endpoint accepts these query parameters:
 - `openkey`: YOUR_API_KEY (Required)
 - `content`: Note content (required, max 1,000,000 characters)
 - `state`: Note state (private or public, defaults to private)
-- `type`: Note type (defaults to `rote`)
+- `type`: Note type (defaults to `Rote`)
 - `title`: Optional title
 - `tag`: Tags (can be multiple, e.g., `tag=tag1&tag=tag2`, each tag max 50 characters, max 20 tags)
 - `pin`: Whether to pin the note (`true`, `false`, `1`, or `0`)

--- a/server/notes/actions.integration.test.ts
+++ b/server/notes/actions.integration.test.ts
@@ -141,6 +141,9 @@ databaseDescribe('note write transactions', () => {
       content: `atomic-create-${randomUUID()}`,
       attachmentIds: [attachmentId],
       articleId: ownedArticleId,
+      state: '',
+      tags: [' work ', '   '],
+      type: '',
     });
     const [attachment] = await database
       .select({ roteid: schema.attachments.roteid })
@@ -154,6 +157,9 @@ databaseDescribe('note write transactions', () => {
     expect(note.articleId).toBe(ownedArticleId);
     expect(attachment?.roteid).toBe(note.id);
     expect(changes.map(({ action }) => action)).toEqual(['CREATE']);
+    expect(note.state).toBe('private');
+    expect(note.tags).toEqual(['work']);
+    expect(note.type).toBe('Rote');
   });
 
   it('rolls back note fields when an update references another users article', async () => {

--- a/server/notes/actions.ts
+++ b/server/notes/actions.ts
@@ -55,6 +55,10 @@ function updateFields(input: UpdateUserNoteInput): Partial<WritableNoteFields> {
   };
 }
 
+function normalizedCreateTags(tags: string[] | undefined): string[] {
+  return (tags ?? []).map((tag) => tag.trim()).filter((tag) => tag.length > 0);
+}
+
 async function assertOwnedArticle(
   transaction: Parameters<Parameters<typeof db.transaction>[0]>[0],
   userId: string,
@@ -146,10 +150,10 @@ export async function createUserNote(userId: string, input: CreateUserNoteInput)
         content: input.content,
         editor: input.editor ?? 'normal',
         pin: input.pin ?? false,
-        state: input.state ?? 'private',
-        tags: input.tags ?? [],
+        state: input.state || 'private',
+        tags: normalizedCreateTags(input.tags),
         title: input.title ?? '',
-        type: input.type ?? 'rote',
+        type: input.type || 'Rote',
         createdAt: sql`now()`,
         updatedAt: sql`now()`,
       })

--- a/server/route/v2/openKey/errorCodes.json
+++ b/server/route/v2/openKey/errorCodes.json
@@ -1,0 +1,3 @@
+{
+  "invalidBooleanParameterPrefix": "invalid_boolean_parameter:"
+}

--- a/server/route/v2/openKey/notes.integration.test.ts
+++ b/server/route/v2/openKey/notes.integration.test.ts
@@ -12,6 +12,8 @@ type NoteResponse = {
     content: string;
     id: string;
     pin: boolean;
+    state: string;
+    tags: string[];
     title: string | null;
     type: string | null;
   };
@@ -89,13 +91,20 @@ databaseDescribe('OpenKey note routes', () => {
   });
 
   it('creates notes through the recommended route without deprecation headers', async () => {
-    const response = await post('/notes', { content: `modern-${randomUUID()}` });
+    const response = await post('/notes', {
+      content: `modern-${randomUUID()}`,
+      state: '',
+      tags: [' work ', '   '],
+      type: '',
+    });
     const body = (await response.json()) as NoteResponse;
 
     expect(response.status).toBe(201);
     expect(response.headers.get('Deprecation')).toBeNull();
     expect(response.headers.get('Link')).toBeNull();
-    expect(body.data.type).toBe('rote');
+    expect(body.data.type).toBe('Rote');
+    expect(body.data.state).toBe('private');
+    expect(body.data.tags).toEqual(['work']);
     expect(body.data.pin).toBe(false);
     expect(body.data.archived).toBe(false);
   });
@@ -111,7 +120,7 @@ databaseDescribe('OpenKey note routes', () => {
     expect(response.status).toBe(201);
     expect(response.headers.get('Deprecation')).toBe('true');
     expect(response.headers.get('Link')).toBe('</v2/api/openkey/notes>; rel="successor-version"');
-    expect(body.data.type).toBe('rote');
+    expect(body.data.type).toBe('Rote');
     expect(body.data.pin).toBe(true);
     expect(body.data.archived).toBe(true);
   });
@@ -134,10 +143,25 @@ databaseDescribe('OpenKey note routes', () => {
 
       expect(response.status).toBe(201);
       expect(response.headers.get('Deprecation')).toBe('true');
-      expect(body.data.type).toBe('rote');
+      expect(body.data.type).toBe('Rote');
       expect(body.data.pin).toBe(expected);
       expect(body.data.archived).toBe(expected);
     }
+  });
+
+  it('preserves defaults when legacy GET includes empty state and type values', async () => {
+    const query = new URLSearchParams({
+      openkey: openKeyId,
+      content: `legacy-empty-defaults-${randomUUID()}`,
+      state: '',
+      type: '',
+    });
+    const response = await request(`/notes/create?${query}`);
+    const body = (await response.json()) as NoteResponse;
+
+    expect(response.status).toBe(201);
+    expect(body.data.state).toBe('private');
+    expect(body.data.type).toBe('Rote');
   });
 
   it('rejects unsupported legacy GET booleans', async () => {
@@ -150,7 +174,7 @@ databaseDescribe('OpenKey note routes', () => {
     const body = (await response.json()) as { message: string };
 
     expect(response.status).toBe(400);
-    expect(body.message).toBe('Invalid pin parameter: expected true, false, 1, or 0');
+    expect(body.message).toBe('invalid_boolean_parameter:pin');
   });
 
   it('updates and deletes notes through the shared application service', async () => {

--- a/server/route/v2/openKey/shared.test.ts
+++ b/server/route/v2/openKey/shared.test.ts
@@ -13,9 +13,7 @@ describe('OpenKey route input parsing', () => {
   });
 
   it('rejects unsupported legacy boolean values', () => {
-    expect(() => parseLegacyBoolean('yes', 'pin')).toThrow(
-      'Invalid pin parameter: expected true, false, 1, or 0'
-    );
+    expect(() => parseLegacyBoolean('yes', 'pin')).toThrow('invalid_boolean_parameter:pin');
   });
 
   it('only accepts whole pagination numbers at or above the minimum', () => {

--- a/server/route/v2/openKey/shared.ts
+++ b/server/route/v2/openKey/shared.ts
@@ -1,5 +1,6 @@
 import type { HonoContext, HonoVariables } from '../../../types/hono';
 import { z } from 'zod';
+import openKeyErrors from './errorCodes.json';
 
 const UuidZod = z.string().uuid();
 
@@ -47,9 +48,12 @@ export function parseLegacyBoolean(
   parameter: string
 ): boolean | undefined {
   if (value === undefined) return undefined;
-  if (value === 'true' || value === '1') return true;
-  if (value === 'false' || value === '0') return false;
-  throw new Error(`Invalid ${parameter} parameter: expected true, false, 1, or 0`);
+  const parsed = z
+    .enum(['true', 'false', '1', '0'], {
+      error: openKeyErrors.invalidBooleanParameterPrefix + parameter,
+    })
+    .parse(value);
+  return parsed === 'true' || parsed === '1';
 }
 
 export function processTags(values: readonly string[]): string[] {


### PR DESCRIPTION
## Summary
- replace legacy boolean validation prose with a stable client-localizable error code
- normalize create-note tags in the shared application service
- preserve defaults for empty `state` and `type` values
- restore canonical `type: Rote` casing across storage, DTO, and API documentation

## Review feedback
Addresses the three inline findings on #335:
- https://github.com/Rabithua/Rote/pull/335#discussion_r3838855162
- https://github.com/Rabithua/Rote/pull/335#discussion_r3838855166
- https://github.com/Rabithua/Rote/pull/335#discussion_r3838855167

## Validation
- `bun run lint`
- `bun run build`
- `bun test route/v2/openKey/shared.test.ts` (8 passed)
- `OPENKEY_NOTES_TEST_DATABASE_URL=postgres://rote:***@localhost:5433/rote bun test route/v2/openKey/notes.integration.test.ts` (6 passed)
- `NOTE_ACTIONS_TEST_DATABASE_URL=postgres://rote:***@localhost:5433/rote bun test notes/actions.integration.test.ts` (6 passed)
- `git diff --check`

## Scope
- backend and OpenKey API documentation only
- no frontend structure or loading changes
- no CI changes