### PR TITLE
Fix attachment upload session capability

### DIFF
--- a/server/route/v2/site.ts
+++ b/server/route/v2/site.ts
@@ -181,7 +181,7 @@ siteRouter.get('/status', async (c: HonoContext) => {
         allowRegistration: uiConfig?.allowRegistration ?? true,
         allowUploadFile: uiConfig?.allowUploadFile ?? true,
         maxVideoUploadSizeMB: uiConfig?.maxVideoUploadSizeMB ?? 300,
-        attachmentUploadSessions: true,
+        attachmentUploadSessions: false,
         attachmentBatchFinalize: billingConfig.enabled,
       },
 

--- a/server/tests/site.test.ts
+++ b/server/tests/site.test.ts
@@ -65,6 +65,11 @@ export class SiteTestSuite {
       TestAssertions.assertNotNull(status.databaseConnected, 'databaseConnected should be present');
       TestAssertions.assertNotNull(status.site, 'Site info should be present');
       TestAssertions.assertNotNull(status.ai, 'AI status should be present');
+      TestAssertions.assertEquals(
+        status.ui?.attachmentUploadSessions,
+        false,
+        'Upload sessions must not be advertised until the recovery API exists'
+      );
       TestAssertions.assertNotNull(
         typeof status.ai.available === 'boolean',
         'AI availability should be boolean'


### PR DESCRIPTION
## Summary
- stop advertising attachment upload-session recovery until its API exists
- keep batch finalize capability enabled
- cover the production capability contract in the site status test

## Validation
- `bun run lint`
- `bun run build`

The existing `/attachments/finalize` and `/attachments/finalize-batch` routes are unchanged.