### PR TITLE
docs: remove retired note type references

### DIFF
--- a/doc/userguide/ROTE-API.md
+++ b/doc/userguide/ROTE-API.md
@@ -171,7 +171,7 @@ curl -X POST 'https://your-domain.com/v2/api/notes/' \
   - `limit`: number（可选，每页数量）
   - `archived`: boolean（可选，是否只显示归档笔记）
   - `tag`: string | string[]（可选，按标签过滤，支持 `tag` 或 `tag[]` 两种格式）
-  - 其他过滤参数（如 `state`、`type` 等）
+  - 其他过滤参数（如 `state`、`pin` 等）
 
 **标签过滤说明**：
 
@@ -432,7 +432,6 @@ curl -X POST 'https://your-domain.com/v2/api/notes/batch' \
 - **Body**: 需要更新的字段（所有字段均为可选，长度限制与创建接口相同）
   - `content`: string（可选，最大 1,000,000 个字符）
   - `title`: string（可选，最大 200 个字符）
-  - `type`: string（可选）
   - `state`: string（可选）
   - `editor`: string（可选）
   - `tags`: string[]（可选，每个标签最大 50 个字符，最多 20 个标签）
@@ -593,7 +592,7 @@ curl -X GET 'https://your-domain.com/v2/api/notes/random' \
   - `limit`: number（可选，每页数量）
   - `archived`: boolean（可选，是否只搜索归档笔记）
   - `tag`: string | string[]（可选，按标签过滤，支持 `tag` 或 `tag[]` 两种格式）
-  - 其他过滤参数（如 `state`、`type` 等）
+  - 其他过滤参数（如 `state`、`pin` 等）
 
 **标签过滤说明**：
 
@@ -659,7 +658,7 @@ curl -X GET 'https://your-domain.com/v2/api/notes/search?keyword=关键词&skip=
   - `skip`: number（可选，分页偏移量）
   - `limit`: number（可选，每页数量）
   - `tag`: string | string[]（可选，按标签过滤，支持 `tag` 或 `tag[]` 两种格式）
-  - 其他过滤参数（如 `type` 等）
+  - 其他过滤参数（如 `pin` 等）
 
 **标签过滤说明**：
 
@@ -793,7 +792,7 @@ curl -X GET 'https://your-domain.com/v2/api/notes/search/users/demo?keyword=关�
   - `limit`: number（可选，每页数量）
   - `archived`: boolean（可选）
   - `tag`: string | string[]（可选，按标签过滤，支持 `tag` 或 `tag[]` 两种格式）
-  - 其他过滤参数（如 `state`、`type` 等）
+  - 其他过滤参数（如 `pin` 等）
 
 **标签过滤说明**：
 
@@ -854,7 +853,7 @@ curl -X GET 'https://your-domain.com/v2/api/notes/users/demo?skip=0&limit=20'
   - `skip`: number（可选，分页偏移量）
   - `limit`: number（可选，每页数量）
   - `tag`: string | string[]（可选，按标签过滤，支持 `tag` 或 `tag[]` 两种格式）
-  - 其他过滤参数（如 `type` 等）
+  - 其他过滤参数（如 `pin` 等）
 
 **标签过滤说明**：
 

--- a/doc/userguide/USER-API.md
+++ b/doc/userguide/USER-API.md
@@ -585,7 +585,7 @@ curl -X POST 'https://your-domain.com/v2/api/imports/attachments/migrate' \
 笔记支持以下字段：
 
 - 必填：`id`（UUID）、`content`（string）。
-- 可选：`title`、`type`、`tags`、`state`、`archived`、`articleId`、`pin`、`editor`、`createdAt`、`updatedAt`、`attachments`、`source`。
+- 可选：`title`、`tags`、`state`、`archived`、`articleId`、`pin`、`editor`、`createdAt`、`updatedAt`、`attachments`、`source`。
 - 单条笔记最多包含 100 个标签和 500 个附件。
 - `createdAt`、`updatedAt` 和 `source.sourceUpdatedAt` 使用 ISO 8601 日期时间字符串。笔记的 `createdAt`
   会保留；`updatedAt` 会被忽略并写为本次导入时间；`sourceUpdatedAt` 当前只参与格式校验，不会持久化或用于冲突判断。


### PR DESCRIPTION
## Summary

- remove the remaining retired note `type` update-field documentation
- replace stale `type` filter examples with supported `state`/`pin` examples
- remove `type` from the documented import-note optional fields

Follow-up to the review on #338. No runtime behavior changed.

## Validation

- `git diff --check`
- searched user-facing API documentation for remaining note `type` contract references
