### PR TITLE
feat(api): report running server release version

### DIFF
--- a/.github/workflows/develop-deploy.yml
+++ b/.github/workflows/develop-deploy.yml
@@ -79,23 +79,3 @@ jobs:
             ${{ secrets.DOCKERHUB_USERNAME }}/rote-frontend:latest-dev
             ${{ secrets.DOCKERHUB_USERNAME }}/rote-frontend:develop
             ${{ secrets.DOCKERHUB_USERNAME }}/rote-frontend:develop-${{ github.sha }}
-
-  deploy-dokploy-dev:
-    needs:
-      - build-backend
-      - build-frontend
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Trigger Dokploy dev deployments
-        env:
-          BACKEND_WEBHOOK_URL: ${{ secrets.DOKPLOY_DEV_BACKEND_WEBHOOK_URL }}
-          FRONTEND_WEBHOOK_URL: ${{ secrets.DOKPLOY_DEV_FRONTEND_WEBHOOK_URL }}
-        run: |
-          if [[ -z "$BACKEND_WEBHOOK_URL" || -z "$FRONTEND_WEBHOOK_URL" ]]; then
-            echo "Dokploy dev webhook URLs are not configured" >&2
-            exit 1
-          fi
-
-          curl --fail --silent --show-error --output /dev/null --request POST "$BACKEND_WEBHOOK_URL"
-          curl --fail --silent --show-error --output /dev/null --request POST "$FRONTEND_WEBHOOK_URL"

--- a/.github/workflows/develop-deploy.yml
+++ b/.github/workflows/develop-deploy.yml
@@ -15,6 +15,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve backend release version
+        id: backend_release
+        run: echo "value=$(git describe --tags --match 'v[0-9]*' --always --dirty)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -34,6 +40,8 @@ jobs:
           file: ./server/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
+          build-args: |
+            ROTE_RELEASE_VERSION=${{ steps.backend_release.outputs.value }}
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/rote-backend:latest-dev
             ${{ secrets.DOCKERHUB_USERNAME }}/rote-backend:develop

--- a/.github/workflows/develop-deploy.yml
+++ b/.github/workflows/develop-deploy.yml
@@ -20,7 +20,10 @@ jobs:
 
       - name: Resolve backend release version
         id: backend_release
-        run: echo "value=$(git describe --tags --match 'v[0-9]*' --always --dirty)" >> "$GITHUB_OUTPUT"
+        shell: bash
+        run: |
+          description="$(git describe --tags --match 'v[0-9]*' --always --long --dirty)"
+          printf 'value=dev-%s\n' "$description" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/develop-deploy.yml
+++ b/.github/workflows/develop-deploy.yml
@@ -79,3 +79,23 @@ jobs:
             ${{ secrets.DOCKERHUB_USERNAME }}/rote-frontend:latest-dev
             ${{ secrets.DOCKERHUB_USERNAME }}/rote-frontend:develop
             ${{ secrets.DOCKERHUB_USERNAME }}/rote-frontend:develop-${{ github.sha }}
+
+  deploy-dokploy-dev:
+    needs:
+      - build-backend
+      - build-frontend
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Trigger Dokploy dev deployments
+        env:
+          BACKEND_WEBHOOK_URL: ${{ secrets.DOKPLOY_DEV_BACKEND_WEBHOOK_URL }}
+          FRONTEND_WEBHOOK_URL: ${{ secrets.DOKPLOY_DEV_FRONTEND_WEBHOOK_URL }}
+        run: |
+          if [[ -z "$BACKEND_WEBHOOK_URL" || -z "$FRONTEND_WEBHOOK_URL" ]]; then
+            echo "Dokploy dev webhook URLs are not configured" >&2
+            exit 1
+          fi
+
+          curl --fail --silent --show-error --output /dev/null --request POST "$BACKEND_WEBHOOK_URL"
+          curl --fail --silent --show-error --output /dev/null --request POST "$FRONTEND_WEBHOOK_URL"

--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -17,6 +17,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve backend release version
+        id: backend_release
+        run: echo "value=$(git describe --tags --match 'v[0-9]*' --always --dirty)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -36,6 +42,8 @@ jobs:
           file: ./server/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
+          build-args: |
+            ROTE_RELEASE_VERSION=${{ steps.backend_release.outputs.value }}
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/rote-backend:latest
             ${{ secrets.DOCKERHUB_USERNAME }}/rote-backend:release

--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -25,8 +25,9 @@ jobs:
         shell: bash
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
+          IS_STABLE_RELEASE: ${{ github.event_name == 'release' && github.event.release.prerelease == false }}
         run: |
-          if [[ "$GITHUB_EVENT_NAME" == "release" && "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if [[ "$IS_STABLE_RELEASE" == "true" && "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             value="$RELEASE_TAG"
           else
             description="$(git describe --tags --match 'v[0-9]*' --always --long --dirty)"

--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -22,7 +22,17 @@ jobs:
 
       - name: Resolve backend release version
         id: backend_release
-        run: echo "value=$(git describe --tags --match 'v[0-9]*' --always --dirty)" >> "$GITHUB_OUTPUT"
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" == "release" && "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            value="$RELEASE_TAG"
+          else
+            description="$(git describe --tags --match 'v[0-9]*' --always --long --dirty)"
+            value="dev-$description"
+          fi
+          printf 'value=%s\n' "$value" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/doc/develop/VERSION-RELEASE-GUIDE.md
+++ b/doc/develop/VERSION-RELEASE-GUIDE.md
@@ -87,7 +87,7 @@ git push origin main
 
 Dokploy dev 应用应分别使用 `rabithua/rote-backend:develop` 和
 `rabithua/rote-frontend:develop`，并在对应 Docker Hub repository 中配置应用专属的 Dokploy
-Webhook URL。Docker Hub 在 `develop` tag 推送完成后通知 Dokploy；Dokploy 仅在 webhook 中的 tag
+HTTPS Webhook URL。Docker Hub 在 `develop` tag 推送完成后通知 Dokploy；Dokploy 仅在 webhook 中的 tag
 与应用配置的镜像 tag 匹配时部署，因此不需要在 GitHub Actions 中保存 Dokploy 凭据。
 
 ## 验证构建

--- a/doc/develop/VERSION-RELEASE-GUIDE.md
+++ b/doc/develop/VERSION-RELEASE-GUIDE.md
@@ -21,7 +21,6 @@
    ```
 
 2. **在 GitHub 上创建 Release**
-
    - 访问 GitHub 仓库页面
    - 点击右侧 "Releases" → "Draft a new release"
    - 选择刚创建的标签（如 `v1.0.0`）
@@ -38,7 +37,6 @@
 发布 `v1.0.0` 版本后，会生成以下镜像：
 
 - **后端镜像**:
-
   - `rote-backend:latest`
   - `rote-backend:v1.0.0`
 
@@ -75,6 +73,9 @@ git push origin main
 - `v1.1.0` - 新增功能
 - `v1.1.1` - 修复 bug
 - `v2.0.0` - 重大更新，不兼容旧版本
+
+只有非 Pre-release 的 GitHub Release 且 tag 严格匹配 `vMAJOR.MINOR.PATCH` 时，Server
+运行版本才使用该稳定 tag；`main`/`develop` 分支构建和 Pre-release 均使用 `dev-<git describe>`。
 
 ## 环境变量配置
 

--- a/doc/develop/VERSION-RELEASE-GUIDE.md
+++ b/doc/develop/VERSION-RELEASE-GUIDE.md
@@ -84,6 +84,15 @@ git push origin main
 - `DOCKERHUB_TOKEN`: Docker Hub 访问令牌
 - `VITE_API_BASE`: 前端 API 基础 URL（生产环境必须配置）
 
+`develop` 分支的镜像构建成功后会触发 Dokploy dev 环境更新。仓库还需要配置以下 Actions Secrets：
+
+- `DOKPLOY_DEV_BACKEND_WEBHOOK_URL`: Dokploy dev 后端应用的专用部署 Webhook URL
+- `DOKPLOY_DEV_FRONTEND_WEBHOOK_URL`: Dokploy dev 前端应用的专用部署 Webhook URL
+
+Dokploy dev 应用应分别使用 `rabithua/rote-backend:develop` 和
+`rabithua/rote-frontend:develop`。部署任务依赖前后端两个镜像构建任务，仅在两者均成功后触发，
+避免 Dokploy 在新镜像推送完成前拉取旧 tag。
+
 ## 验证构建
 
 构建完成后，可以在以下位置验证：

--- a/doc/develop/VERSION-RELEASE-GUIDE.md
+++ b/doc/develop/VERSION-RELEASE-GUIDE.md
@@ -84,14 +84,10 @@ git push origin main
 - `DOCKERHUB_TOKEN`: Docker Hub 访问令牌
 - `VITE_API_BASE`: 前端 API 基础 URL（生产环境必须配置）
 
-`develop` 分支的镜像构建成功后会触发 Dokploy dev 环境更新。仓库还需要配置以下 Actions Secrets：
-
-- `DOKPLOY_DEV_BACKEND_WEBHOOK_URL`: Dokploy dev 后端应用的专用部署 Webhook URL
-- `DOKPLOY_DEV_FRONTEND_WEBHOOK_URL`: Dokploy dev 前端应用的专用部署 Webhook URL
-
 Dokploy dev 应用应分别使用 `rabithua/rote-backend:develop` 和
-`rabithua/rote-frontend:develop`。部署任务依赖前后端两个镜像构建任务，仅在两者均成功后触发，
-避免 Dokploy 在新镜像推送完成前拉取旧 tag。
+`rabithua/rote-frontend:develop`，并在对应 Docker Hub repository 中配置应用专属的 Dokploy
+Webhook URL。Docker Hub 在 `develop` tag 推送完成后通知 Dokploy；Dokploy 仅在 webhook 中的 tag
+与应用配置的镜像 tag 匹配时部署，因此不需要在 GitHub Actions 中保存 Dokploy 凭据。
 
 ## 验证构建
 

--- a/doc/userguide/SITE-API.md
+++ b/doc/userguide/SITE-API.md
@@ -97,7 +97,7 @@ curl -X GET 'https://your-domain.com/v2/api/site/status'
     },
     "system": {
       "version": "1.0.0",
-      "releaseVersion": "v2.1.0",
+      "releaseVersion": "v2.2.0",
       "lastMigration": "1.0.0"
     },
     "notification": {
@@ -150,8 +150,8 @@ curl -X GET 'https://your-domain.com/v2/api/site/status'
     - `content`: string - 公告内容
     - `link`: string | undefined - 公告链接
 - `system`: object - 系统信息
-  - `version`: string - 实例首次初始化时的版本（兼容旧客户端）
-  - `releaseVersion`: string - 当前运行镜像的 Release tag 或构建标识
+  - `version`: string - 实例首次初始化时的版本；为兼容旧客户端保留，不能用于判断当前 Server 镜像版本
+  - `releaseVersion`: string - 当前运行 Server 镜像的版本；稳定 Release 为 `vMAJOR.MINOR.PATCH`，开发构建为 `dev-<git describe>`，无法取得构建信息时为 `dev-unknown`
   - `lastMigration`: string - 最后迁移版本
 - `notification`: object - 通知配置
   - `vapidPublicKey`: string | null - VAPID 公钥（用于 Web Push 通知）
@@ -215,7 +215,7 @@ curl -X GET 'https://your-domain.com/v2/api/site/config-status'
     },
     "system": {
       "version": "1.0.0",
-      "releaseVersion": "v2.1.0"
+      "releaseVersion": "v2.2.0"
     }
   }
 }
@@ -243,8 +243,8 @@ curl -X GET 'https://your-domain.com/v2/api/site/config-status'
   - `description`: string - 站点描述
   - `frontendUrl`: string - 前端地址
 - `system`: object（仅当已初始化时返回）- 系统信息
-  - `version`: string - 实例首次初始化时的版本（兼容旧客户端）
-  - `releaseVersion`: string - 当前运行镜像的 Release tag 或构建标识
+  - `version`: string - 实例首次初始化时的版本；为兼容旧客户端保留，不能用于判断当前 Server 镜像版本
+  - `releaseVersion`: string - 当前运行 Server 镜像的版本；格式与 `/status` 中的同名字段一致
 - `requiresSetup`: boolean（仅当未初始化时返回）- 是否需要设置
 - `setupSteps`: string[]（仅当未初始化时返回）- 需要完成的设置步骤列表
 
@@ -271,6 +271,7 @@ curl -X GET 'https://your-domain.com/v2/api/site/config-status'
 - **存储配置**: 通过 `storage.r2Configured` 判断附件上传功能是否可用，通过 `storage.urlPrefix` 获取附件访问地址前缀
 - **Web Push**: 使用 `notification.vapidPublicKey` 实现 Web Push 通知功能
 - **OAuth 登录**: 根据 `oauth.enabled` 和 `oauth.providers` 动态显示 OAuth 登录按钮，支持多个提供商（如 GitHub、Apple 等）
+- **版本判断**: 只有当 `system.releaseVersion` 严格匹配 `^v\d+\.\d+\.\d+$` 时，才将其作为稳定版本与最新 Release 比较；`dev-*` 表示分支或本地开发镜像，客户端不应把它判定为落后的稳定版
 
 ---
 

--- a/doc/userguide/SITE-API.md
+++ b/doc/userguide/SITE-API.md
@@ -97,6 +97,7 @@ curl -X GET 'https://your-domain.com/v2/api/site/status'
     },
     "system": {
       "version": "1.0.0",
+      "releaseVersion": "v2.1.0",
       "lastMigration": "1.0.0"
     },
     "notification": {
@@ -149,7 +150,8 @@ curl -X GET 'https://your-domain.com/v2/api/site/status'
     - `content`: string - 公告内容
     - `link`: string | undefined - 公告链接
 - `system`: object - 系统信息
-  - `version`: string - 系统版本
+  - `version`: string - 实例首次初始化时的版本（兼容旧客户端）
+  - `releaseVersion`: string - 当前运行镜像的 Release tag 或构建标识
   - `lastMigration`: string - 最后迁移版本
 - `notification`: object - 通知配置
   - `vapidPublicKey`: string | null - VAPID 公钥（用于 Web Push 通知）
@@ -212,7 +214,8 @@ curl -X GET 'https://your-domain.com/v2/api/site/config-status'
       "frontendUrl": "https://rote.ink"
     },
     "system": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "releaseVersion": "v2.1.0"
     }
   }
 }
@@ -240,7 +243,8 @@ curl -X GET 'https://your-domain.com/v2/api/site/config-status'
   - `description`: string - 站点描述
   - `frontendUrl`: string - 前端地址
 - `system`: object（仅当已初始化时返回）- 系统信息
-  - `version`: string - 系统版本
+  - `version`: string - 实例首次初始化时的版本（兼容旧客户端）
+  - `releaseVersion`: string - 当前运行镜像的 Release tag 或构建标识
 - `requiresSetup`: boolean（仅当未初始化时返回）- 是否需要设置
 - `setupSteps`: string[]（仅当未初始化时返回）- 需要完成的设置步骤列表
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -103,7 +103,9 @@ RUN rm -rf /app/node_modules/.cache /tmp/* /var/cache/apk/* && \
       -delete 2>/dev/null || true
 
 # 设置环境变量，提升性能
-ENV NODE_ENV=production
+ARG ROTE_RELEASE_VERSION=unknown
+ENV NODE_ENV=production \
+    ROTE_RELEASE_VERSION=${ROTE_RELEASE_VERSION}
 
 # 切换到非 root 用户
 USER bunuser

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -103,7 +103,7 @@ RUN rm -rf /app/node_modules/.cache /tmp/* /var/cache/apk/* && \
       -delete 2>/dev/null || true
 
 # 设置环境变量，提升性能
-ARG ROTE_RELEASE_VERSION=unknown
+ARG ROTE_RELEASE_VERSION=dev-unknown
 ENV NODE_ENV=production \
     ROTE_RELEASE_VERSION=${ROTE_RELEASE_VERSION}
 

--- a/server/release/releaseVersion.test.ts
+++ b/server/release/releaseVersion.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'bun:test';
+import { getReleaseVersion, UNKNOWN_RELEASE_VERSION } from './releaseVersion';
+
+describe('server release version', () => {
+  it('reports an injected stable release tag unchanged', () => {
+    expect(getReleaseVersion({ ROTE_RELEASE_VERSION: 'v2.2.0' })).toBe('v2.2.0');
+  });
+
+  it('keeps development build identifiers distinct from stable tags', () => {
+    expect(getReleaseVersion({ ROTE_RELEASE_VERSION: 'dev-v2.2.0-3-g1a2b3c4' })).toBe(
+      'dev-v2.2.0-3-g1a2b3c4'
+    );
+  });
+
+  it('trims injected values and uses a non-semver fallback for local builds', () => {
+    expect(getReleaseVersion({ ROTE_RELEASE_VERSION: '  v2.2.0  ' })).toBe('v2.2.0');
+    expect(getReleaseVersion({ ROTE_RELEASE_VERSION: '   ' })).toBe(UNKNOWN_RELEASE_VERSION);
+    expect(getReleaseVersion({})).toBe(UNKNOWN_RELEASE_VERSION);
+  });
+});

--- a/server/release/releaseVersion.ts
+++ b/server/release/releaseVersion.ts
@@ -1,0 +1,5 @@
+export const UNKNOWN_RELEASE_VERSION = 'dev-unknown';
+
+export function getReleaseVersion(environment: NodeJS.ProcessEnv = process.env): string {
+  return environment.ROTE_RELEASE_VERSION?.trim() || UNKNOWN_RELEASE_VERSION;
+}

--- a/server/route/v2/site.ts
+++ b/server/route/v2/site.ts
@@ -17,13 +17,10 @@ import {
 import { createResponse } from '../../utils/main';
 import { generateSitemapXML } from '../../utils/sitemap';
 import { billingConfig } from '../../billing/runtimeConfig';
+import { getReleaseVersion } from '../../release/releaseVersion';
 
 // 站点数据相关路由
 const siteRouter = new Hono<{ Variables: HonoVariables }>();
-
-function getReleaseVersion() {
-  return process.env.ROTE_RELEASE_VERSION?.trim() || 'unknown';
-}
 
 async function getPublicAiStatus() {
   const fallback = {

--- a/server/route/v2/site.ts
+++ b/server/route/v2/site.ts
@@ -21,6 +21,10 @@ import { billingConfig } from '../../billing/runtimeConfig';
 // 站点数据相关路由
 const siteRouter = new Hono<{ Variables: HonoVariables }>();
 
+function getReleaseVersion() {
+  return process.env.ROTE_RELEASE_VERSION?.trim() || 'unknown';
+}
+
 async function getPublicAiStatus() {
   const fallback = {
     enabled: false,
@@ -162,6 +166,7 @@ siteRouter.get('/status', async (c: HonoContext) => {
       // 系统信息
       system: {
         version: (systemConfig as any)?.initializationVersion || '1.0.0',
+        releaseVersion: getReleaseVersion(),
         lastMigration: (systemConfig as any)?.lastMigrationVersion || 'unknown',
       },
 
@@ -262,6 +267,7 @@ siteRouter.get('/config-status', async (c: HonoContext) => {
           },
           system: {
             version: (systemConfig as any)?.initializationVersion || '1.0.0',
+            releaseVersion: getReleaseVersion(),
           },
         }),
         200

--- a/server/tests/site.test.ts
+++ b/server/tests/site.test.ts
@@ -64,6 +64,11 @@ export class SiteTestSuite {
       TestAssertions.assertNotNull(status.isInitialized, 'isInitialized should be present');
       TestAssertions.assertNotNull(status.databaseConnected, 'databaseConnected should be present');
       TestAssertions.assertNotNull(status.site, 'Site info should be present');
+      TestAssertions.assertNotNull(status.system, 'System info should be present');
+      TestAssertions.assertNotNull(
+        status.system.releaseVersion,
+        'Server release version should be present'
+      );
       TestAssertions.assertNotNull(status.ai, 'AI status should be present');
       TestAssertions.assertEquals(
         status.ui?.attachmentUploadSessions,

--- a/server/tests/site.test.ts
+++ b/server/tests/site.test.ts
@@ -118,6 +118,13 @@ export class SiteTestSuite {
         typeof configStatus.isInitialized === 'boolean',
         'isInitialized should be boolean'
       );
+      if (configStatus.isInitialized) {
+        TestAssertions.assertNotNull(configStatus.system, 'System info should be present');
+        TestAssertions.assertNotNull(
+          configStatus.system.releaseVersion,
+          'Server release version should be present'
+        );
+      }
 
       const duration = Date.now() - startTime;
       this.resultManager.recordResult(


### PR DESCRIPTION
## Summary
- add backward-compatible `system.releaseVersion` reporting without changing legacy `system.version`
- inject stable GitHub Release tags or clearly marked `dev-<git describe>` identifiers into backend images
- cover runtime fallback behavior and SITE API responses, and document client comparison rules

## Validation
- `bun test release/releaseVersion.test.ts` (3 pass, 0 fail)
- `bun run lint` (pass)
- `bun run build` (pass)

## Release safety
This PR is ready for review but intentionally not merged because pushes to `develop` trigger deployment, which is outside the authorized scope.