### PR TITLE
Upload attachments directly to final object keys

### DIFF
--- a/server/attachments/attachmentUpload.test.ts
+++ b/server/attachments/attachmentUpload.test.ts
@@ -314,6 +314,151 @@ describe('attachment upload flow', () => {
     ]);
   });
 
+  it('presigns the final attachment key without a preview for direct uploads', async () => {
+    const signed: Array<{ contentLength?: number; key: string }> = [];
+    let reservation:
+      | Parameters<
+          NonNullable<Parameters<typeof presignAttachmentUploads>[1]['createUploadReservation']>
+        >[0]
+      | undefined;
+    const result = await presignAttachmentUploads(
+      {
+        directFinalUpload: true,
+        files: [
+          {
+            contentType: 'image/jpeg',
+            filename: 'IMG_0002.JPG',
+            mediaKind: 'image',
+            size: 1024,
+          },
+        ],
+        scopes: [],
+        userId: USER_ID,
+      },
+      {
+        createUploadReservation: async (input) => {
+          reservation = input;
+          return true;
+        },
+        getAttachmentUploadPolicy: async () => uploadPolicy,
+        getResourceStateForUserId: async () => ({
+          management: 'official',
+          source: 'official_pro',
+          storage: {
+            enforcement: 'enforce',
+            usedBytes: '0',
+            reservedBytes: '0',
+            limitBytes: '10000000000',
+            overLimit: false,
+            canUpload: true,
+          },
+          openKey: {
+            policy: 'unlimited',
+            creationThreshold: null,
+            existingCount: 2,
+            canCreate: true,
+          },
+        }),
+        presignPutUrl: async (key, _contentType, _expiresIn, contentLength) => {
+          signed.push({ contentLength, key });
+          return { putUrl: `https://put.example.com/${key}`, url: `${URL_PREFIX}/${key}` };
+        },
+        randomUUID: () => LIVE_UUID,
+        requireStorageAvailable: () => storageConfig,
+      }
+    );
+
+    expect(result.items[0].original.key).toBe(
+      `users/${USER_ID}/attachments/${LIVE_UUID}/original.jpg`
+    );
+    expect(result.items[0].compressed).toBeUndefined();
+    expect(reservation?.manifest).toHaveLength(1);
+    expect(reservation?.manifest[0].stagingKey).toBe(reservation?.manifest[0].finalKey);
+    expect(signed).toEqual([
+      {
+        contentLength: 1024,
+        key: `users/${USER_ID}/attachments/${LIVE_UUID}/original.jpg`,
+      },
+    ]);
+  });
+
+  it('presigns a direct video and its client-generated poster at final keys', async () => {
+    const signed: Array<{ contentLength?: number; key: string }> = [];
+    let reservation:
+      | Parameters<
+          NonNullable<Parameters<typeof presignAttachmentUploads>[1]['createUploadReservation']>
+        >[0]
+      | undefined;
+    const result = await presignAttachmentUploads(
+      {
+        directFinalUpload: true,
+        files: [
+          {
+            contentType: 'video/quicktime',
+            filename: 'clip.mov',
+            mediaKind: 'video',
+            poster: { contentType: 'image/jpeg', size: 256 },
+            size: 2048,
+          },
+        ],
+        scopes: ['video:upload'],
+        userId: USER_ID,
+      },
+      {
+        createUploadReservation: async (input) => {
+          reservation = input;
+          return true;
+        },
+        getAttachmentUploadPolicy: async () => uploadPolicy,
+        getResourceStateForUserId: async () => ({
+          management: 'official',
+          source: 'official_pro',
+          storage: {
+            enforcement: 'enforce',
+            usedBytes: '0',
+            reservedBytes: '0',
+            limitBytes: '10000000000',
+            overLimit: false,
+            canUpload: true,
+          },
+          openKey: {
+            policy: 'unlimited',
+            creationThreshold: null,
+            existingCount: 2,
+            canCreate: true,
+          },
+        }),
+        presignPutUrl: async (key, _contentType, _expiresIn, contentLength) => {
+          signed.push({ contentLength, key });
+          return { putUrl: `https://put.example.com/${key}`, url: `${URL_PREFIX}/${key}` };
+        },
+        randomUUID: () => LIVE_UUID,
+        requireStorageAvailable: () => storageConfig,
+      }
+    );
+
+    expect(result.items[0].original.key).toBe(
+      `users/${USER_ID}/attachments/${LIVE_UUID}/original.mov`
+    );
+    expect(result.items[0].poster?.key).toBe(
+      `users/${USER_ID}/attachments/${LIVE_UUID}/poster.jpg`
+    );
+    expect(reservation?.manifest.map(({ role, declaredBytes }) => [role, declaredBytes])).toEqual([
+      ['original', '2048'],
+      ['poster', '256'],
+    ]);
+    expect(signed).toEqual([
+      {
+        contentLength: 2048,
+        key: `users/${USER_ID}/attachments/${LIVE_UUID}/original.mov`,
+      },
+      {
+        contentLength: 256,
+        key: `users/${USER_ID}/attachments/${LIVE_UUID}/poster.jpg`,
+      },
+    ]);
+  });
+
   it('finalizes a client-provided Live Photo preview without media processing', async () => {
     const originalKey = `users/${USER_ID}/uploads/${LIVE_UUID}.heic`;
     const pairedVideoKey = `users/${USER_ID}/paired-videos/${LIVE_UUID}.mov`;

--- a/server/attachments/directFinalUpload.test.ts
+++ b/server/attachments/directFinalUpload.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'bun:test';
+import type { UploadReservationManifestItem } from '../resources/service';
+import type { FinalizeAttachmentBatchInput } from './types';
+import { isDirectFinalUploadManifest, prepareDirectFinalUpload } from './directFinalUpload';
+
+const USER_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const ATTACHMENT_ID = '11111111-1111-4111-8111-111111111111';
+const BATCH_ID = '22222222-2222-4222-8222-222222222222';
+const RESERVATION_ID = '33333333-3333-4333-8333-333333333333';
+const NOTE_ID = '44444444-4444-4444-8444-444444444444';
+const CLIENT_ID = '55555555-5555-4555-8555-555555555555';
+const ORIGINAL_KEY = `users/${USER_ID}/attachments/${ATTACHMENT_ID}/original.jpg`;
+
+const manifest = (): UploadReservationManifestItem[] => [
+  {
+    billable: true,
+    contentType: 'image/jpeg',
+    declaredBytes: '1024',
+    finalKey: ORIGINAL_KEY,
+    role: 'original',
+    stagingKey: ORIGINAL_KEY,
+    uuid: ATTACHMENT_ID,
+  },
+];
+
+const input = (): FinalizeAttachmentBatchInput => ({
+  attachments: [
+    {
+      clientId: CLIENT_ID,
+      compressedKey: undefined,
+      mediaKind: 'image',
+      mimetype: 'image/jpeg',
+      originalKey: ORIGINAL_KEY,
+      size: 1024,
+      uuid: ATTACHMENT_ID,
+    },
+  ],
+  batchId: BATCH_ID,
+  noteId: NOTE_ID,
+  order: [{ clientId: CLIENT_ID }],
+  reservationId: RESERVATION_ID,
+});
+
+describe('direct final attachment upload', () => {
+  it('builds database uploads entirely from the reservation manifest', () => {
+    const prepared = prepareDirectFinalUpload(
+      input(),
+      manifest(),
+      USER_ID,
+      'https://cdn.example.com'
+    );
+
+    expect(prepared.objects).toHaveLength(1);
+    expect(prepared.objects[0].actualBytes).toBe(1024n);
+    expect(prepared.uploads).toHaveLength(1);
+    expect(prepared.uploads[0].url).toBe(`https://cdn.example.com/${ORIGINAL_KEY}`);
+    expect(prepared.uploads[0].compressUrl).toBeNull();
+    expect(prepared.uploads[0].details.mimetype).toBe('image/jpeg');
+  });
+
+  it('rejects a size claim that differs from the presigned manifest', () => {
+    const mismatched = input();
+    mismatched.attachments[0].size = 1023;
+
+    expect(() =>
+      prepareDirectFinalUpload(mismatched, manifest(), USER_ID, 'https://cdn.example.com')
+    ).toThrow('resource_upload_manifest_mismatch');
+  });
+
+  it('does not treat staging reservations as direct final uploads', () => {
+    const legacy = manifest();
+    legacy[0].stagingKey = `users/${USER_ID}/staging/${RESERVATION_ID}/uploads/${ATTACHMENT_ID}.jpg`;
+
+    expect(isDirectFinalUploadManifest(legacy)).toBe(false);
+  });
+});

--- a/server/attachments/directFinalUpload.ts
+++ b/server/attachments/directFinalUpload.ts
@@ -1,0 +1,112 @@
+import type { UploadResult } from '../types/main';
+import { inferAttachmentMediaKind } from '../utils/fileValidation';
+import { RESOURCE_ERROR_CODES, ResourcePolicyError } from '../resources/errors';
+import type { UploadReservationManifestItem } from '../resources/service';
+import type { FinalizeAttachmentBatchInput, FinalizeAttachmentInput } from './types';
+import { assertCompleteRequiredManifest, toUploadResult } from './finalizeUpload';
+
+export type PreparedDirectFinalUpload = {
+  objects: Array<UploadReservationManifestItem & { actualBytes: bigint }>;
+  uploads: UploadResult[];
+};
+
+export function isDirectFinalUploadManifest(
+  manifest: readonly UploadReservationManifestItem[]
+): boolean {
+  return manifest.length > 0 && manifest.every((item) => item.stagingKey === item.finalKey);
+}
+
+function invalid(): never {
+  throw new ResourcePolicyError(RESOURCE_ERROR_CODES.uploadManifestMismatch);
+}
+
+function normalizedContentType(value: string | undefined): string | null {
+  return value?.split(';', 1)[0]?.trim().toLowerCase() ?? null;
+}
+
+function exactDeclaredBytes(
+  submitted: number | undefined,
+  manifestItem: UploadReservationManifestItem
+): number {
+  if (manifestItem.declaredBytes === null) invalid();
+  const expected = Number(manifestItem.declaredBytes);
+  if (!Number.isSafeInteger(expected) || expected <= 0 || submitted !== expected) invalid();
+  return expected;
+}
+
+export function prepareDirectFinalUpload(
+  input: FinalizeAttachmentBatchInput,
+  manifest: readonly UploadReservationManifestItem[],
+  userId: string,
+  urlPrefix: string
+): PreparedDirectFinalUpload {
+  if (!isDirectFinalUploadManifest(manifest)) invalid();
+  assertCompleteRequiredManifest(input.attachments, manifest, true);
+
+  const manifestByUuid = new Map<string, UploadReservationManifestItem[]>();
+  for (const item of manifest) {
+    const expectedPrefix = `users/${userId}/attachments/${item.uuid}/`;
+    if (!item.finalKey.startsWith(expectedPrefix) || item.declaredBytes === null) invalid();
+    const entries = manifestByUuid.get(item.uuid) ?? [];
+    entries.push(item);
+    manifestByUuid.set(item.uuid, entries);
+  }
+
+  const uploads = input.attachments.map((attachment): UploadResult => {
+    const objects = manifestByUuid.get(attachment.uuid) ?? invalid();
+    const original = objects.find((item) => item.role === 'original') ?? invalid();
+    const paired = objects.find((item) => item.role === 'paired_video');
+    const poster = objects.find((item) => item.role === 'poster');
+    const compressed = objects.find((item) => item.role === 'compressed');
+    if (compressed) invalid();
+
+    const size = exactDeclaredBytes(attachment.size, original);
+    if (
+      normalizedContentType(attachment.mimetype) !== normalizedContentType(original.contentType)
+    ) {
+      invalid();
+    }
+    if (paired) {
+      exactDeclaredBytes(attachment.pairedVideoSize, paired);
+      if (
+        normalizedContentType(attachment.pairedVideoMimetype) !==
+        normalizedContentType(paired.contentType)
+      ) {
+        invalid();
+      }
+    }
+
+    const mediaKind = paired
+      ? 'livePhoto'
+      : poster
+        ? 'video'
+        : inferAttachmentMediaKind({
+            mediaKind: attachment.mediaKind,
+            mimetype: original.contentType,
+            key: original.finalKey,
+          });
+    if (!mediaKind || (attachment.mediaKind && attachment.mediaKind !== mediaKind)) invalid();
+
+    const normalized: FinalizeAttachmentInput = {
+      ...attachment,
+      compressedKey: undefined,
+      mediaKind,
+      mimetype: original.contentType,
+      originalKey: original.finalKey,
+      pairedVideoKey: paired?.finalKey,
+      pairedVideoMimetype: paired?.contentType,
+      pairedVideoSize: paired ? Number(paired.declaredBytes) : undefined,
+      posterKey: poster?.finalKey,
+      size,
+    };
+    return toUploadResult(urlPrefix, normalized);
+  });
+
+  return {
+    objects: manifest.map((item) => ({
+      ...item,
+      actualBytes: BigInt(item.declaredBytes!),
+    })),
+    uploads,
+  };
+}

--- a/server/attachments/finalizeBatch.ts
+++ b/server/attachments/finalizeBatch.ts
@@ -15,11 +15,13 @@ import { createRoteChange, upsertAttachmentsByOriginalKey } from '../utils/dbMet
 import { MAX_FILES, validateRoteAttachmentDetails } from '../utils/fileValidation';
 import { RESOURCE_ERROR_CODES, ResourcePolicyError } from '../resources/errors';
 import { finalizeAttachmentUploads } from './finalizeUpload';
+import { isDirectFinalUploadManifest, prepareDirectFinalUpload } from './directFinalUpload';
 import type {
   AttachmentBatchOrderReference,
   FinalizeAttachmentBatchInput,
   FinalizeAttachmentBatchResult,
 } from './types';
+import { requireStorageAvailable } from './types';
 
 type FinalizedManagedObject = UploadReservationManifestItem & { actualBytes: bigint };
 
@@ -391,7 +393,11 @@ export async function finalizeAttachmentBatch(params: {
     throw new ResourcePolicyError(RESOURCE_ERROR_CODES.uploadManifestMismatch);
   }
   const inferredReservationId = [...inferredReservationIds][0];
-  if (normalizedReservationId && normalizedReservationId !== inferredReservationId) {
+  if (
+    normalizedReservationId &&
+    inferredReservationId &&
+    normalizedReservationId !== inferredReservationId
+  ) {
     throw new ResourcePolicyError(RESOURCE_ERROR_CODES.uploadManifestMismatch);
   }
   const reservationId = normalizedReservationId ?? inferredReservationId;
@@ -410,7 +416,14 @@ export async function finalizeAttachmentBatch(params: {
   const claim: ActiveFinalizeClaim = claimResult;
 
   try {
-    const prepared = await prepareUploadsOutsideTransaction(input, claim, params.userId);
+    const prepared = isDirectFinalUploadManifest(claim.reservation.manifest)
+      ? prepareDirectFinalUpload(
+          input,
+          claim.reservation.manifest,
+          params.userId,
+          requireStorageAvailable().urlPrefix
+        )
+      : await prepareUploadsOutsideTransaction(input, claim, params.userId);
     const result = await persistBatch({
       claim,
       input,

--- a/server/attachments/finalizeUpload.ts
+++ b/server/attachments/finalizeUpload.ts
@@ -313,7 +313,7 @@ async function collectValidAttachments(
   return validAttachments;
 }
 
-function toUploadResult(urlPrefix: string, item: FinalizeAttachmentInput): UploadResult {
+export function toUploadResult(urlPrefix: string, item: FinalizeAttachmentInput): UploadResult {
   const mediaKind = inferAttachmentMediaKind({
     mediaKind: item.mediaKind,
     mimetype: item.mimetype || null,

--- a/server/attachments/presignUpload.ts
+++ b/server/attachments/presignUpload.ts
@@ -46,7 +46,11 @@ const defaultDependencies: PresignAttachmentDependencies = {
 
 const UPLOAD_RESERVATION_LIFETIME_MS = 24 * 60 * 60 * 1000;
 
-function validatePresignFile(file: PresignFileInput, maxVideoUploadSizeMB: number) {
+function validatePresignFile(
+  file: PresignFileInput,
+  maxVideoUploadSizeMB: number,
+  directFinalUpload: boolean
+) {
   validateContentType(file.contentType);
   if (
     file.compressedContentType !== undefined &&
@@ -54,6 +58,17 @@ function validatePresignFile(file: PresignFileInput, maxVideoUploadSizeMB: numbe
     file.compressedContentType !== 'image/webp'
   ) {
     throw new Error(attachmentErrors.compressedContentTypeInvalid);
+  }
+  if (directFinalUpload && file.compressedContentType !== undefined) {
+    throw new ResourcePolicyError(RESOURCE_ERROR_CODES.uploadManifestMismatch);
+  }
+  const mediaKind =
+    file.mediaKind === 'livePhoto' ? 'livePhoto' : getMediaKindFromContentType(file.contentType);
+  if (directFinalUpload && mediaKind === 'video') {
+    if (file.poster?.contentType !== 'image/jpeg' || !file.poster.size) {
+      throw new ResourcePolicyError(RESOURCE_ERROR_CODES.uploadManifestMismatch);
+    }
+    validateFileSize(file.poster.size, file.poster.contentType, maxVideoUploadSizeMB);
   }
   if (file.mediaKind !== 'livePhoto') {
     validateFileSize(file.size, file.contentType, maxVideoUploadSizeMB);
@@ -79,6 +94,7 @@ export async function presignAttachmentUploads(
     userId: string;
     scopes: string[];
     files: PresignFileInput[];
+    directFinalUpload?: boolean;
   },
   dependencyOverrides: Partial<PresignAttachmentDependencies> = {}
 ) {
@@ -100,11 +116,17 @@ export async function presignAttachmentUploads(
     throw new Error(attachmentErrors.capabilityVideoUpload);
   }
 
-  input.files.forEach((file) => validatePresignFile(file, uploadPolicy.maxVideoUploadSizeMB));
+  const directFinalUpload = input.directFinalUpload === true;
+  input.files.forEach((file) =>
+    validatePresignFile(file, uploadPolicy.maxVideoUploadSizeMB, directFinalUpload)
+  );
 
   const resourceState = await dependencies.getResourceStateForUserId(input.userId);
   const managed =
     resourceState.management !== 'unmanaged' && resourceState.storage.enforcement !== 'off';
+  if (directFinalUpload && !managed) {
+    throw new ResourcePolicyError(RESOURCE_ERROR_CODES.uploadManifestMismatch);
+  }
   const reservationId = managed ? dependencies.randomUUID() : null;
   const credentialExpiresAt = new Date(Date.now() + 15 * 60 * 1000);
   const prepared = input.files.map((file) => {
@@ -113,14 +135,19 @@ export async function presignAttachmentUploads(
     const mediaKind =
       file.mediaKind === 'livePhoto' ? 'livePhoto' : getMediaKindFromContentType(file.contentType);
     const compressedContentType =
-      mediaKind === 'image' || mediaKind === 'livePhoto'
+      !directFinalUpload && (mediaKind === 'image' || mediaKind === 'livePhoto')
         ? (file.compressedContentType ?? (mediaKind === 'livePhoto' ? 'image/jpeg' : 'image/webp'))
         : undefined;
     const finalPrefix = `users/${input.userId}`;
     const stagingPrefix = managed ? `${finalPrefix}/staging/${reservationId}` : finalPrefix;
+    const attachmentPrefix = `${finalPrefix}/attachments/${uuid}`;
     const manifest: UploadReservationManifestItem[] = [];
-    const originalFinalKey = `${finalPrefix}/uploads/${uuid}${ext}`;
-    const originalKey = `${stagingPrefix}/uploads/${uuid}${ext}`;
+    const originalFinalKey = directFinalUpload
+      ? `${attachmentPrefix}/original${ext}`
+      : `${finalPrefix}/uploads/${uuid}${ext}`;
+    const originalKey = directFinalUpload
+      ? originalFinalKey
+      : `${stagingPrefix}/uploads/${uuid}${ext}`;
     manifest.push({
       uuid,
       role: 'original',
@@ -156,8 +183,12 @@ export async function presignAttachmentUploads(
     if (mediaKind === 'livePhoto' && file.pairedVideo) {
       const pairedExt = getUploadExtension(file.pairedVideo.filename, file.pairedVideo.contentType);
       pairedVideo = {
-        key: `${stagingPrefix}/paired-videos/${uuid}${pairedExt}`,
-        finalKey: `${finalPrefix}/paired-videos/${uuid}${pairedExt}`,
+        key: directFinalUpload
+          ? `${attachmentPrefix}/paired-video${pairedExt}`
+          : `${stagingPrefix}/paired-videos/${uuid}${pairedExt}`,
+        finalKey: directFinalUpload
+          ? `${attachmentPrefix}/paired-video${pairedExt}`
+          : `${finalPrefix}/paired-videos/${uuid}${pairedExt}`,
         contentType: file.pairedVideo.contentType ?? 'video/quicktime',
         size: file.pairedVideo.size ?? 0,
       };
@@ -171,18 +202,24 @@ export async function presignAttachmentUploads(
         billable: true,
       });
     }
-    let poster: { key: string; finalKey: string } | undefined;
+    let poster: { key: string; finalKey: string; size: number } | undefined;
     if (mediaKind === 'video') {
+      const posterSize = directFinalUpload ? (file.poster?.size ?? 0) : 0;
       poster = {
-        key: `${stagingPrefix}/posters/${uuid}.jpg`,
-        finalKey: `${finalPrefix}/posters/${uuid}.jpg`,
+        key: directFinalUpload
+          ? `${attachmentPrefix}/poster.jpg`
+          : `${stagingPrefix}/posters/${uuid}.jpg`,
+        finalKey: directFinalUpload
+          ? `${attachmentPrefix}/poster.jpg`
+          : `${finalPrefix}/posters/${uuid}.jpg`,
+        size: posterSize,
       };
       manifest.push({
         uuid,
         role: 'poster',
         stagingKey: poster.key,
         finalKey: poster.finalKey,
-        declaredBytes: null,
+        declaredBytes: directFinalUpload ? String(posterSize) : null,
         contentType: 'image/jpeg',
         billable: false,
       });
@@ -220,8 +257,7 @@ export async function presignAttachmentUploads(
           },
         };
 
-        if (mediaKind === 'image' || mediaKind === 'livePhoto') {
-          if (!compressed) throw new Error('Missing compressed upload manifest');
+        if ((mediaKind === 'image' || mediaKind === 'livePhoto') && compressed) {
           const compressedUpload = managed
             ? {
                 putUrl: dependencies.createDerivedUploadProxyUrl({
@@ -261,19 +297,21 @@ export async function presignAttachmentUploads(
 
         if (mediaKind === 'video') {
           if (!poster) throw new Error('Missing poster upload manifest');
-          const posterUpload = managed
-            ? {
-                putUrl: dependencies.createDerivedUploadProxyUrl({
-                  reservationId: reservationId!,
-                  userId: input.userId,
-                  role: 'poster',
-                  key: poster.key,
-                  contentType: 'image/jpeg',
-                  expiresAt: credentialExpiresAt,
-                }),
-                url: '',
-              }
-            : await dependencies.presignPutUrl(poster.key, 'image/jpeg', 15 * 60);
+          const posterUpload = directFinalUpload
+            ? await dependencies.presignPutUrl(poster.key, 'image/jpeg', 15 * 60, poster.size)
+            : managed
+              ? {
+                  putUrl: dependencies.createDerivedUploadProxyUrl({
+                    reservationId: reservationId!,
+                    userId: input.userId,
+                    role: 'poster',
+                    key: poster.key,
+                    contentType: 'image/jpeg',
+                    expiresAt: credentialExpiresAt,
+                  }),
+                  url: '',
+                }
+              : await dependencies.presignPutUrl(poster.key, 'image/jpeg', 15 * 60);
           result.poster = {
             key: poster.key,
             putUrl: posterUpload.putUrl,
@@ -307,6 +345,7 @@ export async function refreshAttachmentUploadReservation(userId: string, reserva
   }
   const expiresIn = Math.floor(remainingMs / 1000);
   const manifest = reservation.manifest as UploadReservationManifestItem[];
+  const directFinalUpload = manifest.every((item) => item.stagingKey === item.finalKey);
   const byUuid = new Map<string, UploadReservationManifestItem[]>();
   for (const item of manifest) {
     const values = byUuid.get(item.uuid) ?? [];
@@ -333,9 +372,23 @@ export async function refreshAttachmentUploadReservation(userId: string, reserva
           contentType: original.contentType,
         },
       };
-      const derived = (role: 'compressed' | 'poster') => {
+      const derived = async (role: 'compressed' | 'poster') => {
         const object = objects.find((item) => item.role === role);
         if (!object) return undefined;
+        if (directFinalUpload) {
+          const signed = await presignPutUrl(
+            object.finalKey,
+            object.contentType,
+            expiresIn,
+            object.declaredBytes === null ? undefined : Number(object.declaredBytes)
+          );
+          return {
+            key: object.finalKey,
+            putUrl: signed.putUrl,
+            url: signed.url,
+            contentType: object.contentType,
+          };
+        }
         return {
           key: object.stagingKey,
           putUrl: createDerivedUploadProxyUrl({
@@ -350,8 +403,8 @@ export async function refreshAttachmentUploadReservation(userId: string, reserva
           contentType: object.contentType,
         };
       };
-      const compressed = derived('compressed');
-      const poster = derived('poster');
+      const compressed = await derived('compressed');
+      const poster = await derived('poster');
       if (compressed) response.compressed = compressed;
       if (poster) response.poster = poster;
       const paired = objects.find((item) => item.role === 'paired_video');

--- a/server/attachments/types.ts
+++ b/server/attachments/types.ts
@@ -13,6 +13,15 @@ export type PresignFileInput = {
     contentType?: string;
     size?: number;
   };
+  poster?: {
+    contentType?: 'image/jpeg';
+    size?: number;
+  };
+};
+
+export type PresignAttachmentInput = {
+  files: PresignFileInput[];
+  directFinalUpload?: boolean;
 };
 
 export type FinalizeAttachmentInput = {

--- a/server/route/v2/attachment.ts
+++ b/server/route/v2/attachment.ts
@@ -8,7 +8,7 @@ import {
   presignAttachmentUploads,
   refreshAttachmentUploadReservation,
 } from '../../attachments/presignUpload';
-import type { FinalizeAttachmentInput, PresignFileInput } from '../../attachments/types';
+import type { FinalizeAttachmentInput, PresignAttachmentInput } from '../../attachments/types';
 import {
   finalizeInputIncludesVideo,
   presignInputIncludesVideo,
@@ -161,7 +161,7 @@ attachmentsRouter.post(
     const user = c.get('user') as User;
     const body = await c.req.json();
     AttachmentPresignZod.parse(body);
-    const { files } = body as { files: PresignFileInput[] };
+    const { files, directFinalUpload } = body as PresignAttachmentInput;
     const uploadPolicy = await getAttachmentUploadPolicy(user.id);
     if (!uploadPolicy.canUploadAttachments) {
       return c.json(createResponse(null, 'capability_required:attachment.upload'), 403);
@@ -170,6 +170,7 @@ attachmentsRouter.post(
       return c.json(createResponse(null, 'capability_required:attachment.video.upload'), 403);
     }
     const result = await presignAttachmentUploads({
+      directFinalUpload,
       files,
       scopes: ['video:upload'],
       userId: user.id,

--- a/server/route/v2/openKeyAttachment.ts
+++ b/server/route/v2/openKeyAttachment.ts
@@ -4,7 +4,7 @@ import {
   presignAttachmentUploads,
   refreshAttachmentUploadReservation,
 } from '../../attachments/presignUpload';
-import type { FinalizeAttachmentInput, PresignFileInput } from '../../attachments/types';
+import type { FinalizeAttachmentInput, PresignAttachmentInput } from '../../attachments/types';
 import {
   finalizeInputIncludesVideo,
   presignInputIncludesVideo,
@@ -56,7 +56,7 @@ openKeyAttachmentRouter.post(
     const openKey = c.get('openKey')!;
     const body = await c.req.json();
     AttachmentPresignZod.parse(body);
-    const { files } = body as { files: PresignFileInput[] };
+    const { files } = body as PresignAttachmentInput;
     const videoAllowed = canUploadVideo(openKey.permissions);
     if (presignInputIncludesVideo(files) && !videoAllowed) {
       return c.json(createResponse(null, 'openkey_permission_required:UPLOADVIDEO'), 403);

--- a/server/route/v2/site.ts
+++ b/server/route/v2/site.ts
@@ -183,6 +183,7 @@ siteRouter.get('/status', async (c: HonoContext) => {
         maxVideoUploadSizeMB: uiConfig?.maxVideoUploadSizeMB ?? 300,
         attachmentUploadSessions: false,
         attachmentBatchFinalize: billingConfig.enabled,
+        attachmentDirectFinalUpload: billingConfig.enabled,
       },
 
       // OAuth 配置（用于前端判断是否显示 OAuth 登录按钮）

--- a/server/tests/site.test.ts
+++ b/server/tests/site.test.ts
@@ -70,6 +70,11 @@ export class SiteTestSuite {
         false,
         'Upload sessions must not be advertised until the recovery API exists'
       );
+      TestAssertions.assertEquals(
+        status.ui?.attachmentDirectFinalUpload,
+        true,
+        'Direct final uploads should be advertised with batch finalization'
+      );
       TestAssertions.assertNotNull(
         typeof status.ai.available === 'boolean',
         'AI availability should be boolean'

--- a/server/utils/zod.ts
+++ b/server/utils/zod.ts
@@ -130,6 +130,7 @@ export const ReactionCreateZod = z.object({
 
 // 附件文件名验证
 export const AttachmentPresignZod = z.object({
+  directFinalUpload: z.boolean().optional(),
   files: z
     .array(
       z.object({
@@ -142,6 +143,12 @@ export const AttachmentPresignZod = z.object({
             filename: z.string().max(255, 'Filename cannot exceed 255 characters').optional(),
             contentType: z.string().min(1, 'Content type cannot be empty'),
             size: z.number().int().positive('File size must be greater than 0'),
+          })
+          .optional(),
+        poster: z
+          .object({
+            contentType: z.literal('image/jpeg'),
+            size: z.number().int().positive('Poster size must be greater than 0'),
           })
           .optional(),
       })


### PR DESCRIPTION
## Summary

- add an opt-in direct-final upload capability while preserving all legacy attachment endpoints
- presign final object keys for originals, Live Photo pairs, and client-generated video posters
- keep batch finalize idempotent and reduce the direct path to reservation/manifest validation plus one database transaction
- remove object HEAD, staging copy, and post-copy verification from the new direct path

## Compatibility

- existing clients continue using the unchanged staging and legacy finalize behavior
- OpenKey uploads remain on the legacy path
- the new flow is enabled only when the client observes attachmentDirectFinalUpload

## Verification

- bun test server/attachments/directFinalUpload.test.ts server/attachments/attachmentUpload.test.ts server/attachments/finalizeBatch.test.ts
- bun run lint
- bun run build