### PR TITLE
Treat OpenKey GET creation as a supported convenience endpoint

### DIFF
--- a/doc/userguide/API-ENDPOINTS.md
+++ b/doc/userguide/API-ENDPOINTS.md
@@ -180,7 +180,7 @@ AI 与向量存储默认关闭，需要管理员在后台配置供应商并显�
 
 | 路径                    | 方法   | 认证    | 描述                         |
 | ----------------------- | ------ | ------- | ---------------------------- |
-| `/openkey/notes/create` | GET    | API Key | 创建笔记（兼容）             |
+| `/openkey/notes/create` | GET    | API Key | 创建笔记（便捷 URL）         |
 | `/openkey/notes`        | POST   | API Key | 创建笔记                     |
 | `/openkey/notes`        | GET    | API Key | 获取笔记列表                 |
 | `/openkey/notes/search` | GET    | API Key | 搜索笔记                     |

--- a/doc/userguide/API-KEY-GUIDE.md
+++ b/doc/userguide/API-KEY-GUIDE.md
@@ -49,7 +49,7 @@ When generating or updating an API Key, you can specify which permissions it sho
   "content": "Note content (required, max 1,000,000 characters)",
   "title": "Optional title (max 200 characters)",
   "state": "private|public",
-  "type": "rote|article|other",
+  "type": "Rote|article|other",
   "tags": ["tag1", "tag2"], // Each tag max 50 characters, max 20 tags
   "pin": false,
   "articleId": "optional-article-uuid" // Bind to an existing article
@@ -67,7 +67,7 @@ When generating or updating an API Key, you can specify which permissions it sho
     "content": "Note content",
     "title": "Optional title",
     "state": "private",
-    "type": "rote",
+    "type": "Rote",
     "tags": ["tag1", "tag2"],
     "pin": false,
     "authorid": "user_id",
@@ -79,21 +79,28 @@ When generating or updating an API Key, you can specify which permissions it sho
 
 **Required Permission**: `SENDROTE`
 
-### 2. Create Note (Legacy/Compatibility)
+### 2. Create Note (Convenient URL and Legacy POST)
 
 **Endpoints**:
 
-- `GET /v2/api/openkey/notes/create`
-- `POST /v2/api/openkey/notes/create`
+- `GET /v2/api/openkey/notes/create` (supported convenient URL)
+- `POST /v2/api/openkey/notes/create` (legacy compatibility)
 
-Both compatibility endpoints remain available, but new integrations should use
-`POST /v2/api/openkey/notes`. Successful compatibility responses include:
+The GET endpoint is intentionally supported for browser bookmarks, Shortcuts, webhooks, and
+URL-only automation. Responses include `Cache-Control: no-store` so they are not cached.
+
+Because its query string contains the OpenKey and note content, only use the convenient URL in
+trusted environments and avoid sensitive content that could be retained in browser history or
+intermediary logs. Structured integrations should use `POST /v2/api/openkey/notes`.
+
+The legacy POST endpoint remains available, but new POST integrations should use
+`POST /v2/api/openkey/notes`. Successful legacy POST responses include:
 
 - `Deprecation: true`
 - `Link: </v2/api/openkey/notes>; rel="successor-version"`
 
 The legacy POST endpoint accepts the same JSON body as the recommended POST endpoint.
-The legacy GET endpoint accepts these query parameters:
+The convenient GET endpoint accepts these query parameters:
 
 **Query Parameters**:
 

--- a/server/route/v2/openKey/notes.integration.test.ts
+++ b/server/route/v2/openKey/notes.integration.test.ts
@@ -125,7 +125,7 @@ databaseDescribe('OpenKey note routes', () => {
     expect(body.data.archived).toBe(true);
   });
 
-  it('parses all supported legacy GET booleans without changing defaults', async () => {
+  it('supports all documented convenience GET booleans without changing defaults', async () => {
     for (const [value, expected] of [
       ['true', true],
       ['1', true],
@@ -134,7 +134,7 @@ databaseDescribe('OpenKey note routes', () => {
     ] as const) {
       const query = new URLSearchParams({
         openkey: openKeyId,
-        content: `legacy-get-${value}-${randomUUID()}`,
+        content: `convenience-get-${value}-${randomUUID()}`,
         pin: value,
         archived: value,
       });
@@ -142,17 +142,19 @@ databaseDescribe('OpenKey note routes', () => {
       const body = (await response.json()) as NoteResponse;
 
       expect(response.status).toBe(201);
-      expect(response.headers.get('Deprecation')).toBe('true');
+      expect(response.headers.get('Deprecation')).toBeNull();
+      expect(response.headers.get('Link')).toBeNull();
+      expect(response.headers.get('Cache-Control')).toBe('no-store');
       expect(body.data.type).toBe('Rote');
       expect(body.data.pin).toBe(expected);
       expect(body.data.archived).toBe(expected);
     }
   });
 
-  it('preserves defaults when legacy GET includes empty state and type values', async () => {
+  it('preserves defaults when convenience GET includes empty state and type values', async () => {
     const query = new URLSearchParams({
       openkey: openKeyId,
-      content: `legacy-empty-defaults-${randomUUID()}`,
+      content: `convenience-empty-defaults-${randomUUID()}`,
       state: '',
       type: '',
     });
@@ -164,7 +166,7 @@ databaseDescribe('OpenKey note routes', () => {
     expect(body.data.type).toBe('Rote');
   });
 
-  it('rejects unsupported legacy GET booleans', async () => {
+  it('rejects unsupported convenience GET booleans', async () => {
     const query = new URLSearchParams({
       openkey: openKeyId,
       content: `invalid-boolean-${randomUUID()}`,

--- a/server/route/v2/openKey/notes.ts
+++ b/server/route/v2/openKey/notes.ts
@@ -9,8 +9,9 @@ import { NoteCreateZod, NoteUpdateZod, SearchKeywordZod } from '../../../utils/z
 import {
   assertUuid,
   buildNoteFilter,
-  markLegacyNoteCreate,
-  parseLegacyBoolean,
+  markConvenienceNoteCreate,
+  markLegacyNoteCreatePost,
+  parseBooleanQueryParameter,
   parseOptionalInteger,
   processTags,
   requireOpenKey,
@@ -42,15 +43,15 @@ async function createNoteFromBody(c: HonoContext) {
 }
 
 router.get('/notes/create', requireOpenKeyPerm('SENDROTE'), async (c: HonoContext) => {
-  markLegacyNoteCreate(c);
+  markConvenienceNoteCreate(c);
   const input = NoteCreateZod.parse({
     content: c.req.query('content'),
     title: c.req.query('title'),
     state: c.req.query('state'),
     type: c.req.query('type'),
     tags: queryTags(c),
-    pin: parseLegacyBoolean(c.req.query('pin'), 'pin'),
-    archived: parseLegacyBoolean(c.req.query('archived'), 'archived'),
+    pin: parseBooleanQueryParameter(c.req.query('pin'), 'pin'),
+    archived: parseBooleanQueryParameter(c.req.query('archived'), 'archived'),
     editor: c.req.query('editor'),
     articleId: c.req.query('articleId'),
   });
@@ -59,7 +60,7 @@ router.get('/notes/create', requireOpenKeyPerm('SENDROTE'), async (c: HonoContex
 });
 
 router.post('/notes/create', requireOpenKeyPerm('SENDROTE'), async (c: HonoContext) => {
-  markLegacyNoteCreate(c);
+  markLegacyNoteCreatePost(c);
   return createNoteFromBody(c);
 });
 

--- a/server/route/v2/openKey/shared.test.ts
+++ b/server/route/v2/openKey/shared.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'bun:test';
-import { parseLegacyBoolean, parseOptionalInteger, processTags } from './shared';
+import { Hono } from 'hono';
+import {
+  markConvenienceNoteCreate,
+  markLegacyNoteCreatePost,
+  parseBooleanQueryParameter,
+  parseOptionalInteger,
+  processTags,
+} from './shared';
 
 describe('OpenKey route input parsing', () => {
   it.each([
@@ -8,12 +15,12 @@ describe('OpenKey route input parsing', () => {
     ['false', false],
     ['0', false],
     [undefined, undefined],
-  ] as const)('parses legacy boolean %s', (value, expected) => {
-    expect(parseLegacyBoolean(value, 'pin')).toBe(expected);
+  ] as const)('parses query boolean %s', (value, expected) => {
+    expect(parseBooleanQueryParameter(value, 'pin')).toBe(expected);
   });
 
-  it('rejects unsupported legacy boolean values', () => {
-    expect(() => parseLegacyBoolean('yes', 'pin')).toThrow('invalid_boolean_parameter:pin');
+  it('rejects unsupported query boolean values', () => {
+    expect(() => parseBooleanQueryParameter('yes', 'pin')).toThrow('invalid_boolean_parameter:pin');
   });
 
   it('only accepts whole pagination numbers at or above the minimum', () => {
@@ -28,5 +35,34 @@ describe('OpenKey route input parsing', () => {
     expect(() => processTags(Array.from({ length: 21 }, (_, index) => `tag-${index}`))).toThrow(
       'Maximum 20 tags allowed'
     );
+  });
+});
+
+describe('OpenKey note creation route policy', () => {
+  it('marks the convenience GET response as non-cacheable and supported', async () => {
+    const app = new Hono();
+    app.get('/', (c) => {
+      markConvenienceNoteCreate(c);
+      return c.text('ok');
+    });
+
+    const response = await app.request('/');
+
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+    expect(response.headers.get('Deprecation')).toBeNull();
+    expect(response.headers.get('Link')).toBeNull();
+  });
+
+  it('marks only the legacy POST response as deprecated', async () => {
+    const app = new Hono();
+    app.post('/', (c) => {
+      markLegacyNoteCreatePost(c);
+      return c.text('ok');
+    });
+
+    const response = await app.request('/', { method: 'POST' });
+
+    expect(response.headers.get('Deprecation')).toBe('true');
+    expect(response.headers.get('Link')).toBe('</v2/api/openkey/notes>; rel="successor-version"');
   });
 });

--- a/server/route/v2/openKey/shared.ts
+++ b/server/route/v2/openKey/shared.ts
@@ -43,7 +43,7 @@ export function parseOptionalInteger(
   return parsed;
 }
 
-export function parseLegacyBoolean(
+export function parseBooleanQueryParameter(
   value: string | undefined,
   parameter: string
 ): boolean | undefined {
@@ -65,7 +65,11 @@ export function processTags(values: readonly string[]): string[] {
   return tags;
 }
 
-export function markLegacyNoteCreate(c: HonoContext) {
+export function markConvenienceNoteCreate(c: HonoContext) {
+  c.header('Cache-Control', 'no-store');
+}
+
+export function markLegacyNoteCreatePost(c: HonoContext) {
   c.header('Deprecation', 'true');
   c.header('Link', '</v2/api/openkey/notes>; rel="successor-version"');
 }

--- a/server/tests/openkey-endpoints.test.ts
+++ b/server/tests/openkey-endpoints.test.ts
@@ -217,7 +217,7 @@ export class OpenKeyEndpointsTestSuite {
   }
 
   /**
-   * 测试 2: 创建笔记 (GET /notes/create) - 兼容接口
+   * 测试 2: 创建笔记 (GET /notes/create) - 便捷 URL 接口
    */
   async test2_CreateNoteGet(): Promise<any> {
     const startTime = Date.now();
@@ -226,12 +226,12 @@ export class OpenKeyEndpointsTestSuite {
         openkey: this.openKey,
         content: 'This is a test note created via OpenKey GET method.',
         state: 'private',
-        type: 'rote',
+        type: 'Rote',
         title: 'Test Note GET',
         pin: 'false',
       });
       params.append('tag', 'test');
-      params.append('tag', 'legacy');
+      params.append('tag', 'url');
 
       const response = await this.openkeyClient.get(`/notes/create?${params.toString()}`);
 
@@ -244,7 +244,7 @@ export class OpenKeyEndpointsTestSuite {
 
       const duration = Date.now() - startTime;
       this.resultManager.recordResult(
-        'Endpoint 2: Create Note (GET - Legacy)',
+        'Endpoint 2: Create Note (GET - Convenient URL)',
         true,
         `Note created with ID: ${response.data.data.id}`,
         duration,
@@ -256,7 +256,7 @@ export class OpenKeyEndpointsTestSuite {
     } catch (error: any) {
       const duration = Date.now() - startTime;
       this.resultManager.recordResult(
-        'Endpoint 2: Create Note (GET - Legacy)',
+        'Endpoint 2: Create Note (GET - Convenient URL)',
         false,
         `Failed: ${error.message}`,
         duration,
@@ -1302,7 +1302,7 @@ export class OpenKeyEndpointsTestSuite {
       // Endpoint 1: Create Note (POST)
       await this.test1_CreateNotePost();
 
-      // Endpoint 2: Create Note (GET - Legacy)
+      // Endpoint 2: Create Note (GET - Convenient URL)
       await this.test2_CreateNoteGet();
 
       // Endpoint 3: Create Article


### PR DESCRIPTION
## Summary

- keep GET /v2/api/openkey/notes/create as a supported URL-based automation interface
- remove deprecation headers from GET and return Cache-Control: no-store
- keep only POST /v2/api/openkey/notes/create deprecated in favor of POST /v2/api/openkey/notes
- align route naming, tests, and API documentation with the product contract

## Validation

- bun test route/v2/openKey/shared.test.ts route/v2/openKey/notes.integration.test.ts (10 pass; 8 database-gated tests skipped without OPENKEY_NOTES_TEST_DATABASE_URL)
- bun run lint
- bun run build