### PR TITLE
fix(ai): validate embedding contracts and rebuild indexes by generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,59 @@ jobs:
       - name: Type check
         working-directory: ${{ matrix.path }}
         run: bun run build
+
+  embedding-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install --frozen-lockfile
+        working-directory: server
+      - run: bun test embeddings/client.test.ts tests/aiClient.test.ts tests/aiAccess.test.ts
+        working-directory: server
+      - run: bun install --frozen-lockfile
+        working-directory: web
+      - run: bun run test -- src/pages/admin/components/EmbeddingConfig.test.tsx src/pages/admin/components/AIIndexingActions.test.tsx
+        working-directory: web
+
+  embedding-database:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - image: pgvector/pgvector:pg17-trixie
+            database: rote_embedding_test
+            suite: index.integration.test.ts
+          - image: postgres:17
+            database: legacy_embedding_test
+            suite: migration.test.ts
+    services:
+      postgres:
+        image: ${{ matrix.image }}
+        env:
+          POSTGRES_USER: rote
+          POSTGRES_PASSWORD: embedding_test
+          POSTGRES_DB: ${{ matrix.database }}
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      POSTGRESQL_URL: postgres://rote:embedding_test@127.0.0.1:5432/${{ matrix.database }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install --frozen-lockfile
+        working-directory: server
+      - if: matrix.suite == 'index.integration.test.ts'
+        run: bun run db:migrate:programmatic
+        working-directory: server
+      - run: bun test embeddings/${{ matrix.suite }}
+        working-directory: server

--- a/doc/userguide/AI-VECTOR-MIGRATION.zh.md
+++ b/doc/userguide/AI-VECTOR-MIGRATION.zh.md
@@ -20,7 +20,7 @@
 2. 保持 `POSTGRES_PASSWORD`、数据库卷名和 PostgreSQL 大版本不变。
 3. 将 PostgreSQL 镜像切到带 pgvector 扩展的镜像，例如 `pgvector/pgvector:pg17-trixie`。
 4. 先让新版后端执行数据库迁移，再在 Admin 后台启用 AI 与向量能力。
-5. 存量数据不会自动全部向量化，需要管理员执行 backfill。
+5. 存量数据不会自动全部向量化，需要管理员明确启动重建。
 
 ## 迁移前检查
 
@@ -149,22 +149,23 @@ docker exec rote-postgres psql -U rote -d rote -c "select to_regclass('public.do
 `启用 pgvector` 会执行：
 
 - `CREATE EXTENSION IF NOT EXISTS vector`
-- 为当前 embedding dimensions 创建 HNSW 向量索引
+
+保存并验证模型后，“重建向量索引”会按实际维度和新代次创建 HNSW 索引。
 
 可以用 SQL 检查扩展与索引：
 
 ```bash
 docker exec rote-postgres psql -U rote -d rote -c "select extname, extversion from pg_extension where extname = 'vector';"
-docker exec rote-postgres psql -U rote -d rote -c "select indexname from pg_indexes where tablename = 'document_embeddings' and indexname like 'document_embeddings_embedding_hnsw_%';"
+docker exec rote-postgres psql -U rote -d rote -c "select indexname from pg_indexes where tablename = 'document_embeddings' and indexname like 'embedding_%_idx';"
 ```
 
-如果你修改了 embedding dimensions，需要重新点击 `启用 pgvector` 以创建匹配维度的索引，并重新向量化存量数据。
+修改模型输出设置后，保存配置并明确启动重建。无需重新安装扩展。
 
 ## 向量化存量数据
 
 迁移只会创建表结构，不会立即把所有历史笔记和文章向量化。管理员需要在 `AI 相关` 页面执行：
 
-1. 点击 `索引存量数据`。
+1. 保存并验证配置后，点击 `重建向量索引`，确认模型调用费用。
 2. 观察任务统计中的 pending/running/succeeded/failed。
 3. 等待后台 worker 自动处理，或点击 `立即处理`。
 
@@ -181,7 +182,7 @@ docker exec rote-postgres psql -U rote -d rote -c "select count(*) as embeddings
 2. 修复配置后点击 `重试失败任务`。
 3. 再点击 `立即处理`，或等待 worker 自动处理。
 
-如果想完全重建索引，可以在 Admin 页面点击 `清空索引`，然后重新执行 `索引存量数据`。这只会清空 `document_embeddings` 和 `embedding_jobs`，不会删除原始笔记或文章。
+如需重新构建，请使用 `重建向量索引`；历史向量会保留。只有确实需要删除全部代次数据时才执行 `清空索引`，该操作不会删除原始笔记或文章。
 
 ## 迁移后验证
 
@@ -255,11 +256,11 @@ docker exec -i rote-postgres pg_restore -U rote -d rote --clean --if-exists < ro
 
 ### Embedding dimensions mismatch
 
-Embedding Provider 实际返回的向量维度和 Admin 中配置的 dimensions 不一致。请修正 dimensions，重新点击 `启用 pgvector`，然后清空索引并重新 backfill。
+模型实际输出与指定维度或已验证维度不一致。请检查模型能力，选择默认输出或模型支持的指定维度，保存验证后明确启动重建。
 
 ### backfill 很慢
 
-存量笔记多、文章长、模型供应商速率限制较低时，backfill 会比较慢。可以先保持站点正常使用，让后台 worker 慢慢处理；新创建或编辑的内容会在开启自动索引后进入任务队列。
+存量笔记多、文章长、模型供应商速率限制较低时，重建会比较慢。可以保持站点正常使用，让后台 worker 处理；重建期间创建或编辑的内容会通过数据库变更事件进入任务队列，即使日常自动索引关闭。
 
 ### 语义搜索没有结果
 
@@ -272,3 +273,32 @@ Embedding Provider 实际返回的向量维度和 Admin 中配置的 dimensions 
 5. `document_embeddings` 是否有数据。
 6. 当前用户是否有对应内容的访问权限。
 
+
+
+## 向量模型契约升级（Issue #318）
+
+升级到本次版本会执行正式数据库迁移。原有笔记、文章和向量记录都会保留；历史向量没有可靠的供应商配置标识，因此不会自动归入新的索引。迁移不调用模型，不安装 pgvector，不启动全量重建。
+
+升级后向量检索暂停，普通聊天仍可使用。管理员需要：
+
+1. 打开管理后台的 AI 配置。旧的维度设置会保留为“指定输出维度”，以保留原有降维意图。
+2. 对 BGE-M3 等固定维度模型选择“使用模型默认维度”，再测试连接。硅基流动的 `BAAI/bge-m3` 应返回 1024 维，原生模式不会发送 `dimensions` 参数。
+3. 只有需要并支持指定输出维度的模型才使用指定模式。当前全精度 HNSW 索引支持整数 1–2000 维；模型返回更高维度时需要配置模型支持的较小输出，系统不会截断向量。
+4. 保存配置。启用向量功能时，后端会实际验证模型响应，测试成功不等于已经保存。验证失败不会覆盖原配置。
+5. 如有需要，使用“启用 pgvector”安装扩展。这个动作不再创建未验证维度的索引。
+6. 点击“重建向量索引”，确认检索暂停和模型调用费用后启动。重建完成后自动恢复向量检索。
+
+更换供应商、地址、模型、输出模式或分块配置会要求新一轮重建。API Key 轮换需要验证，但输出契约一致时无需重建。多个管理员同时修改配置时，旧版本保存会返回冲突，刷新后再编辑。
+
+重建进度保存在数据库中，服务重启后继续处理。重建期间新增和修改的内容也会被处理，即使日常自动索引关闭。暂停队列会停止扫描和领取新任务；已经执行的请求可完成。失败任务显示失败状态，修复配置或供应商问题后重试；参数和向量格式错误不会自动更改参数重试。
+
+旧向量保留用于追溯，不参与当前检索。明确执行“清空索引”会删除所有代次向量和队列任务，并要求重建。切勿通过回退应用版本直接使用升级后的数据库；如需整体回滚，应同时恢复升级前的应用版本和数据库备份。
+
+### 管理接口变化
+
+- AI 配置为 `schemaVersion: 2`，包含服务端返回的 `revision`。保存必须携带当前版本。
+- `embedding.output` 为 `{ "mode": "native" }` 或 `{ "mode": "dimensions", "dimensions": 1024 }`。旧的 `embedding.dimensions` 不再接受写入。
+- `POST /v2/api/ai/test` 的向量结果包含实际维度、输出模式和数据库准备状态，不产生配置写入。
+- `POST /v2/api/ai/index/rebuild` 接收 `{ "revision": 1 }`，返回 HTTP 202 和持久化重建状态；重复请求同一轮重建不会重复启动。
+- `/v2/api/ai/vector/status` 返回当前代次、维度、配置版本、状态、错误码及 `ready`。`ready` 为真才表示向量检索已准备好。
+- 错误继续采用 `{ code, message, data }` 响应格式；`message` 为 `embedding_*` 错误码，`data` 提供相关数值和供应商 HTTP 状态，不返回原始供应商响应或认证信息。

--- a/server/authz/aiAccess.ts
+++ b/server/authz/aiAccess.ts
@@ -21,7 +21,8 @@ type PgvectorStatus = {
   installed: boolean;
   version: string | null;
   indexName: string | null;
-  dimensions: number;
+  dimensions: number | null;
+  ready: boolean;
 };
 
 export function getAiAccessErrorFromAccess(access: AiAccess): string | null {
@@ -42,7 +43,8 @@ export function isAiMemoryAvailableForAccess(params: {
     getAiAccessErrorFromAccess(params.access) === null &&
     params.config.enabled === true &&
     params.config.vectorEnabled === true &&
-    params.vectorStatus.installed === true
+    params.vectorStatus.installed === true &&
+    params.vectorStatus.ready === true
   );
 }
 

--- a/server/drizzle/migrations/0030_embedding_contract.sql
+++ b/server/drizzle/migrations/0030_embedding_contract.sql
@@ -1,0 +1,41 @@
+CREATE TABLE "embedding_index_state" (
+	"id" integer PRIMARY KEY DEFAULT 1 NOT NULL,
+	"revision" integer DEFAULT 0 NOT NULL,
+	"fingerprint" text,
+	"dimensions" integer,
+	"generationId" uuid,
+	"status" text DEFAULT 'needs_validation' NOT NULL,
+	"scanSource" text DEFAULT 'rote' NOT NULL,
+	"scanCursor" uuid,
+	"scanComplete" boolean DEFAULT false NOT NULL,
+	"errorCode" text,
+	"validatedAt" timestamp (6) with time zone,
+	"updatedAt" timestamp (6) with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "embedding_index_state_singleton" CHECK ("embedding_index_state"."id" = 1),
+	CONSTRAINT "embedding_index_dimensions_range" CHECK ("embedding_index_state"."dimensions" BETWEEN 1 AND 2000)
+);
+--> statement-breakpoint
+ALTER TABLE "document_embeddings" DROP CONSTRAINT "document_embeddings_source_chunk_unique";--> statement-breakpoint
+ALTER TABLE "document_embeddings" ADD COLUMN "generationId" uuid;--> statement-breakpoint
+ALTER TABLE "embedding_jobs" ADD COLUMN "generationId" uuid;--> statement-breakpoint
+ALTER TABLE "embedding_jobs" ADD COLUMN "leaseToken" uuid;--> statement-breakpoint
+ALTER TABLE "embedding_jobs" ADD COLUMN "leaseExpiresAt" timestamp (6) with time zone;--> statement-breakpoint
+ALTER TABLE "embedding_jobs" ADD COLUMN "nextAttemptAt" timestamp (6) with time zone DEFAULT now() NOT NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX "embedding_jobs_pending_source_idx" ON "embedding_jobs" USING btree ("generationId","sourceType","sourceId") WHERE "embedding_jobs"."status" = 'pending';--> statement-breakpoint
+CREATE UNIQUE INDEX "embedding_jobs_running_source_idx" ON "embedding_jobs" USING btree ("generationId","sourceType","sourceId") WHERE "embedding_jobs"."status" = 'running';--> statement-breakpoint
+ALTER TABLE "document_embeddings" ADD CONSTRAINT "document_embeddings_generation_source_chunk_unique" UNIQUE("generationId","sourceType","sourceId","chunkIndex");
+--> statement-breakpoint
+INSERT INTO "embedding_index_state" ("id") VALUES (1);
+--> statement-breakpoint
+UPDATE "embedding_jobs" SET "status" = 'cancelled', "lockedAt" = NULL
+WHERE "status" IN ('pending', 'running');
+--> statement-breakpoint
+UPDATE "settings" SET "config" =
+  jsonb_set(
+    jsonb_set("config", '{embedding}',
+      (COALESCE("config"->'embedding', '{}'::jsonb) - 'dimensions') ||
+      jsonb_build_object('output', CASE
+        WHEN "config"->'embedding' ? 'dimensions' THEN jsonb_build_object('mode', 'dimensions', 'dimensions', "config"->'embedding'->'dimensions')
+        ELSE '{"mode":"native"}'::jsonb END)),
+    '{schemaVersion}', '2'::jsonb) || '{"revision":0}'::jsonb
+WHERE "group" = 'ai';

--- a/server/drizzle/migrations/0031_embedding_source_events.sql
+++ b/server/drizzle/migrations/0031_embedding_source_events.sql
@@ -1,0 +1,40 @@
+CREATE TABLE "embedding_source_events" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"sourceType" text NOT NULL,
+	"sourceId" uuid NOT NULL,
+	"ownerId" uuid NOT NULL,
+	"action" text NOT NULL,
+	"generationId" uuid,
+	"rebuilding" boolean DEFAULT false NOT NULL,
+	"createdAt" timestamp (6) with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "embedding_source_events_pending_idx" ON "embedding_source_events" USING btree ("createdAt","id");
+--> statement-breakpoint
+-- Commit content changes and their indexing events together. No provider calls,
+-- pgvector dependency, or index-state locks are taken by these triggers.
+CREATE FUNCTION record_embedding_source_event() RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE
+  source jsonb;
+  active_generation uuid;
+  rebuilding boolean;
+BEGIN
+  source := CASE WHEN TG_OP = 'DELETE' THEN to_jsonb(OLD) ELSE to_jsonb(NEW) END;
+  SELECT "generationId", status IN ('rebuilding', 'failed')
+    INTO active_generation, rebuilding FROM embedding_index_state WHERE id = 1;
+  INSERT INTO embedding_source_events ("sourceType", "sourceId", "ownerId", action, "generationId", rebuilding)
+    VALUES (TG_ARGV[0], (source->>'id')::uuid, (source->>TG_ARGV[1])::uuid,
+      CASE WHEN TG_OP = 'DELETE' THEN 'delete' ELSE 'upsert' END,
+      active_generation, COALESCE(rebuilding, false));
+  RETURN NULL;
+END;
+$$;
+--> statement-breakpoint
+CREATE TRIGGER rote_embedding_event AFTER INSERT OR UPDATE OR DELETE ON rotes
+FOR EACH ROW EXECUTE FUNCTION record_embedding_source_event('rote', 'authorid');
+--> statement-breakpoint
+CREATE TRIGGER article_embedding_event AFTER INSERT OR UPDATE OR DELETE ON articles
+FOR EACH ROW EXECUTE FUNCTION record_embedding_source_event('article', 'authorId');
+
+--> statement-breakpoint
+ALTER TABLE "embedding_index_state" ADD COLUMN "errorDetails" jsonb;

--- a/server/drizzle/migrations/meta/0030_snapshot.json
+++ b/server/drizzle/migrations/meta/0030_snapshot.json
@@ -1,0 +1,5041 @@
+{
+  "id": "b31dd75b-f5a9-494b-9f7b-5269b1764390",
+  "prevId": "39e9919b-7067-4c7c-8db8-36a7e9f1ac81",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ai_token_usage_logs": {
+      "name": "ai_token_usage_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "promptTokens": {
+          "name": "promptTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "completionTokens": {
+          "name": "completionTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalTokens": {
+          "name": "totalTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_token_usage_logs_userid_idx": {
+          "name": "ai_token_usage_logs_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_token_usage_logs_createdAt_idx": {
+          "name": "ai_token_usage_logs_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_token_usage_logs_userid_users_id_fk": {
+          "name": "ai_token_usage_logs_userid_users_id_fk",
+          "tableFrom": "ai_token_usage_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apns_devices": {
+      "name": "apns_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installationId": {
+          "name": "installationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "masterEnabled": {
+          "name": "masterEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "timeZone": {
+          "name": "timeZone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "lastSeenAt": {
+          "name": "lastSeenAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "apns_devices_userid_idx": {
+          "name": "apns_devices_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "apns_devices_userid_users_id_fk": {
+          "name": "apns_devices_userid_users_id_fk",
+          "tableFrom": "apns_devices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "apns_devices_installation_id_unique": {
+          "name": "apns_devices_installation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "installationId"
+          ]
+        },
+        "apns_devices_token_environment_unique": {
+          "name": "apns_devices_token_environment_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token",
+            "environment"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.articles": {
+      "name": "articles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorId": {
+          "name": "authorId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "articles_authorId_idx": {
+          "name": "articles_authorId_idx",
+          "columns": [
+            {
+              "expression": "authorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "articles_authorId_users_id_fk": {
+          "name": "articles_authorId_users_id_fk",
+          "tableFrom": "articles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "authorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attachments": {
+      "name": "attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compressUrl": {
+          "name": "compressUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "posterUrl": {
+          "name": "posterUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roteid": {
+          "name": "roteid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage": {
+          "name": "storage",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sortIndex": {
+          "name": "sortIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "attachments_userid_idx": {
+          "name": "attachments_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attachments_roteid_idx": {
+          "name": "attachments_roteid_idx",
+          "columns": [
+            {
+              "expression": "roteid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attachments_roteid_sortIndex_idx": {
+          "name": "attachments_roteid_sortIndex_idx",
+          "columns": [
+            {
+              "expression": "roteid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sortIndex",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attachments_userid_users_id_fk": {
+          "name": "attachments_userid_users_id_fk",
+          "tableFrom": "attachments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "attachments_roteid_rotes_id_fk": {
+          "name": "attachments_roteid_rotes_id_fk",
+          "tableFrom": "attachments",
+          "tableTo": "rotes",
+          "columnsFrom": [
+            "roteid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_grants": {
+      "name": "billing_grants",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entitlement_expires_at": {
+          "name": "entitlement_expires_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "benefits": {
+          "name": "benefits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_hash": {
+          "name": "snapshot_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "billing_grants_lease_expires_at_idx": {
+          "name": "billing_grants_lease_expires_at_idx",
+          "columns": [
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_grants_user_id_users_id_fk": {
+          "name": "billing_grants_user_id_users_id_fk",
+          "tableFrom": "billing_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "billing_grants_revision_non_negative": {
+          "name": "billing_grants_revision_non_negative",
+          "value": "\"billing_grants\".\"revision\" >= 0"
+        },
+        "billing_grants_valid_status": {
+          "name": "billing_grants_valid_status",
+          "value": "\"billing_grants\".\"status\" IN ('active', 'grace_period', 'none')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.billing_inbound_deliveries": {
+      "name": "billing_inbound_deliveries",
+      "schema": "",
+      "columns": {
+        "direction": {
+          "name": "direction",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_id": {
+          "name": "key_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_target": {
+          "name": "request_target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_hash": {
+          "name": "body_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "billing_inbound_deliveries_created_at_idx": {
+          "name": "billing_inbound_deliveries_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "billing_inbound_deliveries_direction_delivery_id_pk": {
+          "name": "billing_inbound_deliveries_direction_delivery_id_pk",
+          "columns": [
+            "direction",
+            "delivery_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "billing_inbound_deliveries_paid_to_rote_direction": {
+          "name": "billing_inbound_deliveries_paid_to_rote_direction",
+          "value": "\"billing_inbound_deliveries\".\"direction\" = 'paid_to_rote'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.document_embeddings": {
+      "name": "document_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "generationId": {
+          "name": "generationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceType": {
+          "name": "sourceType",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceId": {
+          "name": "sourceId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunkIndex": {
+          "name": "chunkIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contentHash": {
+          "name": "contentHash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embeddingModel": {
+          "name": "embeddingModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embeddingDimensions": {
+          "name": "embeddingDimensions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_embeddings_ownerId_idx": {
+          "name": "document_embeddings_ownerId_idx",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_embeddings_source_idx": {
+          "name": "document_embeddings_source_idx",
+          "columns": [
+            {
+              "expression": "sourceType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sourceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_embeddings_owner_source_idx": {
+          "name": "document_embeddings_owner_source_idx",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sourceType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_embeddings_model_dimensions_idx": {
+          "name": "document_embeddings_model_dimensions_idx",
+          "columns": [
+            {
+              "expression": "embeddingModel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "embeddingDimensions",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_embeddings_ownerId_users_id_fk": {
+          "name": "document_embeddings_ownerId_users_id_fk",
+          "tableFrom": "document_embeddings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "document_embeddings_generation_source_chunk_unique": {
+          "name": "document_embeddings_generation_source_chunk_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "generationId",
+            "sourceType",
+            "sourceId",
+            "chunkIndex"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.embedding_index_state": {
+      "name": "embedding_index_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dimensions": {
+          "name": "dimensions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generationId": {
+          "name": "generationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'needs_validation'"
+        },
+        "scanSource": {
+          "name": "scanSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'rote'"
+        },
+        "scanCursor": {
+          "name": "scanCursor",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scanComplete": {
+          "name": "scanComplete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "errorCode": {
+          "name": "errorCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "validatedAt": {
+          "name": "validatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "embedding_index_state_singleton": {
+          "name": "embedding_index_state_singleton",
+          "value": "\"embedding_index_state\".\"id\" = 1"
+        },
+        "embedding_index_dimensions_range": {
+          "name": "embedding_index_dimensions_range",
+          "value": "\"embedding_index_state\".\"dimensions\" BETWEEN 1 AND 2000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.embedding_jobs": {
+      "name": "embedding_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "generationId": {
+          "name": "generationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceType": {
+          "name": "sourceType",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceId": {
+          "name": "sourceId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'upsert'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lockedAt": {
+          "name": "lockedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "leaseToken": {
+          "name": "leaseToken",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "leaseExpiresAt": {
+          "name": "leaseExpiresAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nextAttemptAt": {
+          "name": "nextAttemptAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "embedding_jobs_pending_source_idx": {
+          "name": "embedding_jobs_pending_source_idx",
+          "columns": [
+            {
+              "expression": "generationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sourceType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sourceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"embedding_jobs\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "embedding_jobs_running_source_idx": {
+          "name": "embedding_jobs_running_source_idx",
+          "columns": [
+            {
+              "expression": "generationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sourceType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sourceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"embedding_jobs\".\"status\" = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "embedding_jobs_status_idx": {
+          "name": "embedding_jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "embedding_jobs_source_idx": {
+          "name": "embedding_jobs_source_idx",
+          "columns": [
+            {
+              "expression": "sourceType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sourceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "embedding_jobs_ownerId_idx": {
+          "name": "embedding_jobs_ownerId_idx",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "embedding_jobs_ownerId_users_id_fk": {
+          "name": "embedding_jobs_ownerId_users_id_fk",
+          "tableFrom": "embedding_jobs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.note_import_sources": {
+      "name": "note_import_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roteId": {
+          "name": "roteId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachmentMap": {
+          "name": "attachmentMap",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "note_import_sources_owner_idx": {
+          "name": "note_import_sources_owner_idx",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "note_import_sources_ownerId_users_id_fk": {
+          "name": "note_import_sources_ownerId_users_id_fk",
+          "tableFrom": "note_import_sources",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "note_import_sources_roteId_rotes_id_fk": {
+          "name": "note_import_sources_roteId_rotes_id_fk",
+          "tableFrom": "note_import_sources",
+          "tableTo": "rotes",
+          "columnsFrom": [
+            "roteId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "note_import_sources_rote_id_unique": {
+          "name": "note_import_sources_rote_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "roteId"
+          ]
+        },
+        "note_import_sources_owner_source_unique": {
+          "name": "note_import_sources_owner_source_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "ownerId",
+            "provider",
+            "accountId",
+            "externalId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.open_key_usage_logs": {
+      "name": "open_key_usage_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "openKeyId": {
+          "name": "openKeyId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientIp": {
+          "name": "clientIp",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statusCode": {
+          "name": "statusCode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responseTime": {
+          "name": "responseTime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "open_key_usage_logs_openKeyId_idx": {
+          "name": "open_key_usage_logs_openKeyId_idx",
+          "columns": [
+            {
+              "expression": "openKeyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "open_key_usage_logs_createdAt_idx": {
+          "name": "open_key_usage_logs_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "open_key_usage_logs_openKeyId_user_open_keys_id_fk": {
+          "name": "open_key_usage_logs_openKeyId_user_open_keys_id_fk",
+          "tableFrom": "open_key_usage_logs",
+          "tableTo": "user_open_keys",
+          "columnsFrom": [
+            "openKeyId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_campaigns": {
+      "name": "push_campaigns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "route": {
+          "name": "route",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "sentAt": {
+          "name": "sentAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_campaigns_status_idx": {
+          "name": "push_campaigns_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_campaigns_created_by_users_id_fk": {
+          "name": "push_campaigns_created_by_users_id_fk",
+          "tableFrom": "push_campaigns",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_deliveries": {
+      "name": "push_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviceId": {
+          "name": "deviceId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attemptCount": {
+          "name": "attemptCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "nextAttemptAt": {
+          "name": "nextAttemptAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "apnsId": {
+          "name": "apnsId",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastError": {
+          "name": "lastError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sentAt": {
+          "name": "sentAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_deliveries_pending_idx": {
+          "name": "push_deliveries_pending_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nextAttemptAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_deliveries_event_id_push_events_id_fk": {
+          "name": "push_deliveries_event_id_push_events_id_fk",
+          "tableFrom": "push_deliveries",
+          "tableTo": "push_events",
+          "columnsFrom": [
+            "eventId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "push_deliveries_device_id_apns_devices_id_fk": {
+          "name": "push_deliveries_device_id_apns_devices_id_fk",
+          "tableFrom": "push_deliveries",
+          "tableTo": "apns_devices",
+          "columnsFrom": [
+            "deviceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_deliveries_event_device_unique": {
+          "name": "push_deliveries_event_device_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "eventId",
+            "deviceId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_events": {
+      "name": "push_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "titleLocKey": {
+          "name": "titleLocKey",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bodyLocKey": {
+          "name": "bodyLocKey",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route": {
+          "name": "route",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "dedupeKey": {
+          "name": "dedupeKey",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "availableAt": {
+          "name": "availableAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_events_pending_idx": {
+          "name": "push_events_pending_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "availableAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_events_userid_users_id_fk": {
+          "name": "push_events_userid_users_id_fk",
+          "tableFrom": "push_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_events_dedupe_key_unique": {
+          "name": "push_events_dedupe_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "dedupeKey"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_preferences": {
+      "name": "push_preferences",
+      "schema": "",
+      "columns": {
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reactionsEnabled": {
+          "name": "reactionsEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "accountEnabled": {
+          "name": "accountEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "systemEnabled": {
+          "name": "systemEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "dailyReminderEnabled": {
+          "name": "dailyReminderEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "dailyReminderTime": {
+          "name": "dailyReminderTime",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'21:30'"
+        },
+        "timeZone": {
+          "name": "timeZone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nextReminderAt": {
+          "name": "nextReminderAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_preferences_reminder_due_idx": {
+          "name": "push_preferences_reminder_due_idx",
+          "columns": [
+            {
+              "expression": "dailyReminderEnabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nextReminderAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_preferences_userid_users_id_fk": {
+          "name": "push_preferences_userid_users_id_fk",
+          "tableFrom": "push_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reactions": {
+      "name": "reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visitorId": {
+          "name": "visitorId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visitorInfo": {
+          "name": "visitorInfo",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roteid": {
+          "name": "roteid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reactions_roteid_type_idx": {
+          "name": "reactions_roteid_type_idx",
+          "columns": [
+            {
+              "expression": "roteid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reactions_userid_idx": {
+          "name": "reactions_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reactions_visitorId_idx": {
+          "name": "reactions_visitorId_idx",
+          "columns": [
+            {
+              "expression": "visitorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reactions_roteid_rotes_id_fk": {
+          "name": "reactions_roteid_rotes_id_fk",
+          "tableFrom": "reactions",
+          "tableTo": "rotes",
+          "columnsFrom": [
+            "roteid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "reactions_userid_users_id_fk": {
+          "name": "reactions_userid_users_id_fk",
+          "tableFrom": "reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_reaction": {
+          "name": "unique_reaction",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userid",
+            "visitorId",
+            "roteid",
+            "type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resource_cleanup_outbox": {
+      "name": "resource_cleanup_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "storage_identity": {
+          "name": "storage_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "resource_cleanup_outbox_pending_attempt_idx": {
+          "name": "resource_cleanup_outbox_pending_attempt_idx",
+          "columns": [
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "resource_cleanup_outbox_identity_key_unique": {
+          "name": "resource_cleanup_outbox_identity_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "storage_identity",
+            "object_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resource_management_state": {
+      "name": "resource_management_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cleanup_fuse_tripped": {
+          "name": "cleanup_fuse_tripped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reconciliation_status": {
+          "name": "reconciliation_status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reconciliation_started_at": {
+          "name": "reconciliation_started_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconciliation_completed_at": {
+          "name": "reconciliation_completed_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconciliation_last_error": {
+          "name": "reconciliation_last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resource_storage_accounts": {
+      "name": "resource_storage_accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "used_bytes": {
+          "name": "used_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "reserved_bytes": {
+          "name": "reserved_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "reconciled_at": {
+          "name": "reconciled_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "resource_storage_accounts_user_id_users_id_fk": {
+          "name": "resource_storage_accounts_user_id_users_id_fk",
+          "tableFrom": "resource_storage_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resource_storage_objects": {
+      "name": "resource_storage_objects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_identity": {
+          "name": "storage_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actual_bytes": {
+          "name": "actual_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billable": {
+          "name": "billable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_count": {
+          "name": "reference_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "resource_storage_objects_owner_idx": {
+          "name": "resource_storage_objects_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "resource_storage_objects_owner_id_users_id_fk": {
+          "name": "resource_storage_objects_owner_id_users_id_fk",
+          "tableFrom": "resource_storage_objects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "resource_storage_objects_identity_key_unique": {
+          "name": "resource_storage_objects_identity_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "storage_identity",
+            "object_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resource_upload_reservations": {
+      "name": "resource_upload_reservations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grant_revision": {
+          "name": "grant_revision",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_pro_derived": {
+          "name": "grant_pro_derived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "grant_entitlement_expires_at": {
+          "name": "grant_entitlement_expires_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reserved_bytes": {
+          "name": "reserved_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "finalizing_batch_id": {
+          "name": "finalizing_batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finalizing_lease_token": {
+          "name": "finalizing_lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finalizing_lease_expires_at": {
+          "name": "finalizing_lease_expires_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_expires_at": {
+          "name": "credential_expires_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "resource_upload_reservations_user_status_idx": {
+          "name": "resource_upload_reservations_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "resource_upload_reservations_status_expiry_idx": {
+          "name": "resource_upload_reservations_status_expiry_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "resource_upload_reservations_user_id_users_id_fk": {
+          "name": "resource_upload_reservations_user_id_users_id_fk",
+          "tableFrom": "resource_upload_reservations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_permission_policies": {
+      "name": "role_permission_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effect": {
+          "name": "effect",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "role_permission_policies_role_idx": {
+          "name": "role_permission_policies_role_idx",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_role_permission": {
+          "name": "unique_role_permission",
+          "nullsNotDistinct": false,
+          "columns": [
+            "role",
+            "permission"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rote_changes": {
+      "name": "rote_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "originid": {
+          "name": "originid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roteid": {
+          "name": "roteid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CREATE'"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rote_changes_originid_createdAt_idx": {
+          "name": "rote_changes_originid_createdAt_idx",
+          "columns": [
+            {
+              "expression": "originid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rote_changes_originid_action_idx": {
+          "name": "rote_changes_originid_action_idx",
+          "columns": [
+            {
+              "expression": "originid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rote_changes_roteid_createdAt_idx": {
+          "name": "rote_changes_roteid_createdAt_idx",
+          "columns": [
+            {
+              "expression": "roteid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rote_changes_userid_idx": {
+          "name": "rote_changes_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rote_changes_roteid_action_idx": {
+          "name": "rote_changes_roteid_action_idx",
+          "columns": [
+            {
+              "expression": "roteid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rote_changes_roteid_rotes_id_fk": {
+          "name": "rote_changes_roteid_rotes_id_fk",
+          "tableFrom": "rote_changes",
+          "tableTo": "rotes",
+          "columnsFrom": [
+            "roteid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rote_link_previews": {
+      "name": "rote_link_previews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "roteid": {
+          "name": "roteid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "siteName": {
+          "name": "siteName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentExcerpt": {
+          "name": "contentExcerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rote_link_previews_roteid_idx": {
+          "name": "rote_link_previews_roteid_idx",
+          "columns": [
+            {
+              "expression": "roteid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rote_link_previews_roteid_rotes_id_fk": {
+          "name": "rote_link_previews_roteid_rotes_id_fk",
+          "tableFrom": "rote_link_previews",
+          "tableTo": "rotes",
+          "columnsFrom": [
+            "roteid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "rote_link_previews_roteid_url_unique": {
+          "name": "rote_link_previews_roteid_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "roteid",
+            "url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rotes": {
+      "name": "rotes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "authorid": {
+          "name": "authorid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "articleId": {
+          "name": "articleId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pin": {
+          "name": "pin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "editor": {
+          "name": "editor",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'normal'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rotes_authorid_state_idx": {
+          "name": "rotes_authorid_state_idx",
+          "columns": [
+            {
+              "expression": "authorid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rotes_authorid_archived_idx": {
+          "name": "rotes_authorid_archived_idx",
+          "columns": [
+            {
+              "expression": "authorid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rotes_authorid_created_at_idx": {
+          "name": "rotes_authorid_created_at_idx",
+          "columns": [
+            {
+              "expression": "authorid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rotes_tags_idx": {
+          "name": "rotes_tags_idx",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "rotes_articleId_idx": {
+          "name": "rotes_articleId_idx",
+          "columns": [
+            {
+              "expression": "articleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rotes_authorid_users_id_fk": {
+          "name": "rotes_authorid_users_id_fk",
+          "tableFrom": "rotes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "authorid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "rotes_articleId_articles_id_fk": {
+          "name": "rotes_articleId_articles_id_fk",
+          "tableFrom": "rotes",
+          "tableTo": "articles",
+          "columnsFrom": [
+            "articleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group": {
+          "name": "group",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isRequired": {
+          "name": "isRequired",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isInitialized": {
+          "name": "isInitialized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isSystem": {
+          "name": "isSystem",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "settings_isRequired_idx": {
+          "name": "settings_isRequired_idx",
+          "columns": [
+            {
+              "expression": "isRequired",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "settings_isInitialized_idx": {
+          "name": "settings_isInitialized_idx",
+          "columns": [
+            {
+              "expression": "isInitialized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "settings_isSystem_idx": {
+          "name": "settings_isSystem_idx",
+          "columns": [
+            {
+              "expression": "isSystem",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "settings_group_unique": {
+          "name": "settings_group_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_blocks": {
+      "name": "user_blocks",
+      "schema": "",
+      "columns": {
+        "blockerId": {
+          "name": "blockerId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blockedId": {
+          "name": "blockedId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_blocks_blocker_id_idx": {
+          "name": "user_blocks_blocker_id_idx",
+          "columns": [
+            {
+              "expression": "blockerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_blocks_blocked_id_idx": {
+          "name": "user_blocks_blocked_id_idx",
+          "columns": [
+            {
+              "expression": "blockedId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_blocks_blocker_id_users_id_fk": {
+          "name": "user_blocks_blocker_id_users_id_fk",
+          "tableFrom": "user_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blockerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "user_blocks_blocked_id_users_id_fk": {
+          "name": "user_blocks_blocked_id_users_id_fk",
+          "tableFrom": "user_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blockedId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_blocks_blocker_blocked_pk": {
+          "name": "user_blocks_blocker_blocked_pk",
+          "columns": [
+            "blockerId",
+            "blockedId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_blocks_no_self_block": {
+          "name": "user_blocks_no_self_block",
+          "value": "\"user_blocks\".\"blockerId\" <> \"user_blocks\".\"blockedId\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_oauth_bindings": {
+      "name": "user_oauth_bindings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerUsername": {
+          "name": "providerUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_oauth_bindings_userid_idx": {
+          "name": "user_oauth_bindings_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_oauth_bindings_provider_idx": {
+          "name": "user_oauth_bindings_provider_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_oauth_bindings_providerId_idx": {
+          "name": "user_oauth_bindings_providerId_idx",
+          "columns": [
+            {
+              "expression": "providerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_oauth_bindings_userid_users_id_fk": {
+          "name": "user_oauth_bindings_userid_users_id_fk",
+          "tableFrom": "user_oauth_bindings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_provider": {
+          "name": "unique_user_provider",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userid",
+            "provider"
+          ]
+        },
+        "unique_provider_id": {
+          "name": "unique_provider_id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider",
+            "providerId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_open_keys": {
+      "name": "user_open_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"SENDROTE\"}'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_open_keys_userid_idx": {
+          "name": "user_open_keys_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_open_keys_userid_users_id_fk": {
+          "name": "user_open_keys_userid_users_id_fk",
+          "tableFrom": "user_open_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_passkeys": {
+      "name": "user_passkeys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentialId": {
+          "name": "credentialId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "transports": {
+          "name": "transports",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deviceName": {
+          "name": "deviceName",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "deviceType": {
+          "name": "deviceType",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_passkeys_userid_idx": {
+          "name": "user_passkeys_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_passkeys_credentialId_idx": {
+          "name": "user_passkeys_credentialId_idx",
+          "columns": [
+            {
+              "expression": "credentialId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_passkeys_userid_users_id_fk": {
+          "name": "user_passkeys_userid_users_id_fk",
+          "tableFrom": "user_passkeys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_passkeys_credentialId_unique": {
+          "name": "user_passkeys_credentialId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credentialId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_permission_overrides": {
+      "name": "user_permission_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effect": {
+          "name": "effect",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_permission_overrides_userid_idx": {
+          "name": "user_permission_overrides_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_permission_overrides_userid_users_id_fk": {
+          "name": "user_permission_overrides_userid_users_id_fk",
+          "tableFrom": "user_permission_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "user_permission_overrides_updatedBy_users_id_fk": {
+          "name": "user_permission_overrides_updatedBy_users_id_fk",
+          "tableFrom": "user_permission_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updatedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_permission": {
+          "name": "unique_user_permission",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userid",
+            "permission"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "darkmode": {
+          "name": "darkmode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "allowExplore": {
+          "name": "allowExplore",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_settings_userid_idx": {
+          "name": "user_settings_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_settings_userid_users_id_fk": {
+          "name": "user_settings_userid_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_settings_userid_unique": {
+          "name": "user_settings_userid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_sw_subscriptions": {
+      "name": "user_sw_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "expirationTime": {
+          "name": "expirationTime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keys": {
+          "name": "keys",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_sw_subscriptions_userid_idx": {
+          "name": "user_sw_subscriptions_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_sw_subscriptions_endpoint_idx": {
+          "name": "user_sw_subscriptions_endpoint_idx",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_sw_subscriptions_userid_users_id_fk": {
+          "name": "user_sw_subscriptions_userid_users_id_fk",
+          "tableFrom": "user_sw_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_sw_subscriptions_endpoint_unique": {
+          "name": "user_sw_subscriptions_endpoint_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "endpoint"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "passwordhash": {
+          "name": "passwordhash",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salt": {
+          "name": "salt",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover": {
+          "name": "cover",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_username_idx": {
+          "name": "users_username_idx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_authorization_codes": {
+      "name": "oauth_authorization_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "codeHash": {
+          "name": "codeHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requestId": {
+          "name": "requestId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirectUri": {
+          "name": "redirectUri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codeChallenge": {
+          "name": "codeChallenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codeChallengeMethod": {
+          "name": "codeChallengeMethod",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumedAt": {
+          "name": "consumedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_authorization_codes_codeHash_idx": {
+          "name": "oauth_authorization_codes_codeHash_idx",
+          "columns": [
+            {
+              "expression": "codeHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_authorization_codes_requestId_idx": {
+          "name": "oauth_authorization_codes_requestId_idx",
+          "columns": [
+            {
+              "expression": "requestId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_authorization_codes_clientId_oauth_clients_clientId_fk": {
+          "name": "oauth_authorization_codes_clientId_oauth_clients_clientId_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "clientId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "oauth_authorization_codes_requestId_oauth_authorization_requests_id_fk": {
+          "name": "oauth_authorization_codes_requestId_oauth_authorization_requests_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "oauth_authorization_requests",
+          "columnsFrom": [
+            "requestId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "oauth_authorization_codes_userid_users_id_fk": {
+          "name": "oauth_authorization_codes_userid_users_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_authorization_codes_codeHash_unique": {
+          "name": "oauth_authorization_codes_codeHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "codeHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_authorization_requests": {
+      "name": "oauth_authorization_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirectUri": {
+          "name": "redirectUri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codeChallenge": {
+          "name": "codeChallenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codeChallengeMethod": {
+          "name": "codeChallengeMethod",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_authorization_requests_clientId_idx": {
+          "name": "oauth_authorization_requests_clientId_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_authorization_requests_expiresAt_idx": {
+          "name": "oauth_authorization_requests_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_authorization_requests_clientId_oauth_clients_clientId_fk": {
+          "name": "oauth_authorization_requests_clientId_oauth_clients_clientId_fk",
+          "tableFrom": "oauth_authorization_requests",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "clientId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "oauth_authorization_requests_userid_users_id_fk": {
+          "name": "oauth_authorization_requests_userid_users_id_fk",
+          "tableFrom": "oauth_authorization_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_clients": {
+      "name": "oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientName": {
+          "name": "clientName",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientUri": {
+          "name": "clientUri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logoUri": {
+          "name": "logoUri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirectUris": {
+          "name": "redirectUris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "grantTypes": {
+          "name": "grantTypes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"authorization_code\",\"refresh_token\"}'"
+        },
+        "responseTypes": {
+          "name": "responseTypes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"code\"}'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_clients_clientId_idx": {
+          "name": "oauth_clients_clientId_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_clients_clientId_unique": {
+          "name": "oauth_clients_clientId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clientId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_grants": {
+      "name": "oauth_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_grants_userid_idx": {
+          "name": "oauth_grants_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_grants_clientId_oauth_clients_clientId_fk": {
+          "name": "oauth_grants_clientId_oauth_clients_clientId_fk",
+          "tableFrom": "oauth_grants",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "clientId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "oauth_grants_userid_users_id_fk": {
+          "name": "oauth_grants_userid_users_id_fk",
+          "tableFrom": "oauth_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_oauth_grant_user_client_resource": {
+          "name": "unique_oauth_grant_user_client_resource",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userid",
+            "clientId",
+            "resource"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_tokens": {
+      "name": "oauth_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replacedByTokenId": {
+          "name": "replacedByTokenId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_refresh_tokens_tokenHash_idx": {
+          "name": "oauth_refresh_tokens_tokenHash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_tokens_client_user_idx": {
+          "name": "oauth_refresh_tokens_client_user_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_tokens_clientId_oauth_clients_clientId_fk": {
+          "name": "oauth_refresh_tokens_clientId_oauth_clients_clientId_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "clientId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "oauth_refresh_tokens_userid_users_id_fk": {
+          "name": "oauth_refresh_tokens_userid_users_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_refresh_tokens_tokenHash_unique": {
+          "name": "oauth_refresh_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/drizzle/migrations/meta/0031_snapshot.json
+++ b/server/drizzle/migrations/meta/0031_snapshot.json
@@ -1,0 +1,5133 @@
+{
+  "id": "eb35747c-f61e-4356-a7a8-2fd4a2ec9ec0",
+  "prevId": "b31dd75b-f5a9-494b-9f7b-5269b1764390",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ai_token_usage_logs": {
+      "name": "ai_token_usage_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "promptTokens": {
+          "name": "promptTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "completionTokens": {
+          "name": "completionTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalTokens": {
+          "name": "totalTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_token_usage_logs_userid_idx": {
+          "name": "ai_token_usage_logs_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_token_usage_logs_createdAt_idx": {
+          "name": "ai_token_usage_logs_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_token_usage_logs_userid_users_id_fk": {
+          "name": "ai_token_usage_logs_userid_users_id_fk",
+          "tableFrom": "ai_token_usage_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apns_devices": {
+      "name": "apns_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installationId": {
+          "name": "installationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "masterEnabled": {
+          "name": "masterEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "timeZone": {
+          "name": "timeZone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "lastSeenAt": {
+          "name": "lastSeenAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "apns_devices_userid_idx": {
+          "name": "apns_devices_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "apns_devices_userid_users_id_fk": {
+          "name": "apns_devices_userid_users_id_fk",
+          "tableFrom": "apns_devices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "apns_devices_installation_id_unique": {
+          "name": "apns_devices_installation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "installationId"
+          ]
+        },
+        "apns_devices_token_environment_unique": {
+          "name": "apns_devices_token_environment_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token",
+            "environment"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.articles": {
+      "name": "articles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorId": {
+          "name": "authorId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "articles_authorId_idx": {
+          "name": "articles_authorId_idx",
+          "columns": [
+            {
+              "expression": "authorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "articles_authorId_users_id_fk": {
+          "name": "articles_authorId_users_id_fk",
+          "tableFrom": "articles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "authorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attachments": {
+      "name": "attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compressUrl": {
+          "name": "compressUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "posterUrl": {
+          "name": "posterUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roteid": {
+          "name": "roteid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage": {
+          "name": "storage",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sortIndex": {
+          "name": "sortIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "attachments_userid_idx": {
+          "name": "attachments_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attachments_roteid_idx": {
+          "name": "attachments_roteid_idx",
+          "columns": [
+            {
+              "expression": "roteid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attachments_roteid_sortIndex_idx": {
+          "name": "attachments_roteid_sortIndex_idx",
+          "columns": [
+            {
+              "expression": "roteid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sortIndex",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attachments_userid_users_id_fk": {
+          "name": "attachments_userid_users_id_fk",
+          "tableFrom": "attachments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "attachments_roteid_rotes_id_fk": {
+          "name": "attachments_roteid_rotes_id_fk",
+          "tableFrom": "attachments",
+          "tableTo": "rotes",
+          "columnsFrom": [
+            "roteid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_grants": {
+      "name": "billing_grants",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entitlement_expires_at": {
+          "name": "entitlement_expires_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "benefits": {
+          "name": "benefits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_hash": {
+          "name": "snapshot_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "billing_grants_lease_expires_at_idx": {
+          "name": "billing_grants_lease_expires_at_idx",
+          "columns": [
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_grants_user_id_users_id_fk": {
+          "name": "billing_grants_user_id_users_id_fk",
+          "tableFrom": "billing_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "billing_grants_revision_non_negative": {
+          "name": "billing_grants_revision_non_negative",
+          "value": "\"billing_grants\".\"revision\" >= 0"
+        },
+        "billing_grants_valid_status": {
+          "name": "billing_grants_valid_status",
+          "value": "\"billing_grants\".\"status\" IN ('active', 'grace_period', 'none')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.billing_inbound_deliveries": {
+      "name": "billing_inbound_deliveries",
+      "schema": "",
+      "columns": {
+        "direction": {
+          "name": "direction",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_id": {
+          "name": "key_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_target": {
+          "name": "request_target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_hash": {
+          "name": "body_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "billing_inbound_deliveries_created_at_idx": {
+          "name": "billing_inbound_deliveries_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "billing_inbound_deliveries_direction_delivery_id_pk": {
+          "name": "billing_inbound_deliveries_direction_delivery_id_pk",
+          "columns": [
+            "direction",
+            "delivery_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "billing_inbound_deliveries_paid_to_rote_direction": {
+          "name": "billing_inbound_deliveries_paid_to_rote_direction",
+          "value": "\"billing_inbound_deliveries\".\"direction\" = 'paid_to_rote'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.document_embeddings": {
+      "name": "document_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "generationId": {
+          "name": "generationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceType": {
+          "name": "sourceType",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceId": {
+          "name": "sourceId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunkIndex": {
+          "name": "chunkIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contentHash": {
+          "name": "contentHash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embeddingModel": {
+          "name": "embeddingModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embeddingDimensions": {
+          "name": "embeddingDimensions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_embeddings_ownerId_idx": {
+          "name": "document_embeddings_ownerId_idx",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_embeddings_source_idx": {
+          "name": "document_embeddings_source_idx",
+          "columns": [
+            {
+              "expression": "sourceType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sourceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_embeddings_owner_source_idx": {
+          "name": "document_embeddings_owner_source_idx",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sourceType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_embeddings_model_dimensions_idx": {
+          "name": "document_embeddings_model_dimensions_idx",
+          "columns": [
+            {
+              "expression": "embeddingModel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "embeddingDimensions",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_embeddings_ownerId_users_id_fk": {
+          "name": "document_embeddings_ownerId_users_id_fk",
+          "tableFrom": "document_embeddings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "document_embeddings_generation_source_chunk_unique": {
+          "name": "document_embeddings_generation_source_chunk_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "generationId",
+            "sourceType",
+            "sourceId",
+            "chunkIndex"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.embedding_index_state": {
+      "name": "embedding_index_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dimensions": {
+          "name": "dimensions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generationId": {
+          "name": "generationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'needs_validation'"
+        },
+        "scanSource": {
+          "name": "scanSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'rote'"
+        },
+        "scanCursor": {
+          "name": "scanCursor",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scanComplete": {
+          "name": "scanComplete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "errorCode": {
+          "name": "errorCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "errorDetails": {
+          "name": "errorDetails",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "validatedAt": {
+          "name": "validatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "embedding_index_state_singleton": {
+          "name": "embedding_index_state_singleton",
+          "value": "\"embedding_index_state\".\"id\" = 1"
+        },
+        "embedding_index_dimensions_range": {
+          "name": "embedding_index_dimensions_range",
+          "value": "\"embedding_index_state\".\"dimensions\" BETWEEN 1 AND 2000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.embedding_jobs": {
+      "name": "embedding_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "generationId": {
+          "name": "generationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceType": {
+          "name": "sourceType",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceId": {
+          "name": "sourceId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'upsert'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lockedAt": {
+          "name": "lockedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "leaseToken": {
+          "name": "leaseToken",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "leaseExpiresAt": {
+          "name": "leaseExpiresAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nextAttemptAt": {
+          "name": "nextAttemptAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "embedding_jobs_pending_source_idx": {
+          "name": "embedding_jobs_pending_source_idx",
+          "columns": [
+            {
+              "expression": "generationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sourceType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sourceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"embedding_jobs\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "embedding_jobs_running_source_idx": {
+          "name": "embedding_jobs_running_source_idx",
+          "columns": [
+            {
+              "expression": "generationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sourceType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sourceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"embedding_jobs\".\"status\" = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "embedding_jobs_status_idx": {
+          "name": "embedding_jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "embedding_jobs_source_idx": {
+          "name": "embedding_jobs_source_idx",
+          "columns": [
+            {
+              "expression": "sourceType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sourceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "embedding_jobs_ownerId_idx": {
+          "name": "embedding_jobs_ownerId_idx",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "embedding_jobs_ownerId_users_id_fk": {
+          "name": "embedding_jobs_ownerId_users_id_fk",
+          "tableFrom": "embedding_jobs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.embedding_source_events": {
+      "name": "embedding_source_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sourceType": {
+          "name": "sourceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceId": {
+          "name": "sourceId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generationId": {
+          "name": "generationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rebuilding": {
+          "name": "rebuilding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "embedding_source_events_pending_idx": {
+          "name": "embedding_source_events_pending_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.note_import_sources": {
+      "name": "note_import_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roteId": {
+          "name": "roteId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachmentMap": {
+          "name": "attachmentMap",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "note_import_sources_owner_idx": {
+          "name": "note_import_sources_owner_idx",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "note_import_sources_ownerId_users_id_fk": {
+          "name": "note_import_sources_ownerId_users_id_fk",
+          "tableFrom": "note_import_sources",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "note_import_sources_roteId_rotes_id_fk": {
+          "name": "note_import_sources_roteId_rotes_id_fk",
+          "tableFrom": "note_import_sources",
+          "tableTo": "rotes",
+          "columnsFrom": [
+            "roteId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "note_import_sources_rote_id_unique": {
+          "name": "note_import_sources_rote_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "roteId"
+          ]
+        },
+        "note_import_sources_owner_source_unique": {
+          "name": "note_import_sources_owner_source_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "ownerId",
+            "provider",
+            "accountId",
+            "externalId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.open_key_usage_logs": {
+      "name": "open_key_usage_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "openKeyId": {
+          "name": "openKeyId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientIp": {
+          "name": "clientIp",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statusCode": {
+          "name": "statusCode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responseTime": {
+          "name": "responseTime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "open_key_usage_logs_openKeyId_idx": {
+          "name": "open_key_usage_logs_openKeyId_idx",
+          "columns": [
+            {
+              "expression": "openKeyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "open_key_usage_logs_createdAt_idx": {
+          "name": "open_key_usage_logs_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "open_key_usage_logs_openKeyId_user_open_keys_id_fk": {
+          "name": "open_key_usage_logs_openKeyId_user_open_keys_id_fk",
+          "tableFrom": "open_key_usage_logs",
+          "tableTo": "user_open_keys",
+          "columnsFrom": [
+            "openKeyId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_campaigns": {
+      "name": "push_campaigns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "route": {
+          "name": "route",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "sentAt": {
+          "name": "sentAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_campaigns_status_idx": {
+          "name": "push_campaigns_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_campaigns_created_by_users_id_fk": {
+          "name": "push_campaigns_created_by_users_id_fk",
+          "tableFrom": "push_campaigns",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_deliveries": {
+      "name": "push_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviceId": {
+          "name": "deviceId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attemptCount": {
+          "name": "attemptCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "nextAttemptAt": {
+          "name": "nextAttemptAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "apnsId": {
+          "name": "apnsId",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastError": {
+          "name": "lastError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sentAt": {
+          "name": "sentAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_deliveries_pending_idx": {
+          "name": "push_deliveries_pending_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nextAttemptAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_deliveries_event_id_push_events_id_fk": {
+          "name": "push_deliveries_event_id_push_events_id_fk",
+          "tableFrom": "push_deliveries",
+          "tableTo": "push_events",
+          "columnsFrom": [
+            "eventId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "push_deliveries_device_id_apns_devices_id_fk": {
+          "name": "push_deliveries_device_id_apns_devices_id_fk",
+          "tableFrom": "push_deliveries",
+          "tableTo": "apns_devices",
+          "columnsFrom": [
+            "deviceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_deliveries_event_device_unique": {
+          "name": "push_deliveries_event_device_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "eventId",
+            "deviceId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_events": {
+      "name": "push_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "titleLocKey": {
+          "name": "titleLocKey",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bodyLocKey": {
+          "name": "bodyLocKey",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route": {
+          "name": "route",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "dedupeKey": {
+          "name": "dedupeKey",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "availableAt": {
+          "name": "availableAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_events_pending_idx": {
+          "name": "push_events_pending_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "availableAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_events_userid_users_id_fk": {
+          "name": "push_events_userid_users_id_fk",
+          "tableFrom": "push_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_events_dedupe_key_unique": {
+          "name": "push_events_dedupe_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "dedupeKey"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_preferences": {
+      "name": "push_preferences",
+      "schema": "",
+      "columns": {
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reactionsEnabled": {
+          "name": "reactionsEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "accountEnabled": {
+          "name": "accountEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "systemEnabled": {
+          "name": "systemEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "dailyReminderEnabled": {
+          "name": "dailyReminderEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "dailyReminderTime": {
+          "name": "dailyReminderTime",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'21:30'"
+        },
+        "timeZone": {
+          "name": "timeZone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nextReminderAt": {
+          "name": "nextReminderAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_preferences_reminder_due_idx": {
+          "name": "push_preferences_reminder_due_idx",
+          "columns": [
+            {
+              "expression": "dailyReminderEnabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nextReminderAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_preferences_userid_users_id_fk": {
+          "name": "push_preferences_userid_users_id_fk",
+          "tableFrom": "push_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reactions": {
+      "name": "reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visitorId": {
+          "name": "visitorId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visitorInfo": {
+          "name": "visitorInfo",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roteid": {
+          "name": "roteid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reactions_roteid_type_idx": {
+          "name": "reactions_roteid_type_idx",
+          "columns": [
+            {
+              "expression": "roteid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reactions_userid_idx": {
+          "name": "reactions_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reactions_visitorId_idx": {
+          "name": "reactions_visitorId_idx",
+          "columns": [
+            {
+              "expression": "visitorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reactions_roteid_rotes_id_fk": {
+          "name": "reactions_roteid_rotes_id_fk",
+          "tableFrom": "reactions",
+          "tableTo": "rotes",
+          "columnsFrom": [
+            "roteid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "reactions_userid_users_id_fk": {
+          "name": "reactions_userid_users_id_fk",
+          "tableFrom": "reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_reaction": {
+          "name": "unique_reaction",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userid",
+            "visitorId",
+            "roteid",
+            "type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resource_cleanup_outbox": {
+      "name": "resource_cleanup_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "storage_identity": {
+          "name": "storage_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "resource_cleanup_outbox_pending_attempt_idx": {
+          "name": "resource_cleanup_outbox_pending_attempt_idx",
+          "columns": [
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "resource_cleanup_outbox_identity_key_unique": {
+          "name": "resource_cleanup_outbox_identity_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "storage_identity",
+            "object_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resource_management_state": {
+      "name": "resource_management_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cleanup_fuse_tripped": {
+          "name": "cleanup_fuse_tripped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reconciliation_status": {
+          "name": "reconciliation_status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reconciliation_started_at": {
+          "name": "reconciliation_started_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconciliation_completed_at": {
+          "name": "reconciliation_completed_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconciliation_last_error": {
+          "name": "reconciliation_last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resource_storage_accounts": {
+      "name": "resource_storage_accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "used_bytes": {
+          "name": "used_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "reserved_bytes": {
+          "name": "reserved_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "reconciled_at": {
+          "name": "reconciled_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "resource_storage_accounts_user_id_users_id_fk": {
+          "name": "resource_storage_accounts_user_id_users_id_fk",
+          "tableFrom": "resource_storage_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resource_storage_objects": {
+      "name": "resource_storage_objects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_identity": {
+          "name": "storage_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actual_bytes": {
+          "name": "actual_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billable": {
+          "name": "billable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_count": {
+          "name": "reference_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "resource_storage_objects_owner_idx": {
+          "name": "resource_storage_objects_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "resource_storage_objects_owner_id_users_id_fk": {
+          "name": "resource_storage_objects_owner_id_users_id_fk",
+          "tableFrom": "resource_storage_objects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "resource_storage_objects_identity_key_unique": {
+          "name": "resource_storage_objects_identity_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "storage_identity",
+            "object_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resource_upload_reservations": {
+      "name": "resource_upload_reservations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grant_revision": {
+          "name": "grant_revision",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_pro_derived": {
+          "name": "grant_pro_derived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "grant_entitlement_expires_at": {
+          "name": "grant_entitlement_expires_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reserved_bytes": {
+          "name": "reserved_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "finalizing_batch_id": {
+          "name": "finalizing_batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finalizing_lease_token": {
+          "name": "finalizing_lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finalizing_lease_expires_at": {
+          "name": "finalizing_lease_expires_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_expires_at": {
+          "name": "credential_expires_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "resource_upload_reservations_user_status_idx": {
+          "name": "resource_upload_reservations_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "resource_upload_reservations_status_expiry_idx": {
+          "name": "resource_upload_reservations_status_expiry_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "resource_upload_reservations_user_id_users_id_fk": {
+          "name": "resource_upload_reservations_user_id_users_id_fk",
+          "tableFrom": "resource_upload_reservations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_permission_policies": {
+      "name": "role_permission_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effect": {
+          "name": "effect",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "role_permission_policies_role_idx": {
+          "name": "role_permission_policies_role_idx",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_role_permission": {
+          "name": "unique_role_permission",
+          "nullsNotDistinct": false,
+          "columns": [
+            "role",
+            "permission"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rote_changes": {
+      "name": "rote_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "originid": {
+          "name": "originid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roteid": {
+          "name": "roteid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CREATE'"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rote_changes_originid_createdAt_idx": {
+          "name": "rote_changes_originid_createdAt_idx",
+          "columns": [
+            {
+              "expression": "originid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rote_changes_originid_action_idx": {
+          "name": "rote_changes_originid_action_idx",
+          "columns": [
+            {
+              "expression": "originid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rote_changes_roteid_createdAt_idx": {
+          "name": "rote_changes_roteid_createdAt_idx",
+          "columns": [
+            {
+              "expression": "roteid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rote_changes_userid_idx": {
+          "name": "rote_changes_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rote_changes_roteid_action_idx": {
+          "name": "rote_changes_roteid_action_idx",
+          "columns": [
+            {
+              "expression": "roteid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rote_changes_roteid_rotes_id_fk": {
+          "name": "rote_changes_roteid_rotes_id_fk",
+          "tableFrom": "rote_changes",
+          "tableTo": "rotes",
+          "columnsFrom": [
+            "roteid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rote_link_previews": {
+      "name": "rote_link_previews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "roteid": {
+          "name": "roteid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "siteName": {
+          "name": "siteName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentExcerpt": {
+          "name": "contentExcerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rote_link_previews_roteid_idx": {
+          "name": "rote_link_previews_roteid_idx",
+          "columns": [
+            {
+              "expression": "roteid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rote_link_previews_roteid_rotes_id_fk": {
+          "name": "rote_link_previews_roteid_rotes_id_fk",
+          "tableFrom": "rote_link_previews",
+          "tableTo": "rotes",
+          "columnsFrom": [
+            "roteid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "rote_link_previews_roteid_url_unique": {
+          "name": "rote_link_previews_roteid_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "roteid",
+            "url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rotes": {
+      "name": "rotes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "authorid": {
+          "name": "authorid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "articleId": {
+          "name": "articleId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pin": {
+          "name": "pin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "editor": {
+          "name": "editor",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'normal'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rotes_authorid_state_idx": {
+          "name": "rotes_authorid_state_idx",
+          "columns": [
+            {
+              "expression": "authorid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rotes_authorid_archived_idx": {
+          "name": "rotes_authorid_archived_idx",
+          "columns": [
+            {
+              "expression": "authorid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rotes_authorid_created_at_idx": {
+          "name": "rotes_authorid_created_at_idx",
+          "columns": [
+            {
+              "expression": "authorid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rotes_tags_idx": {
+          "name": "rotes_tags_idx",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "rotes_articleId_idx": {
+          "name": "rotes_articleId_idx",
+          "columns": [
+            {
+              "expression": "articleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rotes_authorid_users_id_fk": {
+          "name": "rotes_authorid_users_id_fk",
+          "tableFrom": "rotes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "authorid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "rotes_articleId_articles_id_fk": {
+          "name": "rotes_articleId_articles_id_fk",
+          "tableFrom": "rotes",
+          "tableTo": "articles",
+          "columnsFrom": [
+            "articleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group": {
+          "name": "group",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isRequired": {
+          "name": "isRequired",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isInitialized": {
+          "name": "isInitialized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isSystem": {
+          "name": "isSystem",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "settings_isRequired_idx": {
+          "name": "settings_isRequired_idx",
+          "columns": [
+            {
+              "expression": "isRequired",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "settings_isInitialized_idx": {
+          "name": "settings_isInitialized_idx",
+          "columns": [
+            {
+              "expression": "isInitialized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "settings_isSystem_idx": {
+          "name": "settings_isSystem_idx",
+          "columns": [
+            {
+              "expression": "isSystem",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "settings_group_unique": {
+          "name": "settings_group_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_blocks": {
+      "name": "user_blocks",
+      "schema": "",
+      "columns": {
+        "blockerId": {
+          "name": "blockerId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blockedId": {
+          "name": "blockedId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_blocks_blocker_id_idx": {
+          "name": "user_blocks_blocker_id_idx",
+          "columns": [
+            {
+              "expression": "blockerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_blocks_blocked_id_idx": {
+          "name": "user_blocks_blocked_id_idx",
+          "columns": [
+            {
+              "expression": "blockedId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_blocks_blocker_id_users_id_fk": {
+          "name": "user_blocks_blocker_id_users_id_fk",
+          "tableFrom": "user_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blockerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "user_blocks_blocked_id_users_id_fk": {
+          "name": "user_blocks_blocked_id_users_id_fk",
+          "tableFrom": "user_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blockedId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_blocks_blocker_blocked_pk": {
+          "name": "user_blocks_blocker_blocked_pk",
+          "columns": [
+            "blockerId",
+            "blockedId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_blocks_no_self_block": {
+          "name": "user_blocks_no_self_block",
+          "value": "\"user_blocks\".\"blockerId\" <> \"user_blocks\".\"blockedId\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_oauth_bindings": {
+      "name": "user_oauth_bindings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerUsername": {
+          "name": "providerUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_oauth_bindings_userid_idx": {
+          "name": "user_oauth_bindings_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_oauth_bindings_provider_idx": {
+          "name": "user_oauth_bindings_provider_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_oauth_bindings_providerId_idx": {
+          "name": "user_oauth_bindings_providerId_idx",
+          "columns": [
+            {
+              "expression": "providerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_oauth_bindings_userid_users_id_fk": {
+          "name": "user_oauth_bindings_userid_users_id_fk",
+          "tableFrom": "user_oauth_bindings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_provider": {
+          "name": "unique_user_provider",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userid",
+            "provider"
+          ]
+        },
+        "unique_provider_id": {
+          "name": "unique_provider_id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider",
+            "providerId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_open_keys": {
+      "name": "user_open_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"SENDROTE\"}'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_open_keys_userid_idx": {
+          "name": "user_open_keys_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_open_keys_userid_users_id_fk": {
+          "name": "user_open_keys_userid_users_id_fk",
+          "tableFrom": "user_open_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_passkeys": {
+      "name": "user_passkeys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentialId": {
+          "name": "credentialId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "transports": {
+          "name": "transports",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deviceName": {
+          "name": "deviceName",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "deviceType": {
+          "name": "deviceType",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_passkeys_userid_idx": {
+          "name": "user_passkeys_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_passkeys_credentialId_idx": {
+          "name": "user_passkeys_credentialId_idx",
+          "columns": [
+            {
+              "expression": "credentialId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_passkeys_userid_users_id_fk": {
+          "name": "user_passkeys_userid_users_id_fk",
+          "tableFrom": "user_passkeys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_passkeys_credentialId_unique": {
+          "name": "user_passkeys_credentialId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credentialId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_permission_overrides": {
+      "name": "user_permission_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effect": {
+          "name": "effect",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_permission_overrides_userid_idx": {
+          "name": "user_permission_overrides_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_permission_overrides_userid_users_id_fk": {
+          "name": "user_permission_overrides_userid_users_id_fk",
+          "tableFrom": "user_permission_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "user_permission_overrides_updatedBy_users_id_fk": {
+          "name": "user_permission_overrides_updatedBy_users_id_fk",
+          "tableFrom": "user_permission_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updatedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_permission": {
+          "name": "unique_user_permission",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userid",
+            "permission"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "darkmode": {
+          "name": "darkmode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "allowExplore": {
+          "name": "allowExplore",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_settings_userid_idx": {
+          "name": "user_settings_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_settings_userid_users_id_fk": {
+          "name": "user_settings_userid_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_settings_userid_unique": {
+          "name": "user_settings_userid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_sw_subscriptions": {
+      "name": "user_sw_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "expirationTime": {
+          "name": "expirationTime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keys": {
+          "name": "keys",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_sw_subscriptions_userid_idx": {
+          "name": "user_sw_subscriptions_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_sw_subscriptions_endpoint_idx": {
+          "name": "user_sw_subscriptions_endpoint_idx",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_sw_subscriptions_userid_users_id_fk": {
+          "name": "user_sw_subscriptions_userid_users_id_fk",
+          "tableFrom": "user_sw_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_sw_subscriptions_endpoint_unique": {
+          "name": "user_sw_subscriptions_endpoint_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "endpoint"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "passwordhash": {
+          "name": "passwordhash",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salt": {
+          "name": "salt",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover": {
+          "name": "cover",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_username_idx": {
+          "name": "users_username_idx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_authorization_codes": {
+      "name": "oauth_authorization_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "codeHash": {
+          "name": "codeHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requestId": {
+          "name": "requestId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirectUri": {
+          "name": "redirectUri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codeChallenge": {
+          "name": "codeChallenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codeChallengeMethod": {
+          "name": "codeChallengeMethod",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumedAt": {
+          "name": "consumedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_authorization_codes_codeHash_idx": {
+          "name": "oauth_authorization_codes_codeHash_idx",
+          "columns": [
+            {
+              "expression": "codeHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_authorization_codes_requestId_idx": {
+          "name": "oauth_authorization_codes_requestId_idx",
+          "columns": [
+            {
+              "expression": "requestId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_authorization_codes_clientId_oauth_clients_clientId_fk": {
+          "name": "oauth_authorization_codes_clientId_oauth_clients_clientId_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "clientId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "oauth_authorization_codes_requestId_oauth_authorization_requests_id_fk": {
+          "name": "oauth_authorization_codes_requestId_oauth_authorization_requests_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "oauth_authorization_requests",
+          "columnsFrom": [
+            "requestId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "oauth_authorization_codes_userid_users_id_fk": {
+          "name": "oauth_authorization_codes_userid_users_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_authorization_codes_codeHash_unique": {
+          "name": "oauth_authorization_codes_codeHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "codeHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_authorization_requests": {
+      "name": "oauth_authorization_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirectUri": {
+          "name": "redirectUri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codeChallenge": {
+          "name": "codeChallenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codeChallengeMethod": {
+          "name": "codeChallengeMethod",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_authorization_requests_clientId_idx": {
+          "name": "oauth_authorization_requests_clientId_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_authorization_requests_expiresAt_idx": {
+          "name": "oauth_authorization_requests_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_authorization_requests_clientId_oauth_clients_clientId_fk": {
+          "name": "oauth_authorization_requests_clientId_oauth_clients_clientId_fk",
+          "tableFrom": "oauth_authorization_requests",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "clientId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "oauth_authorization_requests_userid_users_id_fk": {
+          "name": "oauth_authorization_requests_userid_users_id_fk",
+          "tableFrom": "oauth_authorization_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_clients": {
+      "name": "oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientName": {
+          "name": "clientName",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientUri": {
+          "name": "clientUri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logoUri": {
+          "name": "logoUri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirectUris": {
+          "name": "redirectUris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "grantTypes": {
+          "name": "grantTypes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"authorization_code\",\"refresh_token\"}'"
+        },
+        "responseTypes": {
+          "name": "responseTypes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"code\"}'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_clients_clientId_idx": {
+          "name": "oauth_clients_clientId_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_clients_clientId_unique": {
+          "name": "oauth_clients_clientId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clientId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_grants": {
+      "name": "oauth_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_grants_userid_idx": {
+          "name": "oauth_grants_userid_idx",
+          "columns": [
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_grants_clientId_oauth_clients_clientId_fk": {
+          "name": "oauth_grants_clientId_oauth_clients_clientId_fk",
+          "tableFrom": "oauth_grants",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "clientId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "oauth_grants_userid_users_id_fk": {
+          "name": "oauth_grants_userid_users_id_fk",
+          "tableFrom": "oauth_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_oauth_grant_user_client_resource": {
+          "name": "unique_oauth_grant_user_client_resource",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userid",
+            "clientId",
+            "resource"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_tokens": {
+      "name": "oauth_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userid": {
+          "name": "userid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replacedByTokenId": {
+          "name": "replacedByTokenId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_refresh_tokens_tokenHash_idx": {
+          "name": "oauth_refresh_tokens_tokenHash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_tokens_client_user_idx": {
+          "name": "oauth_refresh_tokens_client_user_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_tokens_clientId_oauth_clients_clientId_fk": {
+          "name": "oauth_refresh_tokens_clientId_oauth_clients_clientId_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "clientId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "oauth_refresh_tokens_userid_users_id_fk": {
+          "name": "oauth_refresh_tokens_userid_users_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_refresh_tokens_tokenHash_unique": {
+          "name": "oauth_refresh_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/drizzle/migrations/meta/_journal.json
+++ b/server/drizzle/migrations/meta/_journal.json
@@ -211,6 +211,20 @@
       "when": 1787749501889,
       "tag": "0029_talented_professor_monster",
       "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1788674776412,
+      "tag": "0030_embedding_contract",
+      "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "7",
+      "when": 1788676603359,
+      "tag": "0031_embedding_source_events",
+      "breakpoints": true
     }
   ]
 }

--- a/server/drizzle/schema.ts
+++ b/server/drizzle/schema.ts
@@ -13,6 +13,7 @@ import {
   text,
   timestamp,
   unique,
+  uniqueIndex,
   uuid,
   varchar,
 } from 'drizzle-orm/pg-core';
@@ -856,6 +857,7 @@ export const documentEmbeddings = pgTable(
   'document_embeddings',
   {
     id: uuid('id').primaryKey().defaultRandom(),
+    generationId: uuid('generationId'),
     ownerId: uuid('ownerId').notNull(),
     sourceType: varchar('sourceType', { length: 20 }).notNull(),
     sourceId: uuid('sourceId').notNull(),
@@ -880,7 +882,8 @@ export const documentEmbeddings = pgTable(
       table.embeddingModel,
       table.embeddingDimensions
     ),
-    uniqueSourceChunk: unique('document_embeddings_source_chunk_unique').on(
+    uniqueSourceChunk: unique('document_embeddings_generation_source_chunk_unique').on(
+      table.generationId,
       table.sourceType,
       table.sourceId,
       table.chunkIndex
@@ -899,6 +902,7 @@ export const embeddingJobs = pgTable(
   'embedding_jobs',
   {
     id: uuid('id').primaryKey().defaultRandom(),
+    generationId: uuid('generationId'),
     ownerId: uuid('ownerId').notNull(),
     sourceType: varchar('sourceType', { length: 20 }).notNull(),
     sourceId: uuid('sourceId').notNull(),
@@ -907,10 +911,21 @@ export const embeddingJobs = pgTable(
     attempts: integer('attempts').notNull().default(0),
     error: text('error'),
     lockedAt: timestamp('lockedAt', { withTimezone: true, precision: 6 }),
+    leaseToken: uuid('leaseToken'),
+    leaseExpiresAt: timestamp('leaseExpiresAt', { withTimezone: true, precision: 6 }),
+    nextAttemptAt: timestamp('nextAttemptAt', { withTimezone: true, precision: 6 })
+      .notNull()
+      .defaultNow(),
     createdAt: timestamp('createdAt', { withTimezone: true, precision: 6 }).notNull().defaultNow(),
     updatedAt: timestamp('updatedAt', { withTimezone: true, precision: 6 }).notNull().defaultNow(),
   },
   (table) => ({
+    pendingSource: uniqueIndex('embedding_jobs_pending_source_idx')
+      .on(table.generationId, table.sourceType, table.sourceId)
+      .where(sql`${table.status} = 'pending'`),
+    runningSource: uniqueIndex('embedding_jobs_running_source_idx')
+      .on(table.generationId, table.sourceType, table.sourceId)
+      .where(sql`${table.status} = 'running'`),
     statusIdx: index('embedding_jobs_status_idx').on(table.status, table.createdAt),
     sourceIdx: index('embedding_jobs_source_idx').on(table.sourceType, table.sourceId),
     ownerIdx: index('embedding_jobs_ownerId_idx').on(table.ownerId),
@@ -1201,3 +1216,51 @@ export type BillingGrant = typeof billingGrants.$inferSelect;
 export type NewBillingGrant = typeof billingGrants.$inferInsert;
 export type BillingInboundDelivery = typeof billingInboundDeliveries.$inferSelect;
 export type NewBillingInboundDelivery = typeof billingInboundDeliveries.$inferInsert;
+
+// One authoritative state row; legacy vectors deliberately have no generation.
+export const embeddingIndexState = pgTable(
+  'embedding_index_state',
+  {
+    id: integer('id').primaryKey().default(1),
+    revision: integer('revision').notNull().default(0),
+    fingerprint: text('fingerprint'),
+    dimensions: integer('dimensions'),
+    generationId: uuid('generationId'),
+    status: text('status')
+      .$type<'needs_validation' | 'needs_rebuild' | 'rebuilding' | 'ready' | 'failed'>()
+      .notNull()
+      .default('needs_validation'),
+    scanSource: text('scanSource').$type<'rote' | 'article'>().notNull().default('rote'),
+    scanCursor: uuid('scanCursor'),
+    scanComplete: boolean('scanComplete').notNull().default(false),
+    errorCode: text('errorCode'),
+    errorDetails: jsonb('errorDetails').$type<Record<string, string | number>>(),
+    validatedAt: timestamp('validatedAt', { withTimezone: true, precision: 6 }),
+    updatedAt: timestamp('updatedAt', { withTimezone: true, precision: 6 }).notNull().defaultNow(),
+  },
+  (table) => ({
+    singleton: check('embedding_index_state_singleton', sql`${table.id} = 1`),
+    dimensionsRange: check(
+      'embedding_index_dimensions_range',
+      sql`${table.dimensions} BETWEEN 1 AND 2000`
+    ),
+  })
+);
+
+// Transactional source-change outbox, populated by database triggers.
+export const embeddingSourceEvents = pgTable(
+  'embedding_source_events',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    sourceType: text('sourceType').$type<'rote' | 'article'>().notNull(),
+    sourceId: uuid('sourceId').notNull(),
+    ownerId: uuid('ownerId').notNull(),
+    action: text('action').$type<'upsert' | 'delete'>().notNull(),
+    generationId: uuid('generationId'),
+    rebuilding: boolean('rebuilding').notNull().default(false),
+    createdAt: timestamp('createdAt', { withTimezone: true, precision: 6 }).notNull().defaultNow(),
+  },
+  (table) => ({
+    pending: index('embedding_source_events_pending_idx').on(table.createdAt, table.id),
+  })
+);

--- a/server/embeddings/client.test.ts
+++ b/server/embeddings/client.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import type { EmbeddingProviderConfig } from '../types/config';
+import { createEmbedding, testEmbeddingProvider } from './client';
+import { validateVector, embeddingFingerprint } from './contract';
+import { DEFAULT_AI_CONFIG } from '../utils/ai/providers';
+
+const originalFetch = globalThis.fetch;
+const provider: EmbeddingProviderConfig = {
+  providerId: 'siliconflow',
+  baseUrl: 'https://api.siliconflow.cn/v1',
+  model: 'BAAI/bge-m3',
+  output: { mode: 'native' },
+};
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+function respond(dimensions: number, inspect?: (body: Record<string, unknown>) => void) {
+  globalThis.fetch = (async (_url, init) => {
+    inspect?.(JSON.parse(String(init?.body)));
+    return Response.json({ data: [{ embedding: Array(dimensions).fill(0.1) }] });
+  }) as typeof fetch;
+}
+describe('embedding request contract', () => {
+  it('uses BGE-M3 native dimensions without sending dimensions', async () => {
+    respond(1024, (body) =>
+      expect(body).toEqual({ model: 'BAAI/bge-m3', input: 'Rote embedding connectivity test.' })
+    );
+    expect(await testEmbeddingProvider(provider)).toEqual({
+      dimensions: 1024,
+      output: { mode: 'native' },
+    });
+  });
+  it('validates the protocol over a controllable HTTP model server', async () => {
+    const service = Bun.serve({
+      hostname: '127.0.0.1',
+      port: 0,
+      async fetch(request) {
+        const body = await request.json();
+        if ('dimensions' in body) return Response.json({ error: 'unsupported' }, { status: 400 });
+        return Response.json({ data: [{ embedding: Array(1024).fill(0.1) }] });
+      },
+    });
+    try {
+      const config = { ...provider, baseUrl: `http://127.0.0.1:${service.port}/v1` };
+      expect((await testEmbeddingProvider(config)).dimensions).toBe(1024);
+      await expect(
+        testEmbeddingProvider({ ...config, output: { mode: 'dimensions', dimensions: 1024 } })
+      ).rejects.toMatchObject({ code: 'embedding_parameter_rejected' });
+    } finally {
+      service.stop(true);
+    }
+  });
+  it('accepts unlisted models using the native protocol', async () => {
+    respond(17);
+    expect(
+      (await createEmbedding({ ...provider, model: 'new-model' }, 'test')).embedding
+    ).toHaveLength(17);
+  });
+  it('sends an explicitly requested dimension and detects ignored parameters', async () => {
+    const config: EmbeddingProviderConfig = {
+      ...provider,
+      output: { mode: 'dimensions', dimensions: 3 },
+    };
+    respond(3, (body) => expect(body.dimensions).toBe(3));
+    expect((await testEmbeddingProvider(config)).dimensions).toBe(3);
+    respond(1024);
+    await expect(testEmbeddingProvider(config)).rejects.toMatchObject({
+      code: 'embedding_dimensions_mismatch',
+      details: { expected: 3, actual: 1024 },
+    });
+  });
+  it('accepts 2000 dimensions and rejects 2001 with actionable details', async () => {
+    respond(2000);
+    expect((await testEmbeddingProvider(provider)).dimensions).toBe(2000);
+    respond(2001);
+    await expect(testEmbeddingProvider(provider)).rejects.toMatchObject({
+      code: 'embedding_dimensions_limit',
+      details: { actual: 2001, limit: 2000 },
+    });
+  });
+  it('validates the persisted native dimension on every runtime request', async () => {
+    respond(3);
+    await expect(
+      createEmbedding(provider, 'text', { expectedDimensions: 4 })
+    ).rejects.toMatchObject({ code: 'embedding_dimensions_mismatch' });
+  });
+  it('rejects invalid or unusable float32 vectors', () => {
+    for (const value of [[], [0, 0], [NaN], [Infinity], [1e100], [1e-100], ['1'], null]) {
+      expect(() => validateVector(value)).toThrow('embedding_response_invalid');
+    }
+    expect(validateVector([0.1, -0.2])).toEqual([0.1, -0.2]);
+  });
+  it('does not retry rejected parameters or expose provider payloads', async () => {
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls++;
+      return Response.json({ message: 'private detail' }, { status: 400 });
+    }) as typeof fetch;
+    await expect(testEmbeddingProvider(provider)).rejects.toMatchObject({
+      code: 'embedding_parameter_rejected',
+      retryable: false,
+      details: { providerStatus: 400 },
+    });
+    expect(calls).toBe(1);
+  });
+  it('classifies transient failures and times out stalled requests', async () => {
+    globalThis.fetch = (async () => new Response('', { status: 429 })) as typeof fetch;
+    await expect(testEmbeddingProvider(provider)).rejects.toMatchObject({
+      code: 'embedding_rate_limited',
+      retryable: true,
+    });
+    globalThis.fetch = ((_url, init) =>
+      new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => reject(init.signal?.reason));
+      })) as typeof fetch;
+    await expect(createEmbedding(provider, 'test', { timeoutMs: 5 })).rejects.toMatchObject({
+      code: 'embedding_timeout',
+      retryable: true,
+    });
+  });
+  it('fingerprints semantic configuration while allowing credential rotation', () => {
+    const config = structuredClone(DEFAULT_AI_CONFIG);
+    const before = embeddingFingerprint(config);
+    config.embedding.apiKey = 'rotated';
+    config.indexing.paused = true;
+    expect(embeddingFingerprint(config)).toBe(before);
+    config.embedding.baseUrl = 'https://another-provider.test/v1';
+    expect(embeddingFingerprint(config)).not.toBe(before);
+  });
+});

--- a/server/embeddings/client.ts
+++ b/server/embeddings/client.ts
@@ -1,0 +1,69 @@
+import type { EmbeddingProviderConfig } from '../types/config';
+import { buildHeaders, normalizeBaseUrl, normalizeUsage } from '../utils/ai/clientShared';
+import { embeddingOutputSchema, validateVector } from './contract';
+import { EmbeddingError } from './errors';
+
+export async function createEmbedding(
+  config: EmbeddingProviderConfig,
+  input: string,
+  options: { expectedDimensions?: number; timeoutMs?: number } = {}
+): Promise<{ embedding: number[]; usage?: { prompt_tokens: number; total_tokens: number } }> {
+  const output = embeddingOutputSchema.safeParse(config.output);
+  if (!output.success || !config.baseUrl.trim() || !config.model.trim()) {
+    throw new EmbeddingError('embedding_config_invalid', 400);
+  }
+  const text = input.replace(/\s+/g, ' ').trim();
+  if (!text) throw new EmbeddingError('embedding_input_empty', 400);
+  const signal = AbortSignal.timeout(options.timeoutMs ?? 30_000);
+  let response: Response;
+  let raw: string;
+  try {
+    response = await fetch(`${normalizeBaseUrl(config.baseUrl)}/embeddings`, {
+      method: 'POST',
+      headers: buildHeaders(config),
+      body: JSON.stringify({
+        model: config.model.trim(),
+        input: text,
+        ...(output.data.mode === 'dimensions' ? { dimensions: output.data.dimensions } : {}),
+      }),
+      signal,
+    });
+    raw = await response.text();
+  } catch {
+    throw new EmbeddingError(
+      signal.aborted ? 'embedding_timeout' : 'embedding_network_error',
+      signal.aborted ? 504 : 502,
+      {},
+      true
+    );
+  }
+  if (!response.ok) {
+    const retryable = response.status === 408 || response.status === 429 || response.status >= 500;
+    const code =
+      response.status === 401 || response.status === 403
+        ? 'embedding_auth_failed'
+        : response.status === 429
+          ? 'embedding_rate_limited'
+          : retryable
+            ? 'embedding_provider_unavailable'
+            : 'embedding_parameter_rejected';
+    throw new EmbeddingError(code, 502, { providerStatus: response.status }, retryable);
+  }
+  let body: { data?: { embedding?: unknown }[]; usage?: unknown };
+  try {
+    body = JSON.parse(raw);
+  } catch {
+    throw new EmbeddingError('embedding_response_invalid');
+  }
+  const expected =
+    output.data.mode === 'dimensions' ? output.data.dimensions : options.expectedDimensions;
+  const embedding = validateVector(body?.data?.[0]?.embedding, expected);
+  if (options.expectedDimensions !== undefined)
+    validateVector(embedding, options.expectedDimensions);
+  return { embedding, usage: normalizeUsage(body?.usage) };
+}
+
+export async function testEmbeddingProvider(config: EmbeddingProviderConfig) {
+  const { embedding } = await createEmbedding(config, 'Rote embedding connectivity test.');
+  return { dimensions: embedding.length, output: config.output };
+}

--- a/server/embeddings/configStore.ts
+++ b/server/embeddings/configStore.ts
@@ -1,0 +1,175 @@
+import { eq } from 'drizzle-orm';
+import { z } from 'zod';
+import { embeddingIndexState, settings } from '../drizzle/schema';
+import type { AiConfig } from '../types/config';
+import { mergeAiConfig, resolveIncomingAiConfig } from '../utils/ai/providers';
+import { refreshConfigCache } from '../utils/config';
+import db from '../utils/drizzle';
+import { testEmbeddingProvider } from './client';
+import { embeddingFingerprint, embeddingOutputSchema } from './contract';
+import { EmbeddingError, isEmbeddingContractFailure } from './errors';
+
+export type EmbeddingTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
+export type EmbeddingExecutor = typeof db | EmbeddingTransaction;
+export type IndexState = typeof embeddingIndexState.$inferSelect;
+const providerSchema = z.strictObject({
+  providerId: z.string(),
+  apiFormat: z.literal('openai_compatible').optional(),
+  baseUrl: z.string(),
+  model: z.string(),
+  apiKey: z.string().optional(),
+});
+const configSchema = z.strictObject({
+  schemaVersion: z.literal(2),
+  revision: z.number().int().min(0),
+  enabled: z.boolean(),
+  vectorEnabled: z.boolean(),
+  autoIndexEnabled: z.boolean(),
+  publicExploreVectorEnabled: z.boolean(),
+  chat: providerSchema,
+  embedding: providerSchema.extend({ output: embeddingOutputSchema }),
+  indexing: z.strictObject({
+    chunkSize: z.number().int().min(500),
+    chunkOverlap: z.number().int().min(0),
+    batchSize: z.number().int().min(1).max(20),
+    maxRetries: z.number().int().min(1).max(10),
+    paused: z.boolean().optional(),
+  }),
+});
+export async function readAiSnapshot(executor: EmbeddingExecutor = db) {
+  const [row] = await executor
+    .select({ config: settings.config, state: embeddingIndexState })
+    .from(embeddingIndexState)
+    .leftJoin(settings, eq(settings.group, 'ai'))
+    .where(eq(embeddingIndexState.id, 1));
+  if (!row) throw new EmbeddingError('embedding_state_missing', 503);
+  return {
+    config: {
+      ...mergeAiConfig(row.config as Partial<AiConfig> | null),
+      revision: row.state.revision,
+    },
+    state: row.state,
+  };
+}
+export async function lockIndexState(tx: EmbeddingTransaction) {
+  const [state] = await tx
+    .select()
+    .from(embeddingIndexState)
+    .where(eq(embeddingIndexState.id, 1))
+    .for('update');
+  if (!state) throw new EmbeddingError('embedding_state_missing', 503);
+  return state;
+}
+export async function getStoredAiConfig(): Promise<AiConfig> {
+  return (await readAiSnapshot()).config;
+}
+export function canProcessIndex(config: AiConfig, state: IndexState) {
+  return (
+    config.enabled &&
+    config.vectorEnabled &&
+    state.generationId !== null &&
+    state.dimensions !== null &&
+    (state.status === 'ready' || state.status === 'rebuilding')
+  );
+}
+export function parseIncomingAiConfig(incoming: Partial<AiConfig>, stored: AiConfig): AiConfig {
+  if (
+    incoming.embedding?.apiKey === '********' &&
+    (incoming.embedding.baseUrl !== stored.embedding.baseUrl ||
+      incoming.embedding.providerId !== stored.embedding.providerId)
+  )
+    throw new EmbeddingError('embedding_config_invalid', 400);
+  const parsed = configSchema.safeParse(resolveIncomingAiConfig(incoming, stored));
+  if (!parsed.success) throw new EmbeddingError('embedding_config_invalid', 400);
+  const next = parsed.data;
+  if (next.indexing.chunkOverlap >= next.indexing.chunkSize)
+    throw new EmbeddingError('embedding_config_invalid', 400);
+  return next;
+}
+export async function saveAiSettings(incoming: Partial<AiConfig>): Promise<AiConfig> {
+  const before = await readAiSnapshot();
+  if (incoming.revision !== before.state.revision)
+    throw new EmbeddingError('embedding_revision_conflict', 409);
+  const next = parseIncomingAiConfig(incoming, before.config);
+  const fingerprint = embeddingFingerprint(next);
+  const identityChanged = fingerprint !== before.state.fingerprint;
+  const keyChanged = next.embedding.apiKey !== before.config.embedding.apiKey;
+  const enabledNow = next.enabled && next.vectorEnabled;
+  const enabling = enabledNow && !(before.config.enabled && before.config.vectorEnabled);
+  const contractFailed = isEmbeddingContractFailure(before.state.errorCode);
+  const needsValidation =
+    identityChanged ||
+    keyChanged ||
+    enabling ||
+    contractFailed ||
+    before.state.status === 'needs_validation';
+  const verified =
+    enabledNow && needsValidation ? await testEmbeddingProvider(next.embedding) : null;
+  const invalidatesIndex =
+    identityChanged || (verified !== null && verified.dimensions !== before.state.dimensions);
+  await db.transaction(async (tx) => {
+    const state = await lockIndexState(tx);
+    if (state.revision !== incoming.revision)
+      throw new EmbeddingError('embedding_revision_conflict', 409);
+    next.revision = state.revision + 1;
+    await tx
+      .insert(settings)
+      .values({
+        group: 'ai',
+        config: next,
+        isRequired: false,
+        isSystem: false,
+        isInitialized: true,
+      })
+      .onConflictDoUpdate({ target: settings.group, set: { config: next, updatedAt: new Date() } });
+    await tx
+      .update(embeddingIndexState)
+      .set({
+        revision: next.revision,
+        ...(verified
+          ? {
+              fingerprint,
+              dimensions: verified.dimensions,
+              validatedAt: new Date(),
+              errorCode: null,
+              errorDetails: null,
+              status:
+                invalidatesIndex || contractFailed || state.status === 'needs_validation'
+                  ? ('needs_rebuild' as const)
+                  : state.status,
+            }
+          : needsValidation
+            ? {
+                fingerprint: null,
+                dimensions: null,
+                status: 'needs_validation' as const,
+                validatedAt: null,
+                errorCode: null,
+                errorDetails: null,
+              }
+            : {}),
+        updatedAt: new Date(),
+      })
+      .where(eq(embeddingIndexState.id, 1));
+  });
+  await refreshConfigCache();
+  return next;
+}
+export async function setIndexingPaused(paused: boolean): Promise<AiConfig> {
+  await db.transaction(async (tx) => {
+    await lockIndexState(tx);
+    const { config } = await readAiSnapshot(tx);
+    config.indexing.paused = paused;
+    config.revision += 1;
+    await tx
+      .insert(settings)
+      .values({ group: 'ai', config, isInitialized: true })
+      .onConflictDoUpdate({ target: settings.group, set: { config, updatedAt: new Date() } });
+    await tx
+      .update(embeddingIndexState)
+      .set({ revision: config.revision, updatedAt: new Date() })
+      .where(eq(embeddingIndexState.id, 1));
+  });
+  await refreshConfigCache();
+  return getStoredAiConfig();
+}

--- a/server/embeddings/contract.ts
+++ b/server/embeddings/contract.ts
@@ -1,0 +1,62 @@
+import { createHash } from 'node:crypto';
+import { z } from 'zod';
+import type { AiConfig } from '../types/config';
+import { EmbeddingError } from './errors';
+
+export const MAX_EMBEDDING_DIMENSIONS = 2000;
+export const embeddingOutputSchema = z.discriminatedUnion('mode', [
+  z.strictObject({ mode: z.literal('native') }),
+  z.strictObject({
+    mode: z.literal('dimensions'),
+    dimensions: z.number().int().min(1).max(MAX_EMBEDDING_DIMENSIONS),
+  }),
+]);
+
+export function validateVector(value: unknown, expectedDimensions?: number): number[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new EmbeddingError('embedding_response_invalid');
+  }
+  if (value.length > MAX_EMBEDDING_DIMENSIONS) {
+    throw new EmbeddingError('embedding_dimensions_limit', 422, {
+      actual: value.length,
+      limit: MAX_EMBEDDING_DIMENSIONS,
+    });
+  }
+  let norm = 0;
+  const vector = value.map((item: unknown) => {
+    if (typeof item !== 'number' || !Number.isFinite(item) || !Number.isFinite(Math.fround(item))) {
+      throw new EmbeddingError('embedding_response_invalid');
+    }
+    norm += Math.fround(item) ** 2;
+    return item;
+  });
+  if (!Number.isFinite(norm) || norm === 0) throw new EmbeddingError('embedding_response_invalid');
+  if (expectedDimensions !== undefined && vector.length !== expectedDimensions) {
+    throw new EmbeddingError('embedding_dimensions_mismatch', 422, {
+      expected: expectedDimensions,
+      actual: vector.length,
+    });
+  }
+  return vector;
+}
+
+export function embeddingFingerprint(config: AiConfig): string {
+  const { providerId, baseUrl, model, output, apiFormat } = config.embedding;
+  return createHash('sha256')
+    .update(
+      JSON.stringify({
+        providerId,
+        baseUrl: baseUrl.trim().replace(/\/+$/, ''),
+        model: model.trim(),
+        apiFormat: apiFormat || 'openai_compatible',
+        output:
+          output.mode === 'native'
+            ? { mode: 'native' }
+            : { mode: 'dimensions', dimensions: output.dimensions },
+        chunkSize: config.indexing.chunkSize,
+        chunkOverlap: config.indexing.chunkOverlap,
+        textVersion: 1,
+      })
+    )
+    .digest('hex');
+}

--- a/server/embeddings/errors.ts
+++ b/server/embeddings/errors.ts
@@ -1,0 +1,22 @@
+export class EmbeddingError extends Error {
+  constructor(
+    public readonly code: string,
+    public readonly status: 400 | 409 | 422 | 502 | 503 | 504 = 422,
+    public readonly details: Record<string, string | number> = {},
+    public readonly retryable = false
+  ) {
+    super(code);
+    this.name = 'EmbeddingError';
+  }
+}
+
+export function isEmbeddingContractFailure(code: string | null) {
+  return (
+    code !== null &&
+    [
+      'embedding_response_invalid',
+      'embedding_dimensions_mismatch',
+      'embedding_dimensions_limit',
+    ].includes(code)
+  );
+}

--- a/server/embeddings/index.integration.test.ts
+++ b/server/embeddings/index.integration.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeEach, describe, expect, it } from 'bun:test';
-import { eq } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 import { DEFAULT_AI_CONFIG } from '../utils/ai/providers';
 
 if (
@@ -150,6 +150,47 @@ describe.serial('embedding configuration and index lifecycle', () => {
     });
     expect((await readAiSnapshot()).state.status).toBe('needs_rebuild');
     expect(await db.select().from(documentEmbeddings)).toHaveLength(1);
+  });
+  it('indexes and retrieves the full 2000-dimensional storage boundary', async () => {
+    provider(2000);
+    const config = await saveConfig();
+    await note();
+    await ensurePgvectorReady();
+    await startIndexRebuild(config.revision);
+    await completeRebuild();
+    expect((await getPgvectorStatus()).dimensions).toBe(2000);
+    expect(await semanticSearch({ query: 'fixture', ownerId, viewerId: ownerId })).toHaveLength(1);
+  });
+  it('rolls back replacement when the database rejects a generated source', async () => {
+    const config = await saveConfig();
+    await note();
+    await ensurePgvectorReady();
+    await startIndexRebuild(config.revision);
+    await completeRebuild();
+    const previous = await db.select().from(documentEmbeddings);
+    await note('changed source with rejected database insert');
+    await enqueueEmbeddingJob('rote', noteId, ownerId, 'upsert', true);
+    // Fault injection is confined to the explicitly disposable integration database.
+    await db.execute(
+      sql`CREATE FUNCTION reject_embedding_test_insert() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'fixture insert failure'; END; $$`
+    );
+    try {
+      await db.execute(
+        sql`CREATE TRIGGER reject_embedding_test_insert BEFORE INSERT ON document_embeddings FOR EACH ROW EXECUTE FUNCTION reject_embedding_test_insert()`
+      );
+      await processPendingEmbeddingJobs();
+      expect(await db.select().from(documentEmbeddings)).toEqual(previous);
+      expect((await getEmbeddingJobStats()).failed).toBe(1);
+      expect((await readAiSnapshot()).state.status).toBe('ready');
+    } finally {
+      await db.execute(
+        sql`DROP TRIGGER IF EXISTS reject_embedding_test_insert ON document_embeddings`
+      );
+      await db.execute(sql`DROP FUNCTION reject_embedding_test_insert()`);
+    }
+    await retryFailedEmbeddingJobs();
+    await processPendingEmbeddingJobs();
+    expect((await db.select().from(documentEmbeddings))[0].text).toContain('changed source');
   });
   it('finishes an empty rebuild, and resumes scanning from its persisted cursor', async () => {
     const config = await saveConfig();

--- a/server/embeddings/index.integration.test.ts
+++ b/server/embeddings/index.integration.test.ts
@@ -190,6 +190,26 @@ describe.serial('embedding configuration and index lifecycle', () => {
     await processEmbeddingJob(second!.job, second!.config, 3);
     expect(await db.select().from(documentEmbeddings)).toHaveLength(1);
   });
+  it('does not let an expired worker delete retained vectors when its source disappears', async () => {
+    const config = await saveConfig();
+    await note();
+    await ensurePgvectorReady();
+    await startIndexRebuild(config.revision);
+    await completeRebuild();
+    await enqueueEmbeddingJob('rote', noteId, ownerId, 'upsert', true);
+    const claim = await claimEmbeddingJob();
+    await db.delete(rotes).where(eq(rotes.id, noteId));
+    await db
+      .update(embeddingJobs)
+      .set({ leaseExpiresAt: new Date(0) })
+      .where(eq(embeddingJobs.id, claim!.job.id));
+    await expect(processEmbeddingJob(claim!.job, claim!.config, 3)).rejects.toMatchObject({
+      code: 'embedding_lease_lost',
+    });
+    expect(await db.select().from(documentEmbeddings)).toHaveLength(1);
+    await processPendingEmbeddingJobs();
+    expect(await db.select().from(documentEmbeddings)).toHaveLength(0);
+  });
   it('requeues a changed source and captures changes during rebuild with auto indexing disabled', async () => {
     const config = await saveConfig();
     await note();

--- a/server/embeddings/index.integration.test.ts
+++ b/server/embeddings/index.integration.test.ts
@@ -1,0 +1,379 @@
+import { afterAll, beforeEach, describe, expect, it } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import { DEFAULT_AI_CONFIG } from '../utils/ai/providers';
+
+if (
+  !process.env.POSTGRESQL_URL ||
+  !new URL(process.env.POSTGRESQL_URL).pathname.endsWith('_embedding_test')
+) {
+  throw new Error('Embedding integration tests require a dedicated *_embedding_test database');
+}
+const { default: db, closeDatabase } = await import('../utils/drizzle');
+const {
+  users,
+  rotes,
+  articles,
+  settings,
+  documentEmbeddings,
+  embeddingJobs,
+  embeddingIndexState,
+  embeddingSourceEvents,
+} = await import('../drizzle/schema');
+const { saveAiSettings, readAiSnapshot } = await import('./configStore');
+const { startIndexRebuild, clearAllEmbeddings, retryFailedEmbeddingJobs } =
+  await import('./indexLifecycle');
+const { getPgvectorStatus, ensurePgvectorReady } = await import('../utils/dbMethods/ai/vector');
+const { processPendingEmbeddingJobs } = await import('../utils/dbMethods/ai/embeddingWorker');
+const { enqueueEmbeddingJob, getEmbeddingJobStats } = await import('./queue');
+const { claimEmbeddingJob } = await import('./jobClaims');
+const { processEmbeddingJob } = await import('./jobProcessor');
+const { scanRebuildPage } = await import('./rebuildScanner');
+const { semanticSearch } = await import('../utils/dbMethods/ai/semanticSearch');
+const ownerId = '13180000-0000-4000-8000-000000000001';
+const noteId = '13180000-0000-4000-8000-000000000002';
+const articleId = '13180000-0000-4000-8000-000000000003';
+const realFetch = globalThis.fetch;
+let requests: Record<string, unknown>[] = [];
+function provider(dimensions = 3) {
+  globalThis.fetch = (async (_url, init) => {
+    requests.push(JSON.parse(String(init?.body)));
+    return Response.json({ data: [{ embedding: Array(dimensions).fill(0.1) }] });
+  }) as typeof fetch;
+}
+async function saveConfig() {
+  return saveAiSettings({
+    ...structuredClone(DEFAULT_AI_CONFIG),
+    enabled: true,
+    vectorEnabled: true,
+    embedding: {
+      ...DEFAULT_AI_CONFIG.embedding,
+      baseUrl: 'https://embedding.test/v1',
+      model: 'BAAI/bge-m3',
+    },
+  });
+}
+async function note(content = 'embedding fixture') {
+  await db
+    .insert(rotes)
+    .values({ id: noteId, authorid: ownerId, content })
+    .onConflictDoUpdate({ target: rotes.id, set: { content, updatedAt: new Date() } });
+}
+async function completeRebuild() {
+  for (let i = 0; i < 10; i++) {
+    if ((await readAiSnapshot()).state.status === 'ready') return;
+    await processPendingEmbeddingJobs(20);
+  }
+  expect((await readAiSnapshot()).state.status).toBe('ready');
+}
+beforeEach(async () => {
+  requests = [];
+  provider();
+  await clearAllEmbeddings();
+  await db.delete(rotes).where(eq(rotes.id, noteId));
+  await db.delete(articles).where(eq(articles.id, articleId));
+  await db.delete(embeddingSourceEvents);
+  await db.delete(settings).where(eq(settings.group, 'ai'));
+  await db
+    .update(embeddingIndexState)
+    .set({
+      revision: 0,
+      fingerprint: null,
+      dimensions: null,
+      generationId: null,
+      status: 'needs_validation',
+      scanSource: 'rote',
+      scanCursor: null,
+      scanComplete: false,
+      errorCode: null,
+    })
+    .where(eq(embeddingIndexState.id, 1));
+  await db
+    .insert(users)
+    .values({
+      id: ownerId,
+      email: 'embedding@example.test',
+      username: 'embedding-fixture',
+      role: 'admin',
+    })
+    .onConflictDoNothing();
+});
+afterAll(async () => {
+  globalThis.fetch = realFetch;
+  await closeDatabase();
+});
+
+describe.serial('embedding configuration and index lifecycle', () => {
+  it('verifies at save time, rejects forged dimensions and stale revisions, preserves working settings on failure', async () => {
+    const saved = await saveConfig();
+    expect((await readAiSnapshot()).state.status).toBe('needs_rebuild');
+    expect(saved.revision).toBe(1);
+    await expect(saveAiSettings({ ...saved, revision: 0 })).rejects.toMatchObject({
+      code: 'embedding_revision_conflict',
+    });
+    await expect(
+      saveAiSettings({ ...saved, embedding: { ...saved.embedding, dimensions: 18 } } as never)
+    ).rejects.toMatchObject({ code: 'embedding_config_invalid' });
+    provider(2001);
+    await expect(
+      saveAiSettings({ ...saved, embedding: { ...saved.embedding, model: 'different' } })
+    ).rejects.toMatchObject({ code: 'embedding_dimensions_limit' });
+    expect((await readAiSnapshot()).config).toEqual(saved);
+  });
+  it('builds a real HNSW index, serves generation-scoped results and preserves ready state on key rotation', async () => {
+    const config = await saveConfig();
+    await note();
+    await ensurePgvectorReady();
+    const started = await startIndexRebuild(config.revision);
+    expect(started.status).toBe('rebuilding');
+    expect((await startIndexRebuild(config.revision)).generationId).toBe(started.generationId);
+    await expect(
+      semanticSearch({ query: 'test', ownerId, viewerId: ownerId })
+    ).rejects.toMatchObject({ code: 'embedding_rebuild_required' });
+    await completeRebuild();
+    expect((await getPgvectorStatus()).ready).toBe(true);
+    expect(
+      (await semanticSearch({ query: 'fixture', ownerId, viewerId: ownerId })).map(
+        (row) => row.sourceId
+      )
+    ).toContain(noteId);
+    const saved = await saveAiSettings({
+      ...config,
+      embedding: { ...config.embedding, apiKey: 'rotated-placeholder' },
+    });
+    expect((await readAiSnapshot()).state).toMatchObject({
+      status: 'ready',
+      generationId: started.generationId,
+    });
+    await saveAiSettings({
+      ...saved,
+      embedding: { ...saved.embedding, baseUrl: 'https://other.test/v1' },
+    });
+    expect((await readAiSnapshot()).state.status).toBe('needs_rebuild');
+    expect(await db.select().from(documentEmbeddings)).toHaveLength(1);
+  });
+  it('finishes an empty rebuild, and resumes scanning from its persisted cursor', async () => {
+    const config = await saveConfig();
+    await ensurePgvectorReady();
+    await startIndexRebuild(config.revision);
+    await completeRebuild();
+    await note();
+    await db
+      .insert(articles)
+      .values({ id: articleId, authorId: ownerId, content: 'article fixture' });
+    await startIndexRebuild(config.revision);
+    await scanRebuildPage(1);
+    expect((await readAiSnapshot()).state.scanCursor).toBe(noteId);
+    await scanRebuildPage(1);
+    expect((await readAiSnapshot()).state.scanSource).toBe('article');
+    await completeRebuild();
+    expect((await getEmbeddingJobStats()).succeeded).toBe(2);
+  });
+  it('rejects late results after lease reclamation and prevents concurrent jobs for one source', async () => {
+    const config = await saveConfig();
+    await ensurePgvectorReady();
+    await startIndexRebuild(config.revision);
+    await completeRebuild();
+    await note();
+    await enqueueEmbeddingJob('rote', noteId, ownerId, 'upsert', true);
+    const [one, two] = await Promise.all([claimEmbeddingJob(), claimEmbeddingJob()]);
+    const first = one || two;
+    expect(Number(Boolean(one)) + Number(Boolean(two))).toBe(1);
+    await db
+      .update(embeddingJobs)
+      .set({ leaseExpiresAt: new Date(0) })
+      .where(eq(embeddingJobs.id, first!.job.id));
+    const second = await claimEmbeddingJob();
+    expect(second!.job.leaseToken).not.toBe(first!.job.leaseToken);
+    await expect(processEmbeddingJob(first!.job, first!.config, 3)).rejects.toMatchObject({
+      code: 'embedding_lease_lost',
+    });
+    await processEmbeddingJob(second!.job, second!.config, 3);
+    expect(await db.select().from(documentEmbeddings)).toHaveLength(1);
+  });
+  it('requeues a changed source and captures changes during rebuild with auto indexing disabled', async () => {
+    const config = await saveConfig();
+    await note();
+    await ensurePgvectorReady();
+    await startIndexRebuild(config.revision);
+    await scanRebuildPage();
+    const claimed = await claimEmbeddingJob();
+    globalThis.fetch = (async () => {
+      await note('updated while embedding');
+      return Response.json({ data: [{ embedding: [0.1, 0.1, 0.1] }] });
+    }) as typeof fetch;
+    await processEmbeddingJob(claimed!.job, claimed!.config, 3);
+    expect(await db.select().from(documentEmbeddings)).toHaveLength(0);
+    expect((await getEmbeddingJobStats()).pending).toBe(1);
+    provider();
+    await enqueueEmbeddingJob('rote', noteId, ownerId);
+    await completeRebuild();
+    expect((await db.select().from(documentEmbeddings))[0].text).toContain(
+      'updated while embedding'
+    );
+  });
+  it('does not replace existing vectors on provider failure and blocks readiness until failed rebuild jobs recover', async () => {
+    const config = await saveConfig();
+    await note();
+    await ensurePgvectorReady();
+    await startIndexRebuild(config.revision);
+    await completeRebuild();
+    const oldGeneration = (await readAiSnapshot()).state.generationId;
+    await startIndexRebuild(config.revision);
+    globalThis.fetch = (async () => Response.json({}, { status: 400 })) as typeof fetch;
+    await processPendingEmbeddingJobs();
+    expect((await readAiSnapshot()).state.status).toBe('failed');
+    expect((await db.select().from(documentEmbeddings))[0].generationId).toBe(oldGeneration);
+    provider();
+    await retryFailedEmbeddingJobs();
+    await completeRebuild();
+    expect(await db.select().from(documentEmbeddings)).toHaveLength(2);
+  });
+  it('discards deleted sources and results from an obsolete generation', async () => {
+    const config = await saveConfig();
+    await note();
+    await ensurePgvectorReady();
+    await startIndexRebuild(config.revision);
+    await scanRebuildPage();
+    const claimed = await claimEmbeddingJob();
+    globalThis.fetch = (async () => {
+      await db.delete(rotes).where(eq(rotes.id, noteId));
+      return Response.json({ data: [{ embedding: [0.1, 0.1, 0.1] }] });
+    }) as typeof fetch;
+    await processEmbeddingJob(claimed!.job, claimed!.config, 3);
+    expect(await db.select().from(documentEmbeddings)).toHaveLength(0);
+    provider();
+    await note();
+    await enqueueEmbeddingJob('rote', noteId, ownerId);
+    const stale = await claimEmbeddingJob();
+    await saveAiSettings({ ...config, embedding: { ...config.embedding, model: 'next-model' } });
+    await expect(processEmbeddingJob(stale!.job, stale!.config, 3)).rejects.toMatchObject({
+      code: 'embedding_lease_lost',
+    });
+    expect(await db.select().from(documentEmbeddings)).toHaveLength(0);
+  });
+  it('invalidates verified state when a native model changes its output dimensions', async () => {
+    const config = await saveConfig();
+    await note();
+    await ensurePgvectorReady();
+    await startIndexRebuild(config.revision);
+    await completeRebuild();
+    provider(4);
+    await expect(
+      semanticSearch({ query: 'test', ownerId, viewerId: ownerId })
+    ).rejects.toMatchObject({ code: 'embedding_dimensions_mismatch' });
+    expect((await readAiSnapshot()).state.status).toBe('needs_validation');
+  });
+  it('commits source events atomically, resumes failed rebuilds and cleans deleted generations', async () => {
+    const config = await saveConfig();
+    await ensurePgvectorReady();
+    await startIndexRebuild(config.revision);
+    await expect(
+      db.transaction(async (tx) => {
+        await tx.insert(rotes).values({ id: noteId, authorid: ownerId, content: 'rolled back' });
+        throw new Error('rollback');
+      })
+    ).rejects.toThrow('rollback');
+    expect(await db.select().from(embeddingSourceEvents)).toHaveLength(0);
+    await note(); // No application enqueue: the committed outbox survives restart.
+    expect(await db.select().from(embeddingSourceEvents)).toHaveLength(1);
+    globalThis.fetch = (async () => Response.json({}, { status: 400 })) as typeof fetch;
+    await processPendingEmbeddingJobs();
+    expect((await readAiSnapshot()).state.status).toBe('failed');
+    await note('updated while rebuild failed');
+    await processPendingEmbeddingJobs();
+    expect((await getEmbeddingJobStats()).pending).toBe(1);
+    provider();
+    await retryFailedEmbeddingJobs();
+    await completeRebuild();
+    expect((await db.select().from(documentEmbeddings))[0].text).toContain(
+      'updated while rebuild failed'
+    );
+    await db.delete(rotes).where(eq(rotes.id, noteId));
+    await processPendingEmbeddingJobs();
+    expect(await db.select().from(documentEmbeddings)).toHaveLength(0);
+  });
+  it('bounds expired lease reclamation without another model request', async () => {
+    const config = await saveConfig();
+    await ensurePgvectorReady();
+    await startIndexRebuild(config.revision);
+    await note();
+    const { consumeSourceEvents } = await import('./sourceEvents');
+    await consumeSourceEvents();
+    await scanRebuildPage();
+    const claim = await claimEmbeddingJob();
+    await db
+      .update(embeddingJobs)
+      .set({ attempts: config.indexing.maxRetries, leaseExpiresAt: new Date(0) })
+      .where(eq(embeddingJobs.id, claim!.job.id));
+    const count = requests.length;
+    await processPendingEmbeddingJobs();
+    expect(requests).toHaveLength(count);
+    expect((await readAiSnapshot()).state.status).toBe('failed');
+  });
+  it('enforces authenticated API revision and verification contracts without mutating settings on test', async () => {
+    const { Hono } = await import('hono');
+    const { default: adminRouter } = await import('../route/v2/admin');
+    const { registerAdminAiRoutes } = await import('../route/v2/aiAdmin');
+    const { errorHandler } = await import('../utils/handlers');
+    const { setConfig } = await import('../utils/config');
+    const { generateAccessToken } = await import('../utils/jwt');
+    await setConfig('security', {
+      jwtSecret: 'embedding-test-only-jwt-signing-key',
+      jwtRefreshSecret: 'embedding-test-only-refresh-key',
+      sessionSecret: 'embedding-test-session',
+    });
+    const token = await generateAccessToken({ userId: ownerId, username: 'embedding-fixture' });
+    const app = new Hono<{ Variables: import('../types/hono').HonoVariables }>();
+    const ai = new Hono<{ Variables: import('../types/hono').HonoVariables }>();
+    registerAdminAiRoutes(ai);
+    app.route('/ai', ai).route('/admin', adminRouter).onError(errorHandler);
+    const request = (path: string, method: string, body?: unknown) =>
+      app.request(path, {
+        method,
+        headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+        ...(body ? { body: JSON.stringify(body) } : {}),
+      });
+    expect((await app.request('/ai/test', { method: 'POST' })).status).toBe(401);
+    const config = await saveConfig();
+    const initial = await readAiSnapshot();
+    const tested = await request('/ai/test', 'POST', { target: 'embedding', config });
+    expect(tested.status).toBe(200);
+    expect((await tested.json()).data).toMatchObject({ dimensions: 3, output: { mode: 'native' } });
+    expect(await readAiSnapshot()).toEqual(initial);
+    expect(
+      (
+        await request('/ai/test', 'POST', {
+          target: 'embedding',
+          config: {
+            ...config,
+            embedding: {
+              ...config.embedding,
+              apiKey: '********',
+              baseUrl: 'https://another.test/v1',
+            },
+          },
+        })
+      ).status
+    ).toBe(400);
+    expect(
+      (await request('/admin/settings', 'PUT', { group: 'ai', config: { ...config, revision: 0 } }))
+        .status
+    ).toBe(409);
+    provider(2001);
+    const failed = await request('/admin/settings', 'PUT', {
+      group: 'ai',
+      config: { ...config, embedding: { ...config.embedding, model: 'oversized' } },
+    });
+    expect(failed.status).toBe(422);
+    expect((await failed.json()).data).toMatchObject({ actual: 2001, limit: 2000 });
+    expect((await readAiSnapshot()).config).toEqual(config);
+    provider();
+    await ensurePgvectorReady();
+    expect((await request('/ai/index/rebuild', 'POST', { revision: config.revision })).status).toBe(
+      202
+    );
+    expect((await request('/ai/index/rebuild', 'POST', { revision: 0 })).status).toBe(409);
+    const read = await request('/admin/settings?group=ai', 'GET');
+    expect((await read.json()).data.config.revision).toBe(config.revision);
+  });
+});

--- a/server/embeddings/indexLifecycle.ts
+++ b/server/embeddings/indexLifecycle.ts
@@ -1,0 +1,164 @@
+import { randomUUID } from 'node:crypto';
+import { and, eq, inArray, sql } from 'drizzle-orm';
+import {
+  documentEmbeddings,
+  embeddingIndexState,
+  embeddingJobs,
+  embeddingSourceEvents,
+} from '../drizzle/schema';
+import db from '../utils/drizzle';
+import { vectorIndexName } from '../utils/dbMethods/ai/documents';
+import { getPgvectorStatus } from '../utils/dbMethods/ai/vector';
+import { testEmbeddingProvider } from './client';
+import { lockIndexState, readAiSnapshot } from './configStore';
+import { embeddingFingerprint } from './contract';
+import { EmbeddingError, isEmbeddingContractFailure } from './errors';
+
+export async function startIndexRebuild(revision: unknown) {
+  const before = await readAiSnapshot();
+  if (revision !== before.state.revision)
+    throw new EmbeddingError('embedding_revision_conflict', 409);
+  if (before.state.status === 'rebuilding') return getPgvectorStatus();
+  if (!before.config.enabled || !before.config.vectorEnabled)
+    throw new EmbeddingError('embedding_disabled', 409);
+  const status = await getPgvectorStatus();
+  if (!status.installed) throw new EmbeddingError('embedding_database_unavailable', 503);
+  const verified = await testEmbeddingProvider(before.config.embedding);
+  await db.transaction(async (tx) => {
+    const state = await lockIndexState(tx);
+    if (state.revision !== revision) throw new EmbeddingError('embedding_revision_conflict', 409);
+    if (state.status === 'rebuilding') return;
+    const generationId = randomUUID();
+    const indexName = vectorIndexName(verified.dimensions, generationId);
+    await tx.execute(
+      sql.raw(`CREATE INDEX "${indexName}" ON "document_embeddings"
+      USING hnsw (("embedding"::vector(${verified.dimensions})) vector_cosine_ops)
+      WHERE "generationId" = '${generationId}'::uuid AND "embeddingDimensions" = ${verified.dimensions}`)
+    );
+    await tx
+      .update(embeddingJobs)
+      .set({
+        status: 'cancelled',
+        leaseToken: null,
+        leaseExpiresAt: null,
+        lockedAt: null,
+        updatedAt: new Date(),
+      })
+      .where(inArray(embeddingJobs.status, ['pending', 'running']));
+    await tx
+      .update(embeddingIndexState)
+      .set({
+        status: 'rebuilding',
+        fingerprint: embeddingFingerprint(before.config),
+        dimensions: verified.dimensions,
+        generationId,
+        scanSource: 'rote',
+        scanCursor: null,
+        scanComplete: false,
+        errorCode: null,
+        errorDetails: null,
+        validatedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(embeddingIndexState.id, 1));
+  });
+  return getPgvectorStatus();
+}
+
+export async function retryFailedEmbeddingJobs() {
+  return db.transaction(async (tx) => {
+    const state = await lockIndexState(tx);
+    if (
+      isEmbeddingContractFailure(state.errorCode) ||
+      !state.generationId ||
+      !['failed', 'ready', 'rebuilding'].includes(state.status)
+    ) {
+      throw new EmbeddingError('embedding_rebuild_required', 409);
+    }
+    // Keep only the newest failed attempt per source when no pending successor exists.
+    await tx.execute(sql`WITH ranked AS (
+      SELECT id, row_number() OVER (PARTITION BY "sourceType", "sourceId" ORDER BY "createdAt" DESC, id DESC) AS rank
+      FROM embedding_jobs WHERE status = 'failed' AND "generationId" = ${state.generationId}
+    ) UPDATE embedding_jobs f SET status = 'cancelled'
+      FROM ranked r WHERE r.id = f.id AND (r.rank > 1 OR EXISTS (
+        SELECT 1 FROM embedding_jobs p WHERE p."generationId" = f."generationId"
+        AND p."sourceType" = f."sourceType" AND p."sourceId" = f."sourceId" AND p.status = 'pending'))`);
+    const rows = await tx
+      .update(embeddingJobs)
+      .set({
+        status: 'pending',
+        attempts: 0,
+        error: null,
+        leaseToken: null,
+        leaseExpiresAt: null,
+        lockedAt: null,
+        nextAttemptAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(
+        and(eq(embeddingJobs.generationId, state.generationId), eq(embeddingJobs.status, 'failed'))
+      )
+      .returning({ id: embeddingJobs.id });
+    if (state.status === 'failed')
+      await tx
+        .update(embeddingIndexState)
+        .set({ status: 'rebuilding', errorCode: null, errorDetails: null, updatedAt: new Date() })
+        .where(eq(embeddingIndexState.id, 1));
+    return { retried: rows.length };
+  });
+}
+
+export async function clearAllEmbeddings() {
+  await db.transaction(async (tx) => {
+    const state = await lockIndexState(tx);
+    await tx.delete(documentEmbeddings);
+    await tx.delete(embeddingJobs);
+    await tx.delete(embeddingSourceEvents);
+    await tx
+      .update(embeddingIndexState)
+      .set({
+        status: state.dimensions ? 'needs_rebuild' : 'needs_validation',
+        generationId: null,
+        scanComplete: false,
+        scanCursor: null,
+        errorCode: null,
+        errorDetails: null,
+        updatedAt: new Date(),
+      })
+      .where(eq(embeddingIndexState.id, 1));
+  });
+}
+
+export async function finishIndexRebuild() {
+  const status = await getPgvectorStatus();
+  if (!status.indexName) return;
+  await db.transaction(async (tx) => {
+    const state = await lockIndexState(tx);
+    if (
+      state.status !== 'rebuilding' ||
+      !state.scanComplete ||
+      state.generationId !== status.generationId
+    )
+      return;
+    const [outstanding] = await tx
+      .select({ id: embeddingJobs.id })
+      .from(embeddingJobs)
+      .where(
+        and(
+          eq(embeddingJobs.generationId, state.generationId!),
+          inArray(embeddingJobs.status, ['pending', 'running', 'failed'])
+        )
+      )
+      .limit(1);
+    if (outstanding) return;
+    const [event] = await tx
+      .select({ id: embeddingSourceEvents.id })
+      .from(embeddingSourceEvents)
+      .limit(1);
+    if (event) return;
+    await tx
+      .update(embeddingIndexState)
+      .set({ status: 'ready', errorCode: null, errorDetails: null, updatedAt: new Date() })
+      .where(eq(embeddingIndexState.id, 1));
+  });
+}

--- a/server/embeddings/jobClaims.ts
+++ b/server/embeddings/jobClaims.ts
@@ -1,0 +1,123 @@
+import { randomUUID } from 'node:crypto';
+import { and, eq, sql } from 'drizzle-orm';
+import { embeddingIndexState, embeddingJobs, type EmbeddingJob } from '../drizzle/schema';
+import db from '../utils/drizzle';
+import { canProcessIndex, lockIndexState, readAiSnapshot } from './configStore';
+import { EmbeddingError, isEmbeddingContractFailure } from './errors';
+
+export const LEASE_MS = 120_000;
+export async function claimEmbeddingJob() {
+  return db.transaction(async (tx) => {
+    await lockIndexState(tx);
+    const { config, state } = await readAiSnapshot(tx);
+    if (!canProcessIndex(config, state) || config.indexing.paused) return null;
+    const rows = await tx.execute(sql`
+      SELECT j.id FROM embedding_jobs j WHERE j."generationId" = ${state.generationId}
+      AND ((j.status = 'pending' AND j."nextAttemptAt" <= now() AND NOT EXISTS (
+        SELECT 1 FROM embedding_jobs r WHERE r."generationId" = j."generationId"
+        AND r."sourceType" = j."sourceType" AND r."sourceId" = j."sourceId" AND r.status = 'running'
+      )) OR (j.status = 'running' AND j."leaseExpiresAt" < now()))
+      ORDER BY j."createdAt", j.id LIMIT 1 FOR UPDATE OF j SKIP LOCKED
+    `);
+    if (!rows[0]) return null;
+    const [job] = await tx
+      .update(embeddingJobs)
+      .set({
+        status: 'running',
+        leaseToken: randomUUID(),
+        leaseExpiresAt: new Date(Date.now() + LEASE_MS),
+        lockedAt: new Date(),
+        attempts: sql`${embeddingJobs.attempts} + 1`,
+        updatedAt: new Date(),
+      })
+      .where(eq(embeddingJobs.id, rows[0].id as string))
+      .returning();
+    return { job, config, state };
+  });
+}
+export async function renewClaim(job: EmbeddingJob) {
+  const rows = await db
+    .update(embeddingJobs)
+    .set({ leaseExpiresAt: new Date(Date.now() + LEASE_MS), updatedAt: new Date() })
+    .where(
+      and(
+        eq(embeddingJobs.id, job.id),
+        eq(embeddingJobs.status, 'running'),
+        eq(embeddingJobs.leaseToken, job.leaseToken!),
+        sql`${embeddingJobs.leaseExpiresAt} > now()`,
+        sql`EXISTS (SELECT 1 FROM embedding_index_state eis WHERE eis.id = 1 AND eis."generationId" = ${job.generationId} AND eis.status IN ('ready', 'rebuilding'))`
+      )
+    )
+    .returning({ id: embeddingJobs.id });
+  if (!rows.length) throw new EmbeddingError('embedding_lease_lost', 409);
+}
+export async function failClaim(job: EmbeddingJob, error: unknown, maxRetries: number) {
+  const failure =
+    error instanceof EmbeddingError ? error : new EmbeddingError('embedding_job_failed', 503);
+  await db.transaction(async (tx) => {
+    const state = await lockIndexState(tx);
+    const [current] = await tx
+      .select()
+      .from(embeddingJobs)
+      .where(
+        and(
+          eq(embeddingJobs.id, job.id),
+          eq(embeddingJobs.leaseToken, job.leaseToken!),
+          eq(embeddingJobs.status, 'running')
+        )
+      )
+      .for('update');
+    if (!current || !current.leaseExpiresAt || current.leaseExpiresAt.getTime() <= Date.now())
+      return;
+    const [successor] = await tx
+      .select({ id: embeddingJobs.id })
+      .from(embeddingJobs)
+      .where(
+        and(
+          eq(embeddingJobs.generationId, job.generationId!),
+          eq(embeddingJobs.sourceType, job.sourceType),
+          eq(embeddingJobs.sourceId, job.sourceId),
+          eq(embeddingJobs.status, 'pending')
+        )
+      )
+      .limit(1);
+    const retry = failure.retryable && job.attempts < maxRetries;
+    const stale = state.generationId !== job.generationId;
+    await tx
+      .update(embeddingJobs)
+      .set({
+        status: stale || successor ? 'cancelled' : retry ? 'pending' : 'failed',
+        error: failure.code,
+        leaseToken: null,
+        leaseExpiresAt: null,
+        lockedAt: null,
+        nextAttemptAt: new Date(Date.now() + Math.min(60_000, 1000 * 2 ** job.attempts)),
+        updatedAt: new Date(),
+      })
+      .where(eq(embeddingJobs.id, job.id));
+    if (stale) return;
+    const contractFailure = isEmbeddingContractFailure(failure.code);
+    if (state.status === 'ready' && contractFailure) {
+      await tx
+        .update(embeddingIndexState)
+        .set({
+          status: 'needs_validation',
+          fingerprint: null,
+          errorCode: failure.code,
+          errorDetails: failure.details,
+          updatedAt: new Date(),
+        })
+        .where(eq(embeddingIndexState.id, 1));
+    } else if (state.status === 'rebuilding' && !retry && (!successor || contractFailure)) {
+      await tx
+        .update(embeddingIndexState)
+        .set({
+          status: 'failed',
+          errorCode: failure.code,
+          errorDetails: failure.details,
+          updatedAt: new Date(),
+        })
+        .where(eq(embeddingIndexState.id, 1));
+    }
+  });
+}

--- a/server/embeddings/jobProcessor.ts
+++ b/server/embeddings/jobProcessor.ts
@@ -22,23 +22,19 @@ import type { AiSourceType } from '../utils/dbMethods/ai/types';
 import { createEmbedding } from './client';
 import { canProcessIndex, lockIndexState, readAiSnapshot } from './configStore';
 import { renewClaim } from './jobClaims';
-import { deleteEmbeddingsForSource, queueSource } from './queue';
+import { queueSource } from './queue';
 
 export async function processEmbeddingJob(job: EmbeddingJob, config: AiConfig, dimensions: number) {
   const sourceType = job.sourceType as AiSourceType;
+  await renewClaim(job);
   const source = await getSourceDocument(sourceType, job.sourceId);
-  if (!source || !(await hasCapability(getSourceOwner(sourceType, source), 'ai.chat'))) {
-    await deleteEmbeddingsForSource(sourceType, job.sourceId);
-    return;
-  }
-  const ownerId = getSourceOwner(sourceType, source);
-  const document = buildSourceDocument(sourceType, source);
-  const sourceHash = hashText(JSON.stringify({ ownerId, document }));
-  const chunks = splitIntoChunks(
-    document.text,
-    config.indexing.chunkSize,
-    config.indexing.chunkOverlap
-  );
+  const ownerId = source ? getSourceOwner(sourceType, source) : job.ownerId;
+  const eligibleSource = source && (await hasCapability(ownerId, 'ai.chat'));
+  const document = eligibleSource ? buildSourceDocument(sourceType, source) : null;
+  const sourceHash = document ? hashText(JSON.stringify({ ownerId, document })) : null;
+  const chunks = document
+    ? splitIntoChunks(document.text, config.indexing.chunkSize, config.indexing.chunkOverlap)
+    : [];
   const vectors: NewDocumentEmbedding[] = [];
   for (const [chunkIndex, chunk] of chunks.entries()) {
     await renewClaim(job);
@@ -65,7 +61,7 @@ export async function processEmbeddingJob(job: EmbeddingJob, config: AiConfig, d
       embeddingDimensions: dimensions,
       embedding: JSON.stringify(result.embedding),
       text: chunk,
-      metadata: document.metadata,
+      metadata: document!.metadata,
     });
   }
   await db.transaction(async (tx) => {

--- a/server/embeddings/jobProcessor.ts
+++ b/server/embeddings/jobProcessor.ts
@@ -1,0 +1,142 @@
+import { and, eq, sql } from 'drizzle-orm';
+import {
+  articles,
+  documentEmbeddings,
+  embeddingJobs,
+  rotes,
+  type EmbeddingJob,
+  type NewDocumentEmbedding,
+} from '../drizzle/schema';
+import { hasCapability } from '../authz/capabilityService';
+import type { AiConfig } from '../types/config';
+import db from '../utils/drizzle';
+import {
+  buildSourceDocument,
+  getSourceDocument,
+  getSourceOwner,
+  hashText,
+  splitIntoChunks,
+} from '../utils/dbMethods/ai/documents';
+import { logAiTokenUsage } from '../utils/dbMethods/aiToken';
+import type { AiSourceType } from '../utils/dbMethods/ai/types';
+import { createEmbedding } from './client';
+import { canProcessIndex, lockIndexState, readAiSnapshot } from './configStore';
+import { renewClaim } from './jobClaims';
+import { deleteEmbeddingsForSource, queueSource } from './queue';
+
+export async function processEmbeddingJob(job: EmbeddingJob, config: AiConfig, dimensions: number) {
+  const sourceType = job.sourceType as AiSourceType;
+  const source = await getSourceDocument(sourceType, job.sourceId);
+  if (!source || !(await hasCapability(getSourceOwner(sourceType, source), 'ai.chat'))) {
+    await deleteEmbeddingsForSource(sourceType, job.sourceId);
+    return;
+  }
+  const ownerId = getSourceOwner(sourceType, source);
+  const document = buildSourceDocument(sourceType, source);
+  const sourceHash = hashText(JSON.stringify({ ownerId, document }));
+  const chunks = splitIntoChunks(
+    document.text,
+    config.indexing.chunkSize,
+    config.indexing.chunkOverlap
+  );
+  const vectors: NewDocumentEmbedding[] = [];
+  for (const [chunkIndex, chunk] of chunks.entries()) {
+    await renewClaim(job);
+    const result = await createEmbedding(config.embedding, chunk, {
+      expectedDimensions: dimensions,
+    });
+    if (result.usage)
+      await logAiTokenUsage({
+        userid: ownerId,
+        model: config.embedding.model,
+        type: 'embedding',
+        promptTokens: result.usage.prompt_tokens,
+        completionTokens: 0,
+        totalTokens: result.usage.total_tokens,
+      });
+    vectors.push({
+      generationId: job.generationId,
+      ownerId,
+      sourceType,
+      sourceId: job.sourceId,
+      chunkIndex,
+      contentHash: hashText(chunk),
+      embeddingModel: config.embedding.model,
+      embeddingDimensions: dimensions,
+      embedding: JSON.stringify(result.embedding),
+      text: chunk,
+      metadata: document.metadata,
+    });
+  }
+  await db.transaction(async (tx) => {
+    await lockIndexState(tx);
+    const snapshot = await readAiSnapshot(tx);
+    const [current] = await tx
+      .select()
+      .from(embeddingJobs)
+      .where(
+        and(
+          eq(embeddingJobs.id, job.id),
+          eq(embeddingJobs.status, 'running'),
+          eq(embeddingJobs.leaseToken, job.leaseToken!),
+          sql`${embeddingJobs.leaseExpiresAt} > now()`
+        )
+      )
+      .for('update');
+    if (!current) return;
+    if (
+      snapshot.state.generationId !== job.generationId ||
+      !canProcessIndex(snapshot.config, snapshot.state)
+    ) {
+      await tx
+        .update(embeddingJobs)
+        .set({ status: 'cancelled', leaseToken: null, leaseExpiresAt: null, lockedAt: null })
+        .where(eq(embeddingJobs.id, job.id));
+      return;
+    }
+    const table = sourceType === 'rote' ? rotes : articles;
+    const [liveSource] = await tx
+      .select()
+      .from(table)
+      .where(eq(table.id, job.sourceId))
+      .for('share');
+    const liveOwner = liveSource ? getSourceOwner(sourceType, liveSource) : null;
+    const eligible = liveOwner ? await hasCapability(liveOwner, 'ai.chat') : false;
+    const liveHash = liveSource
+      ? hashText(
+          JSON.stringify({
+            ownerId: liveOwner,
+            document: buildSourceDocument(sourceType, liveSource),
+          })
+        )
+      : null;
+    if (liveSource && eligible && liveHash !== sourceHash) {
+      await queueSource(tx, job.generationId!, sourceType, job.sourceId, liveOwner!);
+    } else {
+      await tx
+        .delete(documentEmbeddings)
+        .where(
+          and(
+            eq(documentEmbeddings.sourceType, sourceType),
+            eq(documentEmbeddings.sourceId, job.sourceId),
+            liveSource && eligible
+              ? eq(documentEmbeddings.generationId, job.generationId!)
+              : undefined
+          )
+        );
+      if (liveSource && eligible && vectors.length)
+        await tx.insert(documentEmbeddings).values(vectors);
+    }
+    await tx
+      .update(embeddingJobs)
+      .set({
+        status: liveHash === sourceHash && eligible ? 'succeeded' : 'cancelled',
+        error: null,
+        leaseToken: null,
+        leaseExpiresAt: null,
+        lockedAt: null,
+        updatedAt: new Date(),
+      })
+      .where(eq(embeddingJobs.id, job.id));
+  });
+}

--- a/server/embeddings/migration.test.ts
+++ b/server/embeddings/migration.test.ts
@@ -1,0 +1,66 @@
+import { expect, it } from 'bun:test';
+import { cpSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import postgres from 'postgres';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import { migrate } from 'drizzle-orm/postgres-js/migrator';
+
+it('migrates a legacy database without pgvector, retaining configuration and vectors', async () => {
+  const url = process.env.POSTGRESQL_URL;
+  if (!url || !new URL(url).pathname.endsWith('legacy_embedding_test'))
+    throw new Error('Use an empty legacy_embedding_test database');
+  const client = postgres(url, { max: 1 });
+  const folder = mkdtempSync(join(tmpdir(), 'rote-embedding-migrations-'));
+  try {
+    const [tables] =
+      await client`SELECT count(*)::int AS count FROM information_schema.tables WHERE table_schema = 'public'`;
+    if (tables.count !== 0) throw new Error('Legacy migration test requires an empty database');
+    const migrationFolder = join(import.meta.dir, '../drizzle/migrations');
+    cpSync(migrationFolder, folder, { recursive: true });
+    const journalPath = join(folder, 'meta/_journal.json');
+    const journal = JSON.parse(readFileSync(journalPath, 'utf8'));
+    journal.entries = journal.entries.filter((entry: { idx: number }) => entry.idx < 30);
+    writeFileSync(journalPath, JSON.stringify(journal));
+    await migrate(drizzle(client), { migrationsFolder: folder });
+    const ownerId = '13180000-0000-4000-8000-000000000011';
+    const sourceId = '13180000-0000-4000-8000-000000000012';
+    const oldConfig = {
+      enabled: true,
+      vectorEnabled: true,
+      embedding: {
+        providerId: 'siliconflow',
+        model: 'BAAI/bge-m3',
+        baseUrl: 'https://api.siliconflow.cn/v1',
+        apiKey: 'migration-placeholder',
+        dimensions: 1024,
+      },
+    };
+    await client`INSERT INTO users (id, email, username) VALUES (${ownerId}, 'legacy@example.test', 'legacy-embedding')`;
+    await client`INSERT INTO settings ("group", config) VALUES ('ai', ${JSON.stringify(oldConfig)}::jsonb)`;
+    const vector = JSON.stringify(Array(1024).fill(0.1));
+    await client`INSERT INTO document_embeddings ("ownerId", "sourceType", "sourceId", "chunkIndex", "contentHash", "embeddingModel", "embeddingDimensions", embedding, text)
+      VALUES (${ownerId}, 'rote', ${sourceId}, 0, 'old-hash', 'BAAI/bge-m3', 1024, ${vector}, 'legacy content')`;
+    await client`INSERT INTO embedding_jobs ("ownerId", "sourceType", "sourceId", status) VALUES (${ownerId}, 'rote', ${sourceId}, 'running')`;
+    await migrate(drizzle(client), { migrationsFolder: migrationFolder });
+    const [setting] = await client`SELECT config FROM settings WHERE "group" = 'ai'`;
+    expect(setting.config.schemaVersion).toBe(2);
+    expect(setting.config.embedding.output).toEqual({ mode: 'dimensions', dimensions: 1024 });
+    expect(setting.config.embedding.apiKey).toBe('migration-placeholder');
+    expect(setting.config.embedding.dimensions).toBeUndefined();
+    const [retained] = await client`SELECT * FROM document_embeddings`;
+    expect(retained.embedding).toBe(vector);
+    expect(retained.generationId).toBeNull();
+    const [job] = await client`SELECT status FROM embedding_jobs`;
+    expect(job.status).toBe('cancelled');
+    const [state] = await client`SELECT * FROM embedding_index_state`;
+    expect(state.status).toBe('needs_validation');
+    expect(state.dimensions).toBeNull();
+    expect(await client`SELECT 1 FROM pg_extension WHERE extname = 'vector'`).toHaveLength(0);
+    await migrate(drizzle(client), { migrationsFolder: migrationFolder });
+    expect(await client`SELECT * FROM document_embeddings`).toHaveLength(1);
+  } finally {
+    await client.end();
+    rmSync(folder, { recursive: true, force: true });
+  }
+}, 30_000);

--- a/server/embeddings/query.ts
+++ b/server/embeddings/query.ts
@@ -1,0 +1,47 @@
+import { and, eq } from 'drizzle-orm';
+import { embeddingIndexState } from '../drizzle/schema';
+import db from '../utils/drizzle';
+import type { AiConfig } from '../types/config';
+import { createEmbedding } from './client';
+import { EmbeddingError, isEmbeddingContractFailure } from './errors';
+import { requireReadyGeneration } from './queue';
+import { getPgvectorStatus } from '../utils/dbMethods/ai/vector';
+
+export async function createQueryEmbedding(
+  config: AiConfig,
+  generationId: string,
+  dimensions: number,
+  input: string
+) {
+  if (!(await getPgvectorStatus()).ready)
+    throw new EmbeddingError('embedding_rebuild_required', 503);
+  try {
+    const result = await createEmbedding(config.embedding, input, {
+      expectedDimensions: dimensions,
+    });
+    const current = await requireReadyGeneration();
+    if (current.state.generationId !== generationId)
+      throw new EmbeddingError('embedding_rebuild_required', 503);
+    return result;
+  } catch (error) {
+    if (error instanceof EmbeddingError && isEmbeddingContractFailure(error.code)) {
+      await db
+        .update(embeddingIndexState)
+        .set({
+          status: 'needs_validation',
+          fingerprint: null,
+          errorCode: error.code,
+          errorDetails: error.details,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(embeddingIndexState.id, 1),
+            eq(embeddingIndexState.generationId, generationId),
+            eq(embeddingIndexState.status, 'ready')
+          )
+        );
+    }
+    throw error;
+  }
+}

--- a/server/embeddings/queue.ts
+++ b/server/embeddings/queue.ts
@@ -1,0 +1,133 @@
+import { and, eq, inArray, sql } from 'drizzle-orm';
+import { documentEmbeddings, embeddingJobs } from '../drizzle/schema';
+import db from '../utils/drizzle';
+import { hasCapability } from '../authz/capabilityService';
+import {
+  canProcessIndex,
+  type IndexState,
+  lockIndexState,
+  readAiSnapshot,
+  type EmbeddingTransaction,
+} from './configStore';
+import type { AiConfig } from '../types/config';
+import { EmbeddingError } from './errors';
+import type {
+  AiSourceType,
+  EmbeddingJobAction,
+  EmbeddingJobStatus,
+} from '../utils/dbMethods/ai/types';
+
+export function canQueueIndex(config: AiConfig, state: IndexState) {
+  return (
+    ((config.enabled && config.vectorEnabled) ||
+      state.status === 'rebuilding' ||
+      state.status === 'failed') &&
+    state.generationId !== null &&
+    state.dimensions !== null &&
+    ['ready', 'rebuilding', 'failed'].includes(state.status)
+  );
+}
+export async function queueSource(
+  tx: EmbeddingTransaction,
+  generationId: string,
+  sourceType: AiSourceType,
+  sourceId: string,
+  ownerId: string
+) {
+  await tx
+    .update(embeddingJobs)
+    .set({ status: 'cancelled', updatedAt: new Date() })
+    .where(
+      and(
+        eq(embeddingJobs.generationId, generationId),
+        eq(embeddingJobs.sourceType, sourceType),
+        eq(embeddingJobs.sourceId, sourceId),
+        eq(embeddingJobs.status, 'failed')
+      )
+    );
+  // A pending successor is retained while a previous revision is running.
+  await tx
+    .insert(embeddingJobs)
+    .values({ generationId, sourceType, sourceId, ownerId, action: 'upsert', status: 'pending' })
+    .onConflictDoNothing();
+}
+export async function enqueueEmbeddingJob(
+  sourceType: AiSourceType,
+  sourceId: string,
+  ownerId: string,
+  action: EmbeddingJobAction = 'upsert',
+  force = false
+) {
+  if (!['rote', 'article'].includes(sourceType)) return;
+  if (action === 'delete' || !(await hasCapability(ownerId, 'ai.chat'))) {
+    await deleteEmbeddingsForSource(sourceType, sourceId);
+    return;
+  }
+  await db.transaction(async (tx) => {
+    await lockIndexState(tx);
+    const { config, state } = await readAiSnapshot(tx);
+    if (!canQueueIndex(config, state)) return;
+    if (!force && !config.autoIndexEnabled && state.status === 'ready') return;
+    await queueSource(tx, state.generationId!, sourceType, sourceId, ownerId);
+  });
+}
+export async function enqueueEmbeddingJobs(
+  sourceType: AiSourceType,
+  sourceIds: string[],
+  ownerId: string
+) {
+  for (const id of new Set(sourceIds)) await enqueueEmbeddingJob(sourceType, id, ownerId);
+}
+export async function deleteEmbeddingsForSource(sourceType: AiSourceType, sourceId: string) {
+  await db.transaction(async (tx) => {
+    await lockIndexState(tx);
+    await tx
+      .delete(documentEmbeddings)
+      .where(
+        and(
+          eq(documentEmbeddings.sourceType, sourceType),
+          eq(documentEmbeddings.sourceId, sourceId)
+        )
+      );
+    await tx
+      .update(embeddingJobs)
+      .set({ status: 'cancelled', leaseToken: null, leaseExpiresAt: null, lockedAt: null })
+      .where(
+        and(
+          eq(embeddingJobs.sourceType, sourceType),
+          eq(embeddingJobs.sourceId, sourceId),
+          inArray(embeddingJobs.status, ['pending', 'running', 'failed'])
+        )
+      );
+  });
+}
+export async function deleteEmbeddingsForOwner(ownerId: string) {
+  await db.transaction(async (tx) => {
+    await lockIndexState(tx);
+    await tx.delete(documentEmbeddings).where(eq(documentEmbeddings.ownerId, ownerId));
+    await tx.delete(embeddingJobs).where(eq(embeddingJobs.ownerId, ownerId));
+  });
+}
+export async function getEmbeddingJobStats(): Promise<Record<EmbeddingJobStatus, number>> {
+  const { state } = await readAiSnapshot();
+  const rows = await db.execute(
+    sql`SELECT status, COUNT(*)::int AS count FROM "embedding_jobs" WHERE "generationId" = ${state.generationId} GROUP BY status`
+  );
+  const stats: Record<EmbeddingJobStatus, number> = {
+    pending: 0,
+    running: 0,
+    succeeded: 0,
+    failed: 0,
+    cancelled: 0,
+  };
+  for (const row of rows)
+    if ((row.status as string) in stats)
+      stats[row.status as EmbeddingJobStatus] = Number(row.count);
+  return stats;
+}
+export async function requireReadyGeneration() {
+  const snapshot = await readAiSnapshot();
+  if (!canProcessIndex(snapshot.config, snapshot.state) || snapshot.state.status !== 'ready')
+    throw new EmbeddingError('embedding_rebuild_required', 503);
+  return snapshot;
+}

--- a/server/embeddings/rebuildScanner.ts
+++ b/server/embeddings/rebuildScanner.ts
@@ -1,0 +1,42 @@
+import { asc, eq, gt } from 'drizzle-orm';
+import { articles, embeddingIndexState, rotes } from '../drizzle/schema';
+import { hasCapability } from '../authz/capabilityService';
+import db from '../utils/drizzle';
+import { canProcessIndex, lockIndexState, readAiSnapshot } from './configStore';
+import { queueSource } from './queue';
+
+export async function scanRebuildPage(pageSize = 100) {
+  return db.transaction(async (tx) => {
+    await lockIndexState(tx);
+    const { config, state } = await readAiSnapshot(tx);
+    if (
+      !canProcessIndex(config, state) ||
+      state.status !== 'rebuilding' ||
+      state.scanComplete ||
+      config.indexing.paused
+    )
+      return;
+    const table = state.scanSource === 'rote' ? rotes : articles;
+    const owner = state.scanSource === 'rote' ? rotes.authorid : articles.authorId;
+    const rows = await tx
+      .select({ id: table.id, ownerId: owner })
+      .from(table)
+      .where(state.scanCursor ? gt(table.id, state.scanCursor) : undefined)
+      .orderBy(asc(table.id))
+      .limit(pageSize);
+    for (const row of rows) {
+      if (await hasCapability(row.ownerId, 'ai.chat'))
+        await queueSource(tx, state.generationId!, state.scanSource, row.id, row.ownerId);
+    }
+    const complete = rows.length < pageSize;
+    await tx
+      .update(embeddingIndexState)
+      .set({
+        scanSource: complete && state.scanSource === 'rote' ? 'article' : state.scanSource,
+        scanCursor: complete ? null : rows[rows.length - 1].id,
+        scanComplete: complete && state.scanSource === 'article',
+        updatedAt: new Date(),
+      })
+      .where(eq(embeddingIndexState.id, 1));
+  });
+}

--- a/server/embeddings/sourceEvents.ts
+++ b/server/embeddings/sourceEvents.ts
@@ -1,0 +1,76 @@
+import { and, asc, eq, inArray } from 'drizzle-orm';
+import { hasCapability } from '../authz/capabilityService';
+import {
+  articles,
+  rotes,
+  documentEmbeddings,
+  embeddingJobs,
+  embeddingSourceEvents,
+} from '../drizzle/schema';
+import db from '../utils/drizzle';
+import { lockIndexState, readAiSnapshot } from './configStore';
+import { canQueueIndex, queueSource } from './queue';
+
+// Source mutations insert these events in their own transaction. Consumption
+// locks only the outbox and queue; source rows are read later by the processor.
+export async function consumeSourceEvents(pageSize = 100) {
+  await db.transaction(async (tx) => {
+    await lockIndexState(tx);
+    const { config, state } = await readAiSnapshot(tx);
+    const events = await tx
+      .select()
+      .from(embeddingSourceEvents)
+      .orderBy(asc(embeddingSourceEvents.createdAt), asc(embeddingSourceEvents.id))
+      .limit(pageSize)
+      .for('update', { skipLocked: true });
+    for (const event of events) {
+      const table = event.sourceType === 'rote' ? rotes : articles;
+      const owner = event.sourceType === 'rote' ? rotes.authorid : articles.authorId;
+      const [source] = await tx
+        .select({ ownerId: owner })
+        .from(table)
+        .where(eq(table.id, event.sourceId));
+      if (!source || !(await hasCapability(source.ownerId, 'ai.chat'))) {
+        await tx
+          .delete(documentEmbeddings)
+          .where(
+            and(
+              eq(documentEmbeddings.sourceType, event.sourceType),
+              eq(documentEmbeddings.sourceId, event.sourceId)
+            )
+          );
+        await tx
+          .update(embeddingJobs)
+          .set({ status: 'cancelled', leaseToken: null, leaseExpiresAt: null, lockedAt: null })
+          .where(
+            and(
+              eq(embeddingJobs.sourceType, event.sourceType),
+              eq(embeddingJobs.sourceId, event.sourceId),
+              inArray(embeddingJobs.status, ['pending', 'running', 'failed'])
+            )
+          );
+      } else if (
+        canQueueIndex(config, state) &&
+        (config.autoIndexEnabled ||
+          state.status !== 'ready' ||
+          event.rebuilding ||
+          event.generationId !== state.generationId)
+      ) {
+        await queueSource(
+          tx,
+          state.generationId!,
+          event.sourceType,
+          event.sourceId,
+          source.ownerId
+        );
+      }
+    }
+    if (events.length)
+      await tx.delete(embeddingSourceEvents).where(
+        inArray(
+          embeddingSourceEvents.id,
+          events.map((event) => event.id)
+        )
+      );
+  });
+}

--- a/server/imports/importService.ts
+++ b/server/imports/importService.ts
@@ -12,9 +12,7 @@ import {
   type NewRote,
 } from '../drizzle/schema';
 import db from '../utils/drizzle';
-import { trackBackgroundTask } from '../utils/backgroundTask';
 import { releaseStorageObjectReferences } from '../resources/service';
-import { enqueueEmbeddingJobs } from '../utils/dbMethods/ai';
 import { DatabaseError } from '../utils/dbMethods/common';
 import { validateRoteAttachmentDetails } from '../utils/fileValidation';
 import { r2deletehandler } from '../utils/r2';
@@ -60,7 +58,6 @@ export async function importUserData(userId: string, rawData: unknown): Promise<
     updated: 0,
     deleted: 0,
   };
-  const changedNoteIds: string[] = [];
 
   try {
     for (let offset = 0; offset < payload.notes.length; offset += IMPORT_CHUNK_SIZE) {
@@ -142,7 +139,6 @@ export async function importUserData(userId: string, rawData: unknown): Promise<
           const noteData = buildNoteData(note, targetId, userId, ownedArticleIds, payload);
           noteRows.push(noteData);
           changes.push({ id: targetId, action: existing ? 'UPDATE' : 'CREATE' });
-          changedNoteIds.push(targetId);
           if (existing) counts.updated += 1;
           else counts.created += 1;
 
@@ -341,11 +337,6 @@ export async function importUserData(userId: string, rawData: unknown): Promise<
           });
         });
     }
-
-    trackBackgroundTask(
-      enqueueEmbeddingJobs('rote', changedNoteIds, userId),
-      'import_embedding_enqueue_failed'
-    );
 
     return {
       count: payload.notes.length,

--- a/server/notes/actions.ts
+++ b/server/notes/actions.ts
@@ -8,12 +8,7 @@ import {
 } from '../resources/service';
 import { notifyPublicNoteCreated } from '../utils/adminHooks';
 import { trackBackgroundTask } from '../utils/backgroundTask';
-import {
-  deleteEmbeddingsForSource,
-  deleteRoteLinkPreviewsByRoteId,
-  enqueueEmbeddingJob,
-  findRoteById,
-} from '../utils/dbMethods';
+import { deleteRoteLinkPreviewsByRoteId, findRoteById } from '../utils/dbMethods';
 import db from '../utils/drizzle';
 import { validateRoteAttachmentDetails } from '../utils/fileValidation';
 import { parseAndStoreRoteLinkPreviews } from '../utils/linkPreview';
@@ -73,10 +68,6 @@ async function assertOwnedArticle(
 }
 
 function scheduleCreatedEffects(note: Rote) {
-  trackBackgroundTask(
-    enqueueEmbeddingJob('rote', note.id, note.authorid),
-    'rote_embedding_enqueue_failed'
-  );
   if (!note.articleId) {
     trackBackgroundTask(
       parseAndStoreRoteLinkPreviews(note.id, note.content),
@@ -89,10 +80,6 @@ function scheduleCreatedEffects(note: Rote) {
 }
 
 function scheduleUpdatedEffects(note: Rote, previousState: string, refreshLinkPreviews: boolean) {
-  trackBackgroundTask(
-    enqueueEmbeddingJob('rote', note.id, note.authorid),
-    'rote_embedding_enqueue_failed'
-  );
   if (refreshLinkPreviews) {
     trackBackgroundTask(
       (async () => {
@@ -274,6 +261,5 @@ export async function deleteUserNote(userId: string, id: string) {
     return removed;
   });
 
-  trackBackgroundTask(deleteEmbeddingsForSource('rote', id), 'rote_embedding_delete_failed');
   return deleted;
 }

--- a/server/route/v2/admin.ts
+++ b/server/route/v2/admin.ts
@@ -1,3 +1,5 @@
+import { saveAiSettings, getStoredAiConfig } from '../../embeddings/configStore';
+import { EmbeddingError } from '../../embeddings/errors';
 import { Hono } from 'hono';
 import {
   authenticateJWT,
@@ -15,7 +17,7 @@ import {
   refreshConfigCache,
   setConfig,
 } from '../../utils/config';
-import { resolveIncomingAiConfig, sanitizeAiConfig } from '../../utils/ai/providers';
+import { sanitizeAiConfig } from '../../utils/ai/providers';
 import {
   buildUserRegisteredEnvelope,
   findAdminHookChannel,
@@ -96,7 +98,7 @@ adminRouter.get('/settings', authenticateJWT, requireAdmin, async (c: HonoContex
 
     if (group) {
       // 获取指定分组的配置
-      const config = await getConfig(group as any);
+      const config = group === 'ai' ? await getStoredAiConfig() : await getConfig(group as any);
       if (!config) {
         return c.json(createResponse(null, 'Configuration group not found'), 404);
       }
@@ -111,6 +113,7 @@ adminRouter.get('/settings', authenticateJWT, requireAdmin, async (c: HonoContex
     } else {
       // 获取所有配置
       const allConfigs = await getAllConfigs();
+      allConfigs.ai = await getStoredAiConfig();
       return c.json(createResponse(sanitizeSettingsForAdmin(allConfigs)), 200);
     }
   } catch (error: any) {
@@ -253,16 +256,8 @@ adminRouter.put('/settings', authenticateJWT, requireAdmin, async (c: HonoContex
     }
 
     if (group === 'ai') {
-      const existing = await getConfig<AiConfig>('ai');
-      config = resolveIncomingAiConfig(config as Partial<AiConfig>, existing);
-      if (
-        config.embedding?.dimensions !== undefined &&
-        (typeof config.embedding.dimensions !== 'number' ||
-          config.embedding.dimensions < 1 ||
-          config.embedding.dimensions > 4000)
-      ) {
-        return c.json(createResponse(null, 'Embedding dimensions must be between 1 and 4000'), 400);
-      }
+      const saved = await saveAiSettings(config);
+      return c.json(createResponse({ group, config: sanitizeAiConfig(saved) }), 200);
     }
 
     if (group === 'notification') {
@@ -295,6 +290,7 @@ adminRouter.put('/settings', authenticateJWT, requireAdmin, async (c: HonoContex
       200
     );
   } catch (error: any) {
+    if (error instanceof EmbeddingError) throw error;
     console.error('Failed to update settings:', error);
     return c.json(createResponse(null, 'Failed to update settings'), 500);
   }

--- a/server/route/v2/ai.ts
+++ b/server/route/v2/ai.ts
@@ -150,7 +150,7 @@ aiRouter.post('/site/test', authenticateJWT, async (c: HonoContext) => {
     config.enabled === true &&
     Boolean(config.chat?.baseUrl?.trim()) &&
     Boolean(config.chat?.model?.trim());
-  const vectorAvailable = config.vectorEnabled === true && vectorStatus.installed === true;
+  const vectorAvailable = config.vectorEnabled === true && vectorStatus.ready === true;
 
   const accessError = getAiAccessErrorFromAccess(access);
   if (accessError) {

--- a/server/route/v2/aiAdmin.ts
+++ b/server/route/v2/aiAdmin.ts
@@ -1,3 +1,6 @@
+import { parseIncomingAiConfig } from '../../embeddings/configStore';
+import { startIndexRebuild } from '../../embeddings/indexLifecycle';
+import { DEFAULT_AI_CONFIG } from '../../utils/ai/providers';
 import type { Hono } from 'hono';
 import { authenticateJWT, requireAdmin } from '../../middleware/jwtAuth';
 import type { HonoContext, HonoVariables } from '../../types/hono';
@@ -17,6 +20,10 @@ import {
 import { bodyTypeCheck, createResponse } from '../../utils/main';
 
 export function registerAdminAiRoutes(router: Hono<{ Variables: HonoVariables }>) {
+  router.get('/defaults', authenticateJWT, requireAdmin, (c: HonoContext) =>
+    c.json(createResponse(DEFAULT_AI_CONFIG), 200)
+  );
+
   router.get('/providers', authenticateJWT, requireAdmin, (c: HonoContext) =>
     c.json(createResponse(AI_PROVIDER_PRESETS), 200)
   );
@@ -25,7 +32,11 @@ export function registerAdminAiRoutes(router: Hono<{ Variables: HonoVariables }>
     const body = await c.req.json();
     const target = body?.target as 'chat' | 'embedding';
     const storedConfig = await getStoredAiConfig();
-    const config = body?.config ? resolveIncomingAiConfig(body.config, storedConfig) : storedConfig;
+    const config = body?.config
+      ? target === 'embedding'
+        ? parseIncomingAiConfig(body.config, storedConfig)
+        : resolveIncomingAiConfig(body.config, storedConfig)
+      : storedConfig;
 
     if (target === 'chat') {
       await testChatProvider(config.chat);
@@ -33,10 +44,10 @@ export function registerAdminAiRoutes(router: Hono<{ Variables: HonoVariables }>
     }
 
     if (target === 'embedding') {
-      const result = await testEmbeddingProvider(config.embedding, config.embedding.dimensions);
+      const result = await testEmbeddingProvider(config.embedding);
       return c.json(
         createResponse(
-          { success: true, dimensions: result.dimensions },
+          { success: true, ...result, database: await getPgvectorStatus() },
           'Embedding provider test successful'
         ),
         200
@@ -60,6 +71,17 @@ export function registerAdminAiRoutes(router: Hono<{ Variables: HonoVariables }>
     const stats = await getEmbeddingJobStats();
     return c.json(createResponse(stats), 200);
   });
+
+  router.post(
+    '/index/rebuild',
+    authenticateJWT,
+    requireAdmin,
+    bodyTypeCheck,
+    async (c: HonoContext) => {
+      const { revision } = await c.req.json();
+      return c.json(createResponse(await startIndexRebuild(revision)), 202);
+    }
+  );
 
   router.post('/index/backfill', authenticateJWT, requireAdmin, async (c: HonoContext) => {
     const result = await enqueueBackfillEmbeddingJobs();

--- a/server/route/v2/openKey/articles.ts
+++ b/server/route/v2/openKey/articles.ts
@@ -1,10 +1,8 @@
 import { Hono } from 'hono';
 import type { HonoContext, HonoVariables } from '../../../types/hono';
-import { trackBackgroundTask } from '../../../utils/backgroundTask';
 import {
   createArticle,
   deleteArticle,
-  deleteEmbeddingsForSource,
   findArticleById,
   findRoteById,
   getNoteArticleCard,
@@ -82,7 +80,6 @@ router.delete('/articles/:id', requireOpenKeyPerm('EDITARTICLE'), async (c: Hono
   const id = assertUuid(c.req.param('id'), 'Invalid or missing ID');
   const article = await deleteArticle({ id, authorId: openKey.userid });
   if (!article) throw new Error('Article not found or permission denied');
-  trackBackgroundTask(deleteEmbeddingsForSource('article', id), 'article_embedding_delete_failed');
   return c.json(createResponse(article), 200);
 });
 

--- a/server/route/v2/site.ts
+++ b/server/route/v2/site.ts
@@ -42,9 +42,7 @@ async function getPublicAiStatus() {
       Boolean(aiConfig.chat?.baseUrl?.trim()) &&
       Boolean(aiConfig.chat?.model?.trim());
     const memoryAvailable =
-      aiConfig.enabled === true &&
-      aiConfig.vectorEnabled === true &&
-      vectorStatus.installed === true;
+      aiConfig.enabled === true && aiConfig.vectorEnabled === true && vectorStatus.ready === true;
 
     return {
       enabled: aiConfig.enabled === true,

--- a/server/tests/aiAccess.test.ts
+++ b/server/tests/aiAccess.test.ts
@@ -17,7 +17,7 @@ const readyConfig: AiConfig = {
     providerId: 'test',
     baseUrl: 'http://test',
     model: 'test-embedding',
-    dimensions: 3,
+    output: { mode: 'dimensions', output: { mode: 'dimensions', dimensions: 3 } },
   },
   indexing: { chunkSize: 800, chunkOverlap: 100, batchSize: 10, maxRetries: 1 },
 };
@@ -27,6 +27,7 @@ const vectorReady = {
   installed: true,
   version: '0.8.0',
   indexName: 'document_embeddings_embedding_hnsw_3_idx',
+  ready: true,
   dimensions: 3,
 };
 

--- a/server/tests/aiAgentRuntime.test.ts
+++ b/server/tests/aiAgentRuntime.test.ts
@@ -5,6 +5,8 @@ import type { RoteAgentStreamEvent } from '../utils/ai/agent/types';
 const originalFetch = globalThis.fetch;
 
 const config: AiConfig = {
+  schemaVersion: 2,
+  revision: 0,
   enabled: true,
   vectorEnabled: true,
   autoIndexEnabled: true,
@@ -14,7 +16,7 @@ const config: AiConfig = {
     providerId: 'test',
     baseUrl: 'http://test',
     model: 'test-embedding',
-    dimensions: 3,
+    output: { mode: 'dimensions', output: { mode: 'dimensions', dimensions: 3 } },
   },
   indexing: { chunkSize: 800, chunkOverlap: 100, batchSize: 10, maxRetries: 1 },
 };

--- a/server/tests/aiClientRuntime.test.ts
+++ b/server/tests/aiClientRuntime.test.ts
@@ -3,6 +3,8 @@ import type { AiConfig } from '../types/config';
 import { executeClientRoteTool } from '../utils/ai/agent/clientRuntime';
 
 const config: AiConfig = {
+  schemaVersion: 2,
+  revision: 0,
   enabled: true,
   vectorEnabled: true,
   autoIndexEnabled: false,
@@ -12,7 +14,7 @@ const config: AiConfig = {
     providerId: 'test',
     baseUrl: 'http://test',
     model: 'test',
-    dimensions: 3,
+    output: { mode: 'dimensions', output: { mode: 'dimensions', dimensions: 3 } },
   },
   indexing: { chunkSize: 800, chunkOverlap: 100, batchSize: 1, maxRetries: 1 },
 };

--- a/server/tests/aiRetrievalPlanner.test.ts
+++ b/server/tests/aiRetrievalPlanner.test.ts
@@ -14,12 +14,19 @@ import type { ChatMessage, ChatToolCall, ChatToolDefinition } from '../utils/ai/
 const AVAILABLE_TAGS = ['工作', '生活', '开心'];
 
 const config: AiConfig = {
+  schemaVersion: 2,
+  revision: 0,
   enabled: true,
   vectorEnabled: true,
   autoIndexEnabled: true,
   publicExploreVectorEnabled: false,
   chat: { providerId: 'test', baseUrl: 'http://test', model: 'test-chat' },
-  embedding: { providerId: 'test', baseUrl: 'http://test', model: 'test-embedding', dimensions: 3 },
+  embedding: {
+    providerId: 'test',
+    baseUrl: 'http://test',
+    model: 'test-embedding',
+    output: { mode: 'dimensions', dimensions: 3 },
+  },
   indexing: { chunkSize: 800, chunkOverlap: 100, batchSize: 10, maxRetries: 1 },
 };
 

--- a/server/types/config.ts
+++ b/server/types/config.ts
@@ -140,15 +140,21 @@ export interface AiIndexingConfig {
   paused?: boolean;
 }
 
+export type EmbeddingOutput = { mode: 'native' } | { mode: 'dimensions'; dimensions: number };
+
+export interface EmbeddingProviderConfig extends AiProviderConfig {
+  output: EmbeddingOutput;
+}
+
 export interface AiConfig {
+  schemaVersion: 2;
+  revision: number;
   enabled: boolean;
   vectorEnabled: boolean;
   autoIndexEnabled: boolean;
   publicExploreVectorEnabled: boolean;
   chat: AiProviderConfig;
-  embedding: AiProviderConfig & {
-    dimensions: number;
-  };
+  embedding: EmbeddingProviderConfig;
   indexing: AiIndexingConfig;
 }
 

--- a/server/utils/ai/client.ts
+++ b/server/utils/ai/client.ts
@@ -38,41 +38,7 @@ export {
   type AiProviderStreamErrorCode,
 } from './clientStreamControl';
 
-export async function createEmbedding(
-  config: AiProviderConfig & { dimensions?: number },
-  input: string
-): Promise<{
-  embedding: number[];
-  usage?: { prompt_tokens: number; total_tokens: number };
-}> {
-  ensureProviderConfig(config);
-
-  const payload: any = {
-    model: config.model,
-    input: input.replace(/\s+/g, ' ').trim(),
-  };
-
-  if (config.dimensions && config.dimensions > 0) {
-    payload.dimensions = config.dimensions;
-  }
-
-  const response = await fetch(`${normalizeBaseUrl(config.baseUrl)}/embeddings`, {
-    method: 'POST',
-    headers: buildHeaders(config),
-    body: JSON.stringify(payload),
-  });
-  const body = await readJsonResponse(response);
-  const embedding = body?.data?.[0]?.embedding;
-
-  if (!Array.isArray(embedding) || embedding.some((value) => typeof value !== 'number')) {
-    throw new Error('Embedding provider returned an invalid embedding response');
-  }
-
-  return {
-    embedding,
-    usage: normalizeUsage(body?.usage),
-  };
-}
+export { createEmbedding, testEmbeddingProvider } from '../../embeddings/client';
 
 export async function createChatCompletion(
   config: AiProviderConfig,
@@ -255,19 +221,6 @@ export async function probeChatProviderToolCalling(
       error: error?.message || String(error),
     };
   }
-}
-
-export async function testEmbeddingProvider(
-  config: AiProviderConfig,
-  expectedDimensions?: number
-): Promise<{ dimensions: number }> {
-  const { embedding } = await createEmbedding(config, 'Rote embedding connectivity test.');
-  if (expectedDimensions && embedding.length !== expectedDimensions) {
-    throw new Error(
-      `Embedding dimensions mismatch: expected ${expectedDimensions}, got ${embedding.length}`
-    );
-  }
-  return { dimensions: embedding.length };
 }
 
 export function vectorToLiteral(vector: number[]): string {

--- a/server/utils/ai/providers.ts
+++ b/server/utils/ai/providers.ts
@@ -139,6 +139,8 @@ export const AI_PROVIDER_PRESETS: AiProviderPreset[] = [
 ];
 
 export const DEFAULT_AI_CONFIG: AiConfig = {
+  schemaVersion: 2,
+  revision: 0,
   enabled: false,
   vectorEnabled: false,
   autoIndexEnabled: false,
@@ -155,7 +157,7 @@ export const DEFAULT_AI_CONFIG: AiConfig = {
     apiFormat: 'openai_compatible',
     baseUrl: 'https://api.openai.com/v1',
     model: 'text-embedding-3-small',
-    dimensions: 1536,
+    output: { mode: 'native' },
     apiKey: '',
   },
   indexing: {

--- a/server/utils/dbMethods/ai.ts
+++ b/server/utils/dbMethods/ai.ts
@@ -12,12 +12,7 @@ export type {
   SearchRotesArgs,
   SemanticSearchResult,
 } from './ai/types';
-export {
-  getOwnerAiMemoryStats,
-  getStoredAiConfig,
-  isAiEligibleUser,
-  updateStoredAiConfig,
-} from './ai/config';
+export { getOwnerAiMemoryStats, getStoredAiConfig, isAiEligibleUser } from './ai/config';
 export {
   clearAllEmbeddings,
   deleteEmbeddingsForOwner,

--- a/server/utils/dbMethods/ai/config.ts
+++ b/server/utils/dbMethods/ai/config.ts
@@ -3,25 +3,16 @@ import { rotes } from '../../../drizzle/schema';
 import { hasCapability } from '../../../authz/capabilityService';
 import type { AiConfig } from '../../../types/config';
 import { DEFAULT_AI_CONFIG, mergeAiConfig } from '../../ai/providers';
-import { getConfig, getGlobalConfig, setConfig } from '../../config';
+import { getGlobalConfig } from '../../config';
 import db from '../../drizzle';
 import { DatabaseError } from '../common';
+import { readAiSnapshot } from '../../../embeddings/configStore';
 
 export function getRuntimeAiConfig(): AiConfig {
   return mergeAiConfig(getGlobalConfig<AiConfig>('ai') || DEFAULT_AI_CONFIG);
 }
 
-export async function getStoredAiConfig(): Promise<AiConfig> {
-  return mergeAiConfig(await getConfig<AiConfig>('ai'));
-}
-
-export async function updateStoredAiConfig(config: AiConfig): Promise<boolean> {
-  return setConfig('ai', mergeAiConfig(config), {
-    isRequired: false,
-    isSystem: false,
-    isInitialized: true,
-  });
-}
+export { getStoredAiConfig } from '../../../embeddings/configStore';
 
 export function isVectorUsable(config = getRuntimeAiConfig()): boolean {
   return config.enabled === true && config.vectorEnabled === true;
@@ -40,6 +31,7 @@ export async function getOwnerAiMemoryStats(ownerId: string): Promise<{
   indexedRoteCount: number;
 }> {
   try {
+    const { state } = await readAiSnapshot();
     const [[roteCountResult], indexedRoteRows] = await Promise.all([
       db.select({ count: count() }).from(rotes).where(eq(rotes.authorid, ownerId)),
       db.execute(sql`
@@ -47,6 +39,7 @@ export async function getOwnerAiMemoryStats(ownerId: string): Promise<{
         FROM "document_embeddings" de
         INNER JOIN "rotes" r ON r."id" = de."sourceId"
         WHERE de."ownerId" = ${ownerId}
+          AND de."generationId" = ${state.generationId}
           AND de."sourceType" = 'rote'
           AND r."authorid" = ${ownerId}
       `) as Promise<Array<{ count: number }>>,

--- a/server/utils/dbMethods/ai/documents.ts
+++ b/server/utils/dbMethods/ai/documents.ts
@@ -5,6 +5,7 @@ import type { AiConfig } from '../../../types/config';
 import { DEFAULT_AI_CONFIG } from '../../ai/providers';
 import { normalizeTimeRangeInput, type NormalizedTimeRange } from '../../ai/retrievalPlan';
 import db from '../../drizzle';
+import { readAiSnapshot } from '../../../embeddings/configStore';
 import type { AiSourceType, SemanticSearchResult } from './types';
 
 export const VALID_SOURCE_TYPES = new Set<AiSourceType>(['rote', 'article']);
@@ -16,8 +17,8 @@ export function hashText(value: string): string {
 
 export function normalizeEmbeddingDimensions(value: number): number {
   const dimensions = Number(value);
-  if (!Number.isInteger(dimensions) || dimensions <= 0 || dimensions > 4000) {
-    throw new Error('Embedding dimensions must be an integer between 1 and 4000');
+  if (!Number.isInteger(dimensions) || dimensions <= 0 || dimensions > 2000) {
+    throw new Error('Embedding dimensions must be an integer between 1 and 2000');
   }
   return dimensions;
 }
@@ -44,8 +45,8 @@ export function buildTextArraySql(values: string[]) {
   )}]::text[]`;
 }
 
-export function vectorIndexName(dimensions: number): string {
-  return `document_embeddings_embedding_hnsw_${dimensions}_idx`;
+export function vectorIndexName(dimensions: number, generationId: string): string {
+  return `embedding_${generationId.replace(/-/g, '')}_${dimensions}_idx`;
 }
 
 export function fallbackAnswer(sources: SemanticSearchResult[]): string {
@@ -138,7 +139,9 @@ export async function sourceNeedsEmbeddingBackfill(
     config.indexing.chunkSize,
     config.indexing.chunkOverlap
   );
-  const expectedDimensions = normalizeEmbeddingDimensions(config.embedding.dimensions);
+  const { state } = await readAiSnapshot();
+  const expectedDimensions = state.dimensions;
+  if (!state.generationId || !expectedDimensions) return true;
   const sourceId = source.id;
   const rows = await db
     .select({
@@ -149,7 +152,11 @@ export async function sourceNeedsEmbeddingBackfill(
     })
     .from(documentEmbeddings)
     .where(
-      and(eq(documentEmbeddings.sourceType, sourceType), eq(documentEmbeddings.sourceId, sourceId))
+      and(
+        eq(documentEmbeddings.sourceType, sourceType),
+        eq(documentEmbeddings.sourceId, sourceId),
+        eq(documentEmbeddings.generationId, state.generationId)
+      )
     );
 
   if (chunks.length === 0) {

--- a/server/utils/dbMethods/ai/embeddingQueue.ts
+++ b/server/utils/dbMethods/ai/embeddingQueue.ts
@@ -1,152 +1,22 @@
-import { and, eq, inArray, sql } from 'drizzle-orm';
-import { articles, documentEmbeddings, embeddingJobs, rotes } from '../../../drizzle/schema';
+import { canProcessIndex, readAiSnapshot } from '../../../embeddings/configStore';
+import { articles, rotes } from '../../../drizzle/schema';
+import { eq } from 'drizzle-orm';
 import db from '../../drizzle';
 import { DatabaseError } from '../common';
 import { getStoredAiConfig, isAiEligibleUser, isVectorUsable, shouldAutoIndex } from './config';
-import { getSourceDocument, sourceNeedsEmbeddingBackfill, VALID_SOURCE_TYPES } from './documents';
-import type { AiSourceType, EmbeddingJobAction, EmbeddingJobStatus } from './types';
-
-export async function enqueueEmbeddingJob(
-  sourceType: AiSourceType,
-  sourceId: string,
-  ownerId: string,
-  action: EmbeddingJobAction = 'upsert',
-  force = false
-): Promise<void> {
-  try {
-    if (!VALID_SOURCE_TYPES.has(sourceType)) return;
-
-    if (action !== 'delete' && !(await isAiEligibleUser(ownerId))) {
-      await deleteEmbeddingsForSource(sourceType, sourceId);
-      return;
-    }
-
-    if (!force && action !== 'delete' && !shouldAutoIndex()) {
-      return;
-    }
-
-    const [existing] = await db
-      .select({ id: embeddingJobs.id })
-      .from(embeddingJobs)
-      .where(
-        and(
-          eq(embeddingJobs.sourceType, sourceType),
-          eq(embeddingJobs.sourceId, sourceId),
-          eq(embeddingJobs.status, 'pending')
-        )
-      )
-      .limit(1);
-
-    if (existing) return;
-
-    await db.insert(embeddingJobs).values({
-      ownerId,
-      sourceType,
-      sourceId,
-      action,
-      status: 'pending',
-      attempts: 0,
-      createdAt: sql`now()`,
-      updatedAt: sql`now()`,
-    });
-  } catch (error: any) {
-    throw new DatabaseError('Failed to enqueue embedding job', error);
-  }
-}
-
-export async function enqueueEmbeddingJobs(
-  sourceType: AiSourceType,
-  sourceIds: string[],
-  ownerId: string
-): Promise<void> {
-  const uniqueIds = [...new Set(sourceIds)];
-  if (uniqueIds.length === 0 || !VALID_SOURCE_TYPES.has(sourceType)) return;
-
-  try {
-    if (!(await isAiEligibleUser(ownerId))) {
-      for (const sourceIdChunk of chunkValues(uniqueIds, 500)) {
-        await db
-          .delete(documentEmbeddings)
-          .where(
-            and(
-              eq(documentEmbeddings.sourceType, sourceType),
-              inArray(documentEmbeddings.sourceId, sourceIdChunk)
-            )
-          );
-      }
-      return;
-    }
-    if (!shouldAutoIndex()) return;
-
-    for (const sourceIdChunk of chunkValues(uniqueIds, 500)) {
-      const existing = await db
-        .select({ sourceId: embeddingJobs.sourceId })
-        .from(embeddingJobs)
-        .where(
-          and(
-            eq(embeddingJobs.sourceType, sourceType),
-            eq(embeddingJobs.status, 'pending'),
-            inArray(embeddingJobs.sourceId, sourceIdChunk)
-          )
-        );
-      const pendingIds = new Set(existing.map((row) => row.sourceId));
-      const rows = sourceIdChunk
-        .filter((sourceId) => !pendingIds.has(sourceId))
-        .map((sourceId) => ({
-          ownerId,
-          sourceType,
-          sourceId,
-          action: 'upsert' as const,
-          status: 'pending' as const,
-          attempts: 0,
-          createdAt: new Date(),
-          updatedAt: new Date(),
-        }));
-
-      if (rows.length > 0) await db.insert(embeddingJobs).values(rows);
-    }
-  } catch (error: any) {
-    throw new DatabaseError('Failed to enqueue embedding jobs', error);
-  }
-}
-
-function chunkValues<T>(values: T[], size: number): T[][] {
-  const chunks: T[][] = [];
-  for (let offset = 0; offset < values.length; offset += size) {
-    chunks.push(values.slice(offset, offset + size));
-  }
-  return chunks;
-}
-
-export async function deleteEmbeddingsForSource(
-  sourceType: AiSourceType,
-  sourceId: string
-): Promise<void> {
-  try {
-    await db
-      .delete(documentEmbeddings)
-      .where(
-        and(
-          eq(documentEmbeddings.sourceType, sourceType),
-          eq(documentEmbeddings.sourceId, sourceId)
-        )
-      );
-  } catch (error: any) {
-    throw new DatabaseError('Failed to delete document embeddings', error);
-  }
-}
-
-export async function deleteEmbeddingsForOwner(ownerId: string): Promise<void> {
-  try {
-    await db.delete(documentEmbeddings).where(eq(documentEmbeddings.ownerId, ownerId));
-    await db.delete(embeddingJobs).where(eq(embeddingJobs.ownerId, ownerId));
-  } catch (error: any) {
-    throw new DatabaseError('Failed to delete user document embeddings', error);
-  }
-}
+import { getSourceDocument, sourceNeedsEmbeddingBackfill } from './documents';
+import { enqueueEmbeddingJob, requireReadyGeneration } from '../../../embeddings/queue';
+export {
+  enqueueEmbeddingJob,
+  enqueueEmbeddingJobs,
+  deleteEmbeddingsForSource,
+  deleteEmbeddingsForOwner,
+  getEmbeddingJobStats,
+} from '../../../embeddings/queue';
 
 export async function enqueueBackfillEmbeddingJobs(): Promise<{ queued: number }> {
   try {
+    await requireReadyGeneration();
     const config = await getStoredAiConfig();
     if (!isVectorUsable(config)) {
       throw new Error('AI vector storage is disabled');
@@ -184,7 +54,12 @@ export async function enqueueBackfillEmbeddingJobsForOwner(
 ): Promise<{ queued: number; skipped: boolean }> {
   try {
     const config = await getStoredAiConfig();
-    if (!shouldAutoIndex(config) || !(await isAiEligibleUser(ownerId))) {
+    const { state } = await readAiSnapshot();
+    if (
+      (!shouldAutoIndex(config) &&
+        !(state.status === 'rebuilding' && canProcessIndex(config, state))) ||
+      !(await isAiEligibleUser(ownerId))
+    ) {
       return { queued: 0, skipped: true };
     }
 
@@ -217,25 +92,4 @@ export async function enqueueBackfillEmbeddingJobsForOwner(
   } catch (error: any) {
     throw new DatabaseError('Failed to enqueue user backfill embedding jobs', error);
   }
-}
-
-export async function getEmbeddingJobStats(): Promise<Record<EmbeddingJobStatus, number>> {
-  const rows = (await db.execute(sql`
-    SELECT status, COUNT(*)::int AS count
-    FROM "embedding_jobs"
-    GROUP BY status
-  `)) as any[];
-
-  const stats: Record<EmbeddingJobStatus, number> = {
-    pending: 0,
-    running: 0,
-    succeeded: 0,
-    failed: 0,
-  };
-  rows.forEach((row) => {
-    if (row.status in stats) {
-      stats[row.status as EmbeddingJobStatus] = Number(row.count) || 0;
-    }
-  });
-  return stats;
 }

--- a/server/utils/dbMethods/ai/embeddingWorker.ts
+++ b/server/utils/dbMethods/ai/embeddingWorker.ts
@@ -1,188 +1,35 @@
-import { asc, eq, sql } from 'drizzle-orm';
-import { documentEmbeddings, embeddingJobs, type EmbeddingJob } from '../../../drizzle/schema';
-import type { AiConfig } from '../../../types/config';
-import { createEmbedding, vectorToLiteral } from '../../ai/client';
-import { DEFAULT_AI_CONFIG, mergeAiConfig } from '../../ai/providers';
-import db from '../../drizzle';
-import { logAiTokenUsage } from '../aiToken';
-import {
-  getStoredAiConfig,
-  isAiEligibleUser,
-  isVectorUsable,
-  updateStoredAiConfig,
-} from './config';
-import {
-  buildSourceDocument,
-  getSourceDocument,
-  getSourceOwner,
-  hashText,
-  normalizeEmbeddingDimensions,
-  splitIntoChunks,
-} from './documents';
-import { deleteEmbeddingsForSource } from './embeddingQueue';
-import type { AiSourceType, EmbeddingJobStatus } from './types';
+import { consumeSourceEvents } from '../../../embeddings/sourceEvents';
+import { EmbeddingError } from '../../../embeddings/errors';
+import { claimEmbeddingJob, failClaim } from '../../../embeddings/jobClaims';
+import { processEmbeddingJob } from '../../../embeddings/jobProcessor';
+import { finishIndexRebuild } from '../../../embeddings/indexLifecycle';
+import { scanRebuildPage } from '../../../embeddings/rebuildScanner';
+import { canProcessIndex, readAiSnapshot } from '../../../embeddings/configStore';
+export { retryFailedEmbeddingJobs, clearAllEmbeddings } from '../../../embeddings/indexLifecycle';
+export { setIndexingPaused } from '../../../embeddings/configStore';
 
-let embeddingJobsProcessing = false;
-
-async function markJob(
-  jobId: string,
-  status: EmbeddingJobStatus,
-  data?: { error?: string | null; attempts?: number }
-): Promise<void> {
-  await db
-    .update(embeddingJobs)
-    .set({
-      status,
-      error: data?.error ?? null,
-      attempts: data?.attempts,
-      lockedAt: status === 'running' ? new Date() : null,
-      updatedAt: new Date(),
-    })
-    .where(eq(embeddingJobs.id, jobId));
-}
-
-async function processJob(job: EmbeddingJob, config: AiConfig): Promise<void> {
-  if (job.action === 'delete') {
-    await deleteEmbeddingsForSource(job.sourceType as AiSourceType, job.sourceId);
-    return;
-  }
-
-  const sourceType = job.sourceType as AiSourceType;
-  const source = await getSourceDocument(sourceType, job.sourceId);
-  if (!source) {
-    await deleteEmbeddingsForSource(sourceType, job.sourceId);
-    return;
-  }
-
-  const ownerId = getSourceOwner(sourceType, source);
-  if (!(await isAiEligibleUser(ownerId))) {
-    await deleteEmbeddingsForSource(sourceType, job.sourceId);
-    return;
-  }
-
-  const document = buildSourceDocument(sourceType, source);
-  const chunks = splitIntoChunks(
-    document.text,
-    config.indexing.chunkSize,
-    config.indexing.chunkOverlap
-  );
-
-  await deleteEmbeddingsForSource(sourceType, job.sourceId);
-  if (chunks.length === 0) return;
-
-  const expectedDimensions = normalizeEmbeddingDimensions(config.embedding.dimensions);
-  for (let index = 0; index < chunks.length; index += 1) {
-    const chunk = chunks[index];
-    const { embedding, usage } = await createEmbedding(config.embedding, chunk);
-
-    if (usage) {
-      await logAiTokenUsage({
-        userid: ownerId,
-        model: config.embedding.model,
-        type: 'embedding',
-        promptTokens: usage.prompt_tokens,
-        completionTokens: 0,
-        totalTokens: usage.total_tokens,
-      });
-    }
-    if (embedding.length !== expectedDimensions) {
-      throw new Error(
-        `Embedding dimensions mismatch: expected ${expectedDimensions}, got ${embedding.length}`
-      );
-    }
-
-    await db.insert(documentEmbeddings).values({
-      ownerId,
-      sourceType,
-      sourceId: job.sourceId,
-      chunkIndex: index,
-      contentHash: hashText(chunk),
-      embeddingModel: config.embedding.model,
-      embeddingDimensions: expectedDimensions,
-      embedding: vectorToLiteral(embedding),
-      text: chunk,
-      metadata: document.metadata,
-      createdAt: sql`now()`,
-      updatedAt: sql`now()`,
-    });
-  }
-}
-
-export async function processPendingEmbeddingJobs(limit?: number): Promise<{
-  processed: number;
-  failed: number;
-  skipped: boolean;
-}> {
-  if (embeddingJobsProcessing) {
+export async function processPendingEmbeddingJobs(limit?: number) {
+  await consumeSourceEvents();
+  const { config, state } = await readAiSnapshot();
+  if (!canProcessIndex(config, state) || config.indexing.paused)
     return { processed: 0, failed: 0, skipped: true };
-  }
-  embeddingJobsProcessing = true;
-
-  try {
-    const config = await getStoredAiConfig();
-    if (!isVectorUsable(config) || config.indexing.paused) {
-      return { processed: 0, failed: 0, skipped: true };
+  await scanRebuildPage();
+  let processed = 0;
+  let failed = 0;
+  const batchSize = Math.min(Math.max(limit || config.indexing.batchSize, 1), 20);
+  for (let i = 0; i < batchSize; i++) {
+    const claim = await claimEmbeddingJob();
+    if (!claim) break;
+    try {
+      if (claim.job.attempts > claim.config.indexing.maxRetries)
+        throw new EmbeddingError('embedding_job_failed', 503);
+      await processEmbeddingJob(claim.job, claim.config, claim.state.dimensions!);
+      processed++;
+    } catch (error) {
+      await failClaim(claim.job, error, claim.config.indexing.maxRetries);
+      failed++;
     }
-
-    const batchSize = Math.min(Math.max(limit || config.indexing.batchSize || 1, 1), 20);
-    const jobs = await db.query.embeddingJobs.findMany({
-      where: (tbl, { eq }) => eq(tbl.status, 'pending'),
-      orderBy: (tbl) => [asc(tbl.createdAt)],
-      limit: batchSize,
-    });
-
-    let processed = 0;
-    let failed = 0;
-
-    for (const job of jobs) {
-      const attempts = (job.attempts || 0) + 1;
-      await markJob(job.id, 'running', { attempts });
-      try {
-        await processJob(job, config);
-        await markJob(job.id, 'succeeded', { attempts });
-        processed += 1;
-      } catch (error: any) {
-        const nextStatus: EmbeddingJobStatus =
-          attempts >= (config.indexing.maxRetries || DEFAULT_AI_CONFIG.indexing.maxRetries)
-            ? 'failed'
-            : 'pending';
-        await markJob(job.id, nextStatus, {
-          attempts,
-          error: error?.message || 'Unknown embedding error',
-        });
-        failed += 1;
-      }
-    }
-
-    return { processed, failed, skipped: false };
-  } finally {
-    embeddingJobsProcessing = false;
   }
-}
-
-export async function retryFailedEmbeddingJobs(): Promise<{ retried: number }> {
-  const rows = await db
-    .update(embeddingJobs)
-    .set({ status: 'pending', error: null, lockedAt: null, updatedAt: new Date() })
-    .where(eq(embeddingJobs.status, 'failed'))
-    .returning({ id: embeddingJobs.id });
-  return { retried: rows.length };
-}
-
-export async function clearAllEmbeddings(): Promise<void> {
-  await db.delete(documentEmbeddings);
-  await db.delete(embeddingJobs);
-}
-
-export async function setIndexingPaused(paused: boolean): Promise<AiConfig> {
-  const current = await getStoredAiConfig();
-  const next = mergeAiConfig({
-    ...current,
-    indexing: {
-      ...current.indexing,
-      paused,
-    },
-  });
-  await updateStoredAiConfig(next);
-  return next;
+  await finishIndexRebuild();
+  return { processed, failed, skipped: false };
 }

--- a/server/utils/dbMethods/ai/semanticSearch.ts
+++ b/server/utils/dbMethods/ai/semanticSearch.ts
@@ -1,14 +1,14 @@
 import { sql } from 'drizzle-orm';
 import type { SecurityConfig } from '../../../types/config';
-import { createEmbedding, vectorToLiteral } from '../../ai/client';
+import { vectorToLiteral } from '../../ai/client';
 import { getGlobalConfig } from '../../config';
 import db from '../../drizzle';
 import { logAiTokenUsage } from '../aiToken';
 import { subjectIsVisibleToViewer } from '../userBlock';
-import { getStoredAiConfig, isVectorUsable } from './config';
+import { requireReadyGeneration } from '../../../embeddings/queue';
+import { createQueryEmbedding } from '../../../embeddings/query';
 import {
   buildTextArraySql,
-  normalizeEmbeddingDimensions,
   normalizeLimit,
   normalizeSearchTimeRange,
   VALID_SOURCE_TYPES,
@@ -36,31 +36,23 @@ export async function semanticSearch(params: {
   exclude?: { sourceType: AiSourceType; sourceId: string };
   excludeIds?: string[];
 }): Promise<SemanticSearchResult[]> {
-  const config = await getStoredAiConfig();
-  if (!isVectorUsable(config)) {
-    throw new Error('AI vector search is disabled');
-  }
+  const { config, state } = await requireReadyGeneration();
   if (params.scope === 'public' && !config.publicExploreVectorEnabled) {
     throw new Error('Public semantic search is disabled');
   }
 
-  const dimensions = normalizeEmbeddingDimensions(config.embedding.dimensions);
+  const dimensions = state.dimensions!;
   const limit = normalizeLimit(params.limit);
   const { timeRange } = normalizeSearchTimeRange(params.timeRange);
   const dateField = params.dateField === 'updatedAt' ? 'updatedAt' : 'createdAt';
   const queryText = [params.query, ...(params.semanticScope || [])].filter(Boolean).join('\n');
 
-  let queryEmbedding: number[];
-  let usage: { prompt_tokens: number; total_tokens: number } | undefined;
-  if (queryText) {
-    const result = await createEmbedding(config.embedding, queryText);
-    queryEmbedding = result.embedding;
-    usage = result.usage;
-  } else {
-    const result = await createEmbedding(config.embedding, 'all notes');
-    queryEmbedding = result.embedding;
-    usage = result.usage;
-  }
+  const { embedding: queryEmbedding, usage } = await createQueryEmbedding(
+    config,
+    state.generationId!,
+    dimensions,
+    queryText || 'all notes'
+  );
   if (usage && params.ownerId) {
     await logAiTokenUsage({
       userid: params.ownerId,
@@ -71,12 +63,6 @@ export async function semanticSearch(params: {
       totalTokens: usage.total_tokens,
     });
   }
-  if (queryEmbedding.length !== dimensions) {
-    throw new Error(
-      `Embedding dimensions mismatch: expected ${dimensions}, got ${queryEmbedding.length}`
-    );
-  }
-
   const securityConfig = getGlobalConfig<SecurityConfig>('security');
   const requireVerifiedEmailForExplore = securityConfig?.requireVerifiedEmailForExplore === true;
   const sourceTypes = Array.from(
@@ -209,7 +195,9 @@ export async function semanticSearch(params: {
     FROM "document_embeddings" de
     LEFT JOIN "rotes" r ON de."sourceType" = 'rote' AND r."id" = de."sourceId"
     LEFT JOIN "articles" a ON de."sourceType" = 'article' AND a."id" = de."sourceId"
-    WHERE de."embeddingModel" = ${config.embedding.model}
+    WHERE de."generationId" = ${state.generationId}
+      AND EXISTS (SELECT 1 FROM "embedding_index_state" eis WHERE eis.id = 1 AND eis.status = 'ready' AND eis."generationId" = de."generationId")
+      AND de."embeddingModel" = ${config.embedding.model}
       AND de."embeddingDimensions" = ${dimensions}
       ${liveSourceSql}
       ${permissionSql}

--- a/server/utils/dbMethods/ai/types.ts
+++ b/server/utils/dbMethods/ai/types.ts
@@ -2,7 +2,7 @@ import type { RetrievalSelection } from '../../ai/retrievalPlan';
 
 export type AiSourceType = 'rote' | 'article';
 export type EmbeddingJobAction = 'upsert' | 'delete' | 'reindex';
-export type EmbeddingJobStatus = 'pending' | 'running' | 'succeeded' | 'failed';
+export type EmbeddingJobStatus = 'pending' | 'running' | 'succeeded' | 'failed' | 'cancelled';
 
 export type {
   NormalizedTimeRange,

--- a/server/utils/dbMethods/ai/vector.ts
+++ b/server/utils/dbMethods/ai/vector.ts
@@ -1,66 +1,47 @@
 import { sql } from 'drizzle-orm';
 import db from '../../drizzle';
-import { DatabaseError } from '../common';
-import { getStoredAiConfig } from './config';
-import { normalizeEmbeddingDimensions, vectorIndexName } from './documents';
+import { readAiSnapshot } from '../../../embeddings/configStore';
+import { EmbeddingError } from '../../../embeddings/errors';
+import { vectorIndexName } from './documents';
 
-export async function getPgvectorStatus(): Promise<{
-  available: boolean;
-  installed: boolean;
-  version: string | null;
-  indexName: string | null;
-  dimensions: number;
-}> {
-  try {
-    const config = await getStoredAiConfig();
-    const dimensions = normalizeEmbeddingDimensions(config.embedding.dimensions);
-    const rows = (await db.execute(sql`
-      SELECT
-        EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'vector') AS "available",
-        EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'vector') AS "installed",
-        (SELECT extversion FROM pg_extension WHERE extname = 'vector') AS "version",
-        EXISTS (
-          SELECT 1 FROM pg_indexes
-          WHERE schemaname = 'public' AND indexname = ${vectorIndexName(dimensions)}
-        ) AS "hasIndex"
-    `)) as any[];
-    const row = rows[0] || {};
-
-    return {
-      available: Boolean(row.available),
-      installed: Boolean(row.installed),
-      version: row.version || null,
-      indexName: row.hasIndex ? vectorIndexName(dimensions) : null,
-      dimensions,
-    };
-  } catch (error: any) {
-    throw new DatabaseError('Failed to check pgvector status', error);
-  }
+export async function getPgvectorStatus() {
+  const { config, state } = await readAiSnapshot();
+  const name =
+    state.dimensions && state.generationId
+      ? vectorIndexName(state.dimensions, state.generationId)
+      : null;
+  const rows = await db.execute(sql`
+    SELECT EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'vector') AS available,
+      EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'vector') AS installed,
+      (SELECT extversion FROM pg_extension WHERE extname = 'vector') AS version,
+      EXISTS (SELECT 1 FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public' AND c.relname = ${name} AND i.indisvalid) AS "hasIndex"
+  `);
+  const row = rows[0];
+  return {
+    available: Boolean(row.available),
+    installed: Boolean(row.installed),
+    version: row.version as string | null,
+    indexName: row.hasIndex ? name : null,
+    dimensions: state.dimensions,
+    generationId: state.generationId,
+    revision: state.revision,
+    status: state.status,
+    errorCode: state.errorCode,
+    errorDetails: state.errorDetails,
+    scanComplete: state.scanComplete,
+    ready:
+      config.enabled &&
+      config.vectorEnabled &&
+      state.status === 'ready' &&
+      Boolean(row.installed && row.hasIndex),
+  };
 }
 
-export async function ensurePgvectorReady(): Promise<
-  Awaited<ReturnType<typeof getPgvectorStatus>>
-> {
-  try {
-    const before = await getPgvectorStatus();
-    if (!before.available) {
-      throw new Error('pgvector extension is not available in this Postgres image');
-    }
-
-    await db.execute(sql`CREATE EXTENSION IF NOT EXISTS vector`);
-    const dimensions = before.dimensions;
-    const indexName = vectorIndexName(dimensions);
-    await db.execute(
-      sql.raw(`
-      CREATE INDEX IF NOT EXISTS "${indexName}"
-      ON "document_embeddings"
-      USING hnsw (("embedding"::vector(${dimensions})) vector_cosine_ops)
-      WHERE "embeddingDimensions" = ${dimensions}
-    `)
-    );
-
-    return getPgvectorStatus();
-  } catch (error: any) {
-    throw new DatabaseError('Failed to enable pgvector', error);
-  }
+export async function ensurePgvectorReady() {
+  const before = await getPgvectorStatus();
+  if (!before.available) throw new EmbeddingError('embedding_database_unavailable', 503);
+  await db.execute(sql`CREATE EXTENSION IF NOT EXISTS vector`);
+  return getPgvectorStatus();
 }

--- a/server/utils/dbMethods/article.ts
+++ b/server/utils/dbMethods/article.ts
@@ -2,7 +2,6 @@ import { and, desc, eq, ilike, inArray, sql } from 'drizzle-orm';
 import { type Article, articles, rotes } from '../../drizzle/schema';
 import db from '../drizzle';
 import { parseMarkdownMeta } from '../markdown';
-import { deleteEmbeddingsForSource, enqueueEmbeddingJob } from './ai';
 import { createRoteChange } from './change';
 import { DatabaseError } from './common';
 import { subjectIsVisibleToViewer } from './userBlock';
@@ -100,9 +99,6 @@ export async function createArticle(data: {
 
     // 补充计算字段
     const meta = parseMarkdownMeta(article.content);
-    void enqueueEmbeddingJob('article', article.id, article.authorId).catch((error) => {
-      console.error('Failed to enqueue article embedding job:', error);
-    });
     return { ...article, ...meta };
   } catch (error: any) {
     throw new DatabaseError('Failed to create article', error);
@@ -147,9 +143,6 @@ export async function updateArticle(data: {
     }
 
     const meta = parseMarkdownMeta(article.content);
-    void enqueueEmbeddingJob('article', article.id, article.authorId).catch((error) => {
-      console.error('Failed to enqueue article embedding job:', error);
-    });
     return { ...article, ...meta };
   } catch (error: any) {
     throw new DatabaseError(`Failed to update article: ${data.id}`, error);
@@ -188,10 +181,6 @@ export async function deleteArticle(data: {
     } catch (_error) {
       // 记录变更失败不影响操作
     }
-
-    void deleteEmbeddingsForSource('article', data.id).catch((error) => {
-      console.error('Failed to delete article embeddings:', error);
-    });
 
     return article;
   } catch (error: any) {

--- a/server/utils/handlers.ts
+++ b/server/utils/handlers.ts
@@ -1,3 +1,4 @@
+import { EmbeddingError } from '../embeddings/errors';
 import { HonoContext } from '../types/hono';
 import { ResourcePolicyError } from '../resources/errors';
 import { PushApiError } from '../push/errors';
@@ -17,6 +18,8 @@ function containsSensitiveServerDetails(message: string): boolean {
 }
 
 export const errorHandler = async (err: Error, c: HonoContext) => {
+  if (err instanceof EmbeddingError)
+    return c.json({ code: 1, message: err.code, data: err.details }, err.status);
   console.error('API Error:', err.message);
 
   // 只在开发环境下打印完整的错误堆栈

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -390,7 +390,11 @@
           },
           "overLimit": "Usage has reached or exceeded the quota. Existing files will not be deleted.",
           "uploadBlocked": "New attachments are paused; reading, downloading, and deleting remain available.",
-          "enforcement": { "off": "Off", "observe": "Observing", "enforce": "Enforcing" }
+          "enforcement": {
+            "off": "Off",
+            "observe": "Observing",
+            "enforce": "Enforcing"
+          }
         },
         "openKey": {
           "subtitle": "Connect shortcuts, MCP, and automations",
@@ -570,20 +574,15 @@
       "clear": "Clear chat",
       "backToBottom": "Back to bottom",
       "model": {
-        "title": "Model source",
-        "site": "Site model",
+        "source": "Model source",
+        "model": "Current model",
+        "site": "Site / cloud AI",
         "local": "Local model",
-        "localDescription": "Local model requests only travel between this device and the local bridge.",
-        "bridgeUrl": "Local bridge URL",
-        "modelName": "Model name",
-        "token": "Local bridge token",
-        "test": "Test local connection",
-        "testing": "Testing...",
-        "connected": "Local model connected",
-        "connectionFailed": "Local model connection failed: {{error}}",
-        "toolsReady": "Local model with Rote tools",
-        "chatOnly": "Local model, chat only",
-        "localIncomplete": "Complete the local model connection settings"
+        "personal": "My model/API",
+        "personalLocal": "My local model",
+        "personalRemote": "My remote API",
+        "disabled": "Disabled",
+        "noModel": "Not configured"
       },
       "saveAsArticle": "Save as article",
       "saved": "Saved",
@@ -631,17 +630,6 @@
         "permissionDenied": "This account does not have AI chat permission",
         "unavailable": "AI chat model is not configured",
         "memoryUnavailable": "The chat model is configured, but memory still needs vector indexing"
-      },
-      "model": {
-        "source": "Model source",
-        "model": "Current model",
-        "site": "Site / cloud AI",
-        "local": "Local model",
-        "personal": "My model/API",
-        "personalLocal": "My local model",
-        "personalRemote": "My remote API",
-        "disabled": "Disabled",
-        "noModel": "Not configured"
       },
       "personal": {
         "title": "Personal AI settings",
@@ -1250,9 +1238,18 @@
       "description": "Choose an account state to preview the storage and OpenKey details shown on the official Rote service.",
       "scenarioLabel": "Preview scenario",
       "scenarios": {
-        "free": { "title": "Free account", "description": "500 MB and 1 OpenKey" },
-        "pro": { "title": "Rote Pro", "description": "More space, unlimited OpenKeys" },
-        "expired": { "title": "Pro expired", "description": "Content stays, new items pause" }
+        "free": {
+          "title": "Free account",
+          "description": "500 MB and 1 OpenKey"
+        },
+        "pro": {
+          "title": "Rote Pro",
+          "description": "More space, unlimited OpenKeys"
+        },
+        "expired": {
+          "title": "Pro expired",
+          "description": "Content stays, new items pause"
+        }
       },
       "notice": "This is a local preview. It doesn't connect to billing or change any account data."
     },
@@ -1379,12 +1376,19 @@
         "officialManaged": "Official benefit policy",
         "officialEnforcement": "Storage enforcement: {{mode}}",
         "modeLabel": "Instance resource management",
-        "mode": { "unmanaged": "Unmanaged", "local": "Local policy" },
+        "mode": {
+          "unmanaged": "Unmanaged",
+          "local": "Local policy"
+        },
         "modeDescription": {
           "unmanaged": "Do not measure or limit storage and OpenKey creation.",
           "local": "Use this instance's own policy without connecting to official billing or using Rote Pro branding."
         },
-        "enforcement": { "off": "Off", "observe": "Observe only", "enforce": "Enforce" },
+        "enforcement": {
+          "off": "Off",
+          "observe": "Observe only",
+          "enforce": "Enforce"
+        },
         "storage": {
           "title": "Local storage quota",
           "enforcement": "Enforcement",
@@ -1667,7 +1671,21 @@
           "pending": "Pending",
           "running": "Running",
           "succeeded": "Completed",
-          "failed": "Failed"
+          "failed": "Failed",
+          "lifecycle": {
+            "needs_validation": "Verification required",
+            "needs_validationDescription": "Verify the model after an upgrade or configuration change, then explicitly start rebuilding. Old vectors are not reused.",
+            "needs_rebuild": "Rebuild required",
+            "needs_rebuildDescription": "The configuration is verified. Start rebuilding to restore vector search.",
+            "rebuilding": "Rebuilding",
+            "rebuildingDescription": "Building the current model index. Vector search is paused.",
+            "failed": "Rebuild failed",
+            "failedDescription": "Check the errors and model configuration, then retry failed jobs or verify the configuration again.",
+            "ready": "Ready",
+            "readyDescription": "The vector index is ready."
+          },
+          "scanning": "Scanning sources. More jobs may still be added.",
+          "scanComplete": "Source scan complete. Waiting for this generation’s jobs."
         },
         "runtime": {
           "title": "Model source",
@@ -1688,6 +1706,37 @@
           "copySuccess": "Command copied",
           "copyFailed": "Failed to copy",
           "embeddingNote": "Memory also needs an embedding model. pgvector HNSW indexes require 2000 dimensions or fewer; if local embeddings return more dimensions, keep vector memory off or use a lower-dimensional embedding model."
+        },
+        "outputMode": "Output dimensions",
+        "nativeDimensions": "Use model default",
+        "requestedDimensions": "Request dimensions",
+        "detectedDimensions": "Detected {{dimensions}} dimensions",
+        "dimensionTestRequired": "Test the connection to verify output dimensions. Supports 1–2000 dimensions.",
+        "rebuild": "Rebuild vector index",
+        "rebuildConfirmation": "Vector search will pause during rebuilding. Regular chat remains available. Notes and articles belonging to eligible users will be processed again, incurring model usage charges. Vector search resumes when rebuilding completes.",
+        "rebuildCancel": "Cancel",
+        "rebuildConfirm": "Start rebuilding",
+        "rebuildStarted": "Rebuild started",
+        "saveBeforeRebuild": "Save your configuration before rebuilding.",
+        "embeddingErrors": {
+          "embedding_config_invalid": "Invalid embedding configuration. Check the output mode, dimensions and chunk settings.",
+          "embedding_dimensions_limit": "The model returned {{actual}} dimensions; this index supports up to {{limit}}. Use a model that supports a smaller output.",
+          "embedding_dimensions_mismatch": "The model returned {{actual}} dimensions instead of {{expected}}.",
+          "embedding_response_invalid": "The model returned an invalid vector. Verify the model configuration.",
+          "embedding_parameter_rejected": "The provider rejected the request parameters. Check the model name; use the model default for fixed-dimension models.",
+          "embedding_auth_failed": "Provider authentication failed. Check your API key and model access.",
+          "embedding_timeout": "The embedding request timed out.",
+          "embedding_network_error": "Could not connect to the embedding service.",
+          "embedding_rate_limited": "The embedding service is rate limiting requests. Try again later.",
+          "embedding_provider_unavailable": "The embedding service is temporarily unavailable.",
+          "embedding_database_unavailable": "Install and enable pgvector before rebuilding.",
+          "embedding_revision_conflict": "The configuration has changed. Refresh before editing again.",
+          "embedding_rebuild_required": "Vector search is not ready. Verify the configuration and rebuild the index.",
+          "embedding_disabled": "Enable AI and vector features and save the configuration first.",
+          "embedding_input_empty": "Non-empty text is required.",
+          "embedding_state_missing": "Index state is missing. Check database migrations.",
+          "embedding_lease_lost": "This job has been claimed by another worker.",
+          "embedding_job_failed": "Embedding processing failed. Check the index status before retrying."
         }
       },
       "users": {

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -394,7 +394,11 @@
           },
           "overLimit": "使用量が上限に達しています。既存ファイルは削除されません。",
           "uploadBlocked": "新規添付は停止中です。閲覧・ダウンロード・削除は利用できます。",
-          "enforcement": { "off": "オフ", "observe": "監視中", "enforce": "適用中" }
+          "enforcement": {
+            "off": "オフ",
+            "observe": "監視中",
+            "enforce": "適用中"
+          }
         },
         "openKey": {
           "subtitle": "ショートカット、MCP、自動化ツールに接続",
@@ -574,20 +578,15 @@
       "clear": "チャットをクリア",
       "backToBottom": "一番下へ戻る",
       "model": {
-        "title": "モデルソース",
-        "site": "サイトモデル",
-        "local": "ローカルモデル",
-        "localDescription": "ローカルモデルのリクエストは、この端末とローカルブリッジ間だけで送信されます。",
-        "bridgeUrl": "ローカルブリッジ URL",
-        "modelName": "モデル名",
-        "token": "ローカルブリッジ Token",
-        "test": "ローカル接続をテスト",
-        "testing": "テスト中...",
-        "connected": "ローカルモデルに接続しました",
-        "connectionFailed": "ローカルモデル接続に失敗しました：{{error}}",
-        "toolsReady": "Rote ツール付きローカルモデル",
-        "chatOnly": "ローカルモデル、通常チャットのみ",
-        "localIncomplete": "ローカルモデル接続を設定してください"
+        "source": "モデルソース",
+        "model": "現在のモデル",
+        "site": "サイト / クラウド AI",
+        "local": "ローカル大規模モデル",
+        "personal": "自分のモデル/API",
+        "personalLocal": "自分のローカルモデル",
+        "personalRemote": "自分のリモート API",
+        "disabled": "無効",
+        "noModel": "未設定"
       },
       "saveAsArticle": "記事として保存",
       "saved": "保存済み",
@@ -635,17 +634,6 @@
         "permissionDenied": "このアカウントには AI チャット権限がありません",
         "unavailable": "AI チャットモデルが未設定です",
         "memoryUnavailable": "チャットモデルは設定済みですが、メモリーにはベクトル索引が必要です"
-      },
-      "model": {
-        "source": "モデルソース",
-        "model": "現在のモデル",
-        "site": "サイト / クラウド AI",
-        "local": "ローカル大規模モデル",
-        "personal": "自分のモデル/API",
-        "personalLocal": "自分のローカルモデル",
-        "personalRemote": "自分のリモート API",
-        "disabled": "無効",
-        "noModel": "未設定"
       },
       "personal": {
         "title": "個人 AI 設定",
@@ -1254,9 +1242,18 @@
       "description": "アカウント状態を選んで、Rote 公式サービスに表示されるストレージと OpenKey 情報を確認できます。",
       "scenarioLabel": "プレビューシナリオ",
       "scenarios": {
-        "free": { "title": "無料アカウント", "description": "500 MB と OpenKey 1個" },
-        "pro": { "title": "Rote Pro", "description": "容量アップ、OpenKey 無制限" },
-        "expired": { "title": "Pro 期限切れ", "description": "内容は保持、新規追加のみ停止" }
+        "free": {
+          "title": "無料アカウント",
+          "description": "500 MB と OpenKey 1個"
+        },
+        "pro": {
+          "title": "Rote Pro",
+          "description": "容量アップ、OpenKey 無制限"
+        },
+        "expired": {
+          "title": "Pro 期限切れ",
+          "description": "内容は保持、新規追加のみ停止"
+        }
       },
       "notice": "これはローカルプレビューです。課金サービスへ接続せず、アカウントデータも変更しません。"
     },
@@ -1383,12 +1380,19 @@
         "officialManaged": "公式特典ポリシー",
         "officialEnforcement": "ストレージ適用状態：{{mode}}",
         "modeLabel": "インスタンスのリソース管理",
-        "mode": { "unmanaged": "管理なし", "local": "ローカルポリシー" },
+        "mode": {
+          "unmanaged": "管理なし",
+          "local": "ローカルポリシー"
+        },
         "modeDescription": {
           "unmanaged": "ストレージと OpenKey を計測・制限しません。",
           "local": "公式課金に接続せず、Rote Pro 表示を使わない独自ポリシーです。"
         },
-        "enforcement": { "off": "オフ", "observe": "監視のみ", "enforce": "強制適用" },
+        "enforcement": {
+          "off": "オフ",
+          "observe": "監視のみ",
+          "enforce": "強制適用"
+        },
         "storage": {
           "title": "ローカルストレージクォータ",
           "enforcement": "適用方法",
@@ -1671,7 +1675,21 @@
           "pending": "保留中",
           "running": "実行中",
           "succeeded": "完了",
-          "failed": "失敗"
+          "failed": "失敗",
+          "lifecycle": {
+            "needs_validation": "検証が必要",
+            "needs_validationDescription": "更新または設定変更後にモデルを検証し、再構築を開始してください。旧ベクトルは再利用されません。",
+            "needs_rebuild": "再構築が必要",
+            "needs_rebuildDescription": "設定は検証済みです。再構築してベクトル検索を復元してください。",
+            "rebuilding": "再構築中",
+            "rebuildingDescription": "現在のモデルの索引を作成しています。ベクトル検索は停止中です。",
+            "failed": "再構築失敗",
+            "failedDescription": "エラーとモデル設定を確認し、失敗したタスクを再試行するか、設定を再検証してください。",
+            "ready": "利用可能",
+            "readyDescription": "ベクトル索引の準備ができました。"
+          },
+          "scanning": "ソースをスキャン中です。タスク数は増える場合があります。",
+          "scanComplete": "ソースのスキャン完了。この世代のタスク完了を待っています。"
         },
         "runtime": {
           "title": "モデルソース",
@@ -1692,6 +1710,37 @@
           "copySuccess": "コマンドをコピーしました",
           "copyFailed": "コピーに失敗しました",
           "embeddingNote": "メモリーには埋め込みモデルも必要です。pgvector HNSW インデックスは 2000 次元以下が必要です。ローカル埋め込みがそれ以上の次元を返す場合は、ベクトルメモリーをオフにするか、低次元の埋め込みモデルを使用してください。"
+        },
+        "outputMode": "出力次元数",
+        "nativeDimensions": "モデルの既定値を使用",
+        "requestedDimensions": "出力次元数を指定",
+        "detectedDimensions": "{{dimensions}} 次元を検出しました",
+        "dimensionTestRequired": "接続テストで出力次元数を確認してください。1〜2000 次元に対応します。",
+        "rebuild": "ベクトル索引を再構築",
+        "rebuildConfirmation": "再構築中はベクトル検索を停止します。通常のチャットは引き続き利用できます。権限のあるユーザーのノートと記事を再処理するため、モデル利用料金が発生します。完了後にベクトル検索を再開します。",
+        "rebuildCancel": "キャンセル",
+        "rebuildConfirm": "再構築を開始",
+        "rebuildStarted": "再構築を開始しました",
+        "saveBeforeRebuild": "再構築の前に設定を保存してください。",
+        "embeddingErrors": {
+          "embedding_config_invalid": "埋め込み設定が無効です。出力モード、次元数、分割設定を確認してください。",
+          "embedding_dimensions_limit": "モデルは {{actual}} 次元を返しました。索引の上限は {{limit}} 次元です。より小さい出力に対応するモデルを使用してください。",
+          "embedding_dimensions_mismatch": "要求した {{expected}} 次元ではなく {{actual}} 次元が返されました。",
+          "embedding_response_invalid": "モデルが無効なベクトルを返しました。設定を再確認してください。",
+          "embedding_parameter_rejected": "提供元が要求パラメータを拒否しました。モデル名を確認し、固定次元モデルでは既定値を使用してください。",
+          "embedding_auth_failed": "提供元の認証に失敗しました。API キーとモデルのアクセス権を確認してください。",
+          "embedding_timeout": "埋め込み要求がタイムアウトしました。",
+          "embedding_network_error": "埋め込みサービスに接続できませんでした。",
+          "embedding_rate_limited": "埋め込みサービスのレート制限に達しました。後で再試行してください。",
+          "embedding_provider_unavailable": "埋め込みサービスを一時的に利用できません。",
+          "embedding_database_unavailable": "再構築の前に pgvector をインストールして有効にしてください。",
+          "embedding_revision_conflict": "設定が変更されました。更新してから編集してください。",
+          "embedding_rebuild_required": "ベクトル検索は未準備です。設定を確認し、索引を再構築してください。",
+          "embedding_disabled": "先に AI とベクトル機能を有効にして設定を保存してください。",
+          "embedding_input_empty": "空でないテキストが必要です。",
+          "embedding_state_missing": "索引の状態がありません。データベース移行を確認してください。",
+          "embedding_lease_lost": "このタスクは別のワーカーに引き継がれました。",
+          "embedding_job_failed": "埋め込み処理に失敗しました。索引の状態を確認して再試行してください。"
         }
       },
       "users": {

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -373,7 +373,11 @@
           "uploading": "还有 {{reserved}} 正在上传",
           "ready": "空间充足，可以继续上传。",
           "fullDescription": "当前空间已用满，暂时不能上传新附件。你仍然可以查看、下载或删除已有文件。",
-          "status": { "available": "可以上传", "observing": "正在统计", "full": "空间已满" },
+          "status": {
+            "available": "可以上传",
+            "observing": "正在统计",
+            "full": "空间已满"
+          },
           "overLimit": "当前用量已达到或超过额度。已有文件不会被删除。",
           "uploadBlocked": "已暂停新增附件；读取、下载和删除仍可使用。",
           "enforcement": {
@@ -387,7 +391,11 @@
           "created": "已创建 {{count}} 个",
           "countThreshold": "（{{count}}/{{limit}}）",
           "countUnlimited": "（{{count}}/∞）",
-          "status": { "available": "可以新建", "unlimited": "不限数量", "paused": "暂不可新建" },
+          "status": {
+            "available": "可以新建",
+            "unlimited": "不限数量",
+            "paused": "暂不可新建"
+          },
           "policy": {
             "unmanaged": "未限制",
             "threshold": "创建阈值",
@@ -556,20 +564,15 @@
       "clear": "清空对话",
       "backToBottom": "回到底部",
       "model": {
-        "title": "模型来源",
-        "site": "站点模型",
-        "local": "本地模型",
-        "localDescription": "本地模型请求只在当前设备与本地桥接器之间传输。",
-        "bridgeUrl": "本地桥接器地址",
-        "modelName": "模型名称",
-        "token": "本地桥接器 Token",
-        "test": "测试本地连接",
-        "testing": "测试中...",
-        "connected": "本地模型连接成功",
-        "connectionFailed": "本地模型连接失败：{{error}}",
-        "toolsReady": "本地模型，可读取 Rote",
-        "chatOnly": "本地模型，仅普通对话",
-        "localIncomplete": "请完成本地模型连接配置"
+        "source": "模型来源",
+        "model": "当前模型",
+        "site": "站内 / 云端 AI",
+        "local": "本地大模型",
+        "personal": "我的模型/API",
+        "personalLocal": "我的本地大模型",
+        "personalRemote": "我的远程 API",
+        "disabled": "未启用",
+        "noModel": "未配置"
       },
       "saveAsArticle": "保存为文章",
       "saved": "已保存",
@@ -617,17 +620,6 @@
         "permissionDenied": "当前账号没有 AI 对话权限",
         "unavailable": "AI 对话模型未配置",
         "memoryUnavailable": "对话模型已配置，记忆还需要启用向量索引"
-      },
-      "model": {
-        "source": "模型来源",
-        "model": "当前模型",
-        "site": "站内 / 云端 AI",
-        "local": "本地大模型",
-        "personal": "我的模型/API",
-        "personalLocal": "我的本地大模型",
-        "personalRemote": "我的远程 API",
-        "disabled": "未启用",
-        "noModel": "未配置"
       },
       "personal": {
         "title": "个人 AI 设置",
@@ -1236,9 +1228,18 @@
       "description": "选择一种账户状态，预览用户在 Rote 官方服务中看到的空间与 OpenKey 信息。",
       "scenarioLabel": "预览场景",
       "scenarios": {
-        "free": { "title": "免费账户", "description": "500 MB 与 1 个 OpenKey" },
-        "pro": { "title": "Rote Pro", "description": "更多空间，不限 OpenKey" },
-        "expired": { "title": "Pro 已到期", "description": "内容保留，暂停新增" }
+        "free": {
+          "title": "免费账户",
+          "description": "500 MB 与 1 个 OpenKey"
+        },
+        "pro": {
+          "title": "Rote Pro",
+          "description": "更多空间，不限 OpenKey"
+        },
+        "expired": {
+          "title": "Pro 已到期",
+          "description": "内容保留，暂停新增"
+        }
       },
       "notice": "这是本地预览，不会连接付费服务，也不会修改任何账户数据。"
     },
@@ -1365,12 +1366,19 @@
         "officialManaged": "官方权益策略",
         "officialEnforcement": "存储执行状态：{{mode}}",
         "modeLabel": "实例资源管理模式",
-        "mode": { "unmanaged": "未托管", "local": "本地策略" },
+        "mode": {
+          "unmanaged": "未托管",
+          "local": "本地策略"
+        },
         "modeDescription": {
           "unmanaged": "不计量或限制存储与 OpenKey，保持传统 self-hosted 行为。",
           "local": "使用此实例自己的策略；不会连接官方付费服务，也不会显示 Rote Pro。"
         },
-        "enforcement": { "off": "关闭", "observe": "仅观察", "enforce": "强制执行" },
+        "enforcement": {
+          "off": "关闭",
+          "observe": "仅观察",
+          "enforce": "强制执行"
+        },
         "storage": {
           "title": "本地存储配额",
           "enforcement": "执行方式",
@@ -1653,7 +1661,21 @@
           "pending": "待处理",
           "running": "运行中",
           "succeeded": "已完成",
-          "failed": "失败"
+          "failed": "失败",
+          "lifecycle": {
+            "needs_validation": "待验证",
+            "needs_validationDescription": "升级或配置变更后，需要验证模型并明确启动重建；旧向量不会被复用。",
+            "needs_rebuild": "待重建",
+            "needs_rebuildDescription": "配置已验证。请启动索引重建，完成后恢复向量检索。",
+            "rebuilding": "重建中",
+            "rebuildingDescription": "正在建立当前模型的索引，向量检索暂停。",
+            "failed": "重建失败",
+            "failedDescription": "请检查错误和模型配置，修复后重试失败任务或重新验证配置。",
+            "ready": "可用",
+            "readyDescription": "向量索引已就绪。"
+          },
+          "scanning": "正在扫描来源，任务总数会继续增加。",
+          "scanComplete": "来源扫描完成，正在等待本代次任务完成。"
         },
         "runtime": {
           "title": "模型来源",
@@ -1674,6 +1696,37 @@
           "copySuccess": "命令已复制",
           "copyFailed": "复制失败",
           "embeddingNote": "记忆还需要 embedding 模型。pgvector HNSW 索引要求维度不超过 2000；如果本地 embedding 返回更高维度，请先关闭向量记忆或换用较低维度的 embedding 模型。"
+        },
+        "outputMode": "输出维度",
+        "nativeDimensions": "使用模型默认维度",
+        "requestedDimensions": "指定输出维度",
+        "detectedDimensions": "已检测到 {{dimensions}} 维",
+        "dimensionTestRequired": "测试连接以验证输出维度，支持 1–2000 维。",
+        "rebuild": "重建向量索引",
+        "rebuildConfirmation": "重建期间向量检索会暂停，普通聊天仍可使用。系统将重新处理有权限用户的笔记和文章，并产生模型调用费用。完成后自动恢复向量检索。",
+        "rebuildCancel": "取消",
+        "rebuildConfirm": "开始重建",
+        "rebuildStarted": "重建已启动",
+        "saveBeforeRebuild": "请先保存当前配置，再启动重建。",
+        "embeddingErrors": {
+          "embedding_config_invalid": "向量模型配置无效，请检查输出模式、维度和分块设置。",
+          "embedding_dimensions_limit": "模型返回 {{actual}} 维，当前索引最多支持 {{limit}} 维。请使用支持指定较小维度的模型。",
+          "embedding_dimensions_mismatch": "实际返回 {{actual}} 维，与要求的 {{expected}} 维不一致。",
+          "embedding_response_invalid": "模型返回了无效向量，请重新验证模型配置。",
+          "embedding_parameter_rejected": "供应商拒绝了请求参数。请检查模型名称；固定维度模型应选择“使用模型默认维度”。",
+          "embedding_auth_failed": "供应商认证失败，请检查 API Key 和模型访问权限。",
+          "embedding_timeout": "向量模型请求超时。",
+          "embedding_network_error": "无法连接向量模型服务。",
+          "embedding_rate_limited": "向量模型请求受到限流，请稍后重试。",
+          "embedding_provider_unavailable": "向量模型服务暂时不可用。",
+          "embedding_database_unavailable": "请先安装并启用 pgvector，再启动重建。",
+          "embedding_revision_conflict": "配置已被修改，请刷新后重新编辑。",
+          "embedding_rebuild_required": "向量检索尚未就绪，请完成配置验证和索引重建。",
+          "embedding_disabled": "请先启用 AI 和向量功能并保存配置。",
+          "embedding_input_empty": "需要提供非空文本。",
+          "embedding_state_missing": "索引状态缺失，请检查数据库迁移。",
+          "embedding_lease_lost": "任务已由其他执行者接管。",
+          "embedding_job_failed": "向量处理失败，请查看索引状态后重试。"
         }
       },
       "users": {

--- a/web/src/pages/admin/components/AIConfigAdvancedSettings.tsx
+++ b/web/src/pages/admin/components/AIConfigAdvancedSettings.tsx
@@ -11,6 +11,7 @@ type AiConfig = NonNullable<SystemConfig['ai']>;
 
 interface AIConfigAdvancedSettingsProps {
   config: AiConfig;
+  hasUnsavedChanges: boolean;
   vectorStatus?: VectorStatus;
   jobStats?: EmbeddingJobStats;
   busyAction: string | null;
@@ -20,6 +21,7 @@ interface AIConfigAdvancedSettingsProps {
 
 export default function AIConfigAdvancedSettings({
   config,
+  hasUnsavedChanges,
   vectorStatus,
   jobStats,
   busyAction,
@@ -114,6 +116,7 @@ export default function AIConfigAdvancedSettings({
         />
 
         <AIIndexingActions
+          hasUnsavedChanges={hasUnsavedChanges}
           batchSize={config.indexing?.batchSize || 5}
           busyAction={busyAction}
           jobStats={jobStats}

--- a/web/src/pages/admin/components/AIConfigProviderForm.tsx
+++ b/web/src/pages/admin/components/AIConfigProviderForm.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+import { formatEmbeddingError } from './embeddingErrors';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -12,11 +14,11 @@ import { post } from '@/utils/api';
 import { Brain, Copy, Database, Terminal } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
-import type { AiProviderConfig, AiProviderPreset, SystemConfig } from '../types';
+import type { AiProviderConfig, AiProviderPreset, SystemConfig, EmbeddingOutput } from '../types';
 
 type AiConfig = NonNullable<SystemConfig['ai']>;
 type ProviderTarget = 'chat' | 'embedding';
-type ProviderPatch = Partial<AiProviderConfig & { dimensions?: number }>;
+type ProviderPatch = Partial<AiProviderConfig & { output: EmbeddingOutput }>;
 
 const LOCAL_LLAMA_COMMAND =
   'llama-server --hf-repo google/gemma-4-12B-it-qat-q4_0-gguf:Q4_0 --host 127.0.0.1 --port 8080 --alias gemma-4-12b-it';
@@ -28,7 +30,6 @@ interface AIConfigProviderFormProps {
   busyAction: string | null;
   updateProvider: (target: ProviderTarget, next: ProviderPatch) => void;
   applyPreset: (target: ProviderTarget, providerId: string) => void;
-  runAction: (key: string, action: () => Promise<any>, success: string) => Promise<void>;
 }
 
 export default function AIConfigProviderForm({
@@ -38,10 +39,30 @@ export default function AIConfigProviderForm({
   busyAction,
   updateProvider,
   applyPreset,
-  runAction,
 }: AIConfigProviderFormProps) {
   const { t } = useTranslation('translation', { keyPrefix: 'pages.admin' });
   const provider = target === 'chat' ? config.chat : config.embedding;
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<{ signature: string; dimensions: number } | null>(
+    null
+  );
+  const signature = JSON.stringify(provider);
+  const detectedDimensions = testResult?.signature === signature ? testResult.dimensions : null;
+  const testProvider = async () => {
+    setTesting(true);
+    setTestResult(null);
+    try {
+      const res = await post('/ai/test', { target, config });
+      if (target === 'embedding') setTestResult({ signature, dimensions: res.data.dimensions });
+      toast.success(t('ai.testSuccess'));
+    } catch (error) {
+      toast.error(
+        formatEmbeddingError(error, t) || (error instanceof Error ? error.message : t('saveError'))
+      );
+    } finally {
+      setTesting(false);
+    }
+  };
   const capability = target === 'chat' ? 'chat' : 'embedding';
   const availableProviders = providers.filter((item) => item.capabilities.includes(capability));
   const showLlamaCppTip = target === 'chat' && provider?.providerId === 'llama-cpp';
@@ -68,16 +89,10 @@ export default function AIConfigProviderForm({
           type="button"
           variant="outline"
           size="sm"
-          disabled={busyAction === `test-${target}`}
-          onClick={() =>
-            runAction(
-              `test-${target}`,
-              () => post('/ai/test', { target, config }),
-              t('ai.testSuccess')
-            )
-          }
+          disabled={testing || busyAction !== null}
+          onClick={testProvider}
         >
-          {busyAction === `test-${target}` ? t('ai.testing') : t('ai.test')}
+          {testing ? t('ai.testing') : t('ai.test')}
         </Button>
       </div>
 
@@ -152,16 +167,49 @@ export default function AIConfigProviderForm({
           </div>
           {target === 'embedding' && (
             <div className="space-y-2">
-              <Label>{t('ai.dimensions')}</Label>
-              <Input
-                type="number"
-                min="1"
-                max="4000"
-                value={config.embedding?.dimensions || 1536}
-                onChange={(event) =>
-                  updateProvider('embedding', { dimensions: Number(event.target.value) || 1536 })
+              <Label htmlFor="embedding-output-mode">{t('ai.outputMode')}</Label>
+              <Select
+                value={config.embedding?.output.mode || 'native'}
+                onValueChange={(mode) =>
+                  updateProvider('embedding', {
+                    output:
+                      mode === 'native'
+                        ? { mode: 'native' }
+                        : { mode: 'dimensions', dimensions: detectedDimensions || 0 },
+                  })
                 }
-              />
+              >
+                <SelectTrigger id="embedding-output-mode" className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="native">{t('ai.nativeDimensions')}</SelectItem>
+                  <SelectItem value="dimensions">{t('ai.requestedDimensions')}</SelectItem>
+                </SelectContent>
+              </Select>
+              {config.embedding?.output.mode === 'dimensions' && (
+                <>
+                  <Label htmlFor="embedding-dimensions">{t('ai.dimensions')}</Label>
+                  <Input
+                    id="embedding-dimensions"
+                    type="number"
+                    min="1"
+                    max="2000"
+                    step="1"
+                    value={config.embedding.output.dimensions || ''}
+                    onChange={(event) =>
+                      updateProvider('embedding', {
+                        output: { mode: 'dimensions', dimensions: Number(event.target.value) },
+                      })
+                    }
+                  />
+                </>
+              )}
+              <p className="text-muted-foreground text-xs" role="status">
+                {detectedDimensions
+                  ? t('ai.detectedDimensions', { dimensions: detectedDimensions })
+                  : t('ai.dimensionTestRequired')}
+              </p>
             </div>
           )}
         </div>

--- a/web/src/pages/admin/components/AIConfigTab.tsx
+++ b/web/src/pages/admin/components/AIConfigTab.tsx
@@ -1,3 +1,4 @@
+import { formatEmbeddingError } from './embeddingErrors';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import Divider from '@/components/ui/divider';
@@ -14,35 +15,6 @@ import AIConfigAdvancedSettings from './AIConfigAdvancedSettings';
 import AIConfigProviderForm from './AIConfigProviderForm';
 import type { EmbeddingJobStats, VectorStatus } from './AIIndexingStatus';
 
-const DEFAULT_AI_CONFIG: NonNullable<SystemConfig['ai']> = {
-  enabled: false,
-  vectorEnabled: false,
-  autoIndexEnabled: false,
-  publicExploreVectorEnabled: false,
-  chat: {
-    providerId: 'openai',
-    apiFormat: 'openai_compatible',
-    baseUrl: 'https://api.openai.com/v1',
-    model: 'gpt-4.1-mini',
-    apiKey: '',
-  },
-  embedding: {
-    providerId: 'openai',
-    apiFormat: 'openai_compatible',
-    baseUrl: 'https://api.openai.com/v1',
-    model: 'text-embedding-3-small',
-    dimensions: 1536,
-    apiKey: '',
-  },
-  indexing: {
-    chunkSize: 1800,
-    chunkOverlap: 200,
-    batchSize: 5,
-    maxRetries: 3,
-    paused: false,
-  },
-};
-
 interface AIConfigTabProps {
   aiConfig: SystemConfig['ai'] | undefined;
   setAiConfig: (config: SystemConfig['ai'] | undefined) => void;
@@ -51,19 +23,22 @@ interface AIConfigTabProps {
   onMutate: () => void;
 }
 
-function mergeAiConfig(config?: SystemConfig['ai']): NonNullable<SystemConfig['ai']> {
-  const chat = { ...DEFAULT_AI_CONFIG.chat, ...(config?.chat || {}) } as AiProviderConfig;
+function mergeAiConfig(
+  config: SystemConfig['ai'],
+  defaults: NonNullable<SystemConfig['ai']>
+): NonNullable<SystemConfig['ai']> {
+  const chat = { ...defaults.chat, ...(config?.chat || {}) } as AiProviderConfig;
   const embedding = {
-    ...DEFAULT_AI_CONFIG.embedding,
+    ...defaults.embedding,
     ...(config?.embedding || {}),
   } as NonNullable<SystemConfig['ai']>['embedding'];
 
   return {
-    ...DEFAULT_AI_CONFIG,
+    ...defaults,
     ...(config || {}),
     chat,
     embedding,
-    indexing: { ...DEFAULT_AI_CONFIG.indexing, ...(config?.indexing || {}) },
+    indexing: { ...defaults.indexing, ...(config?.indexing || {}) },
   };
 }
 
@@ -90,17 +65,36 @@ function MetricBlock({ label, value }: { label: string; value: string | number }
   );
 }
 
-export default function AIConfigTab({
+export default function AIConfigTab(props: AIConfigTabProps) {
+  const { t } = useTranslation();
+  const { data: defaults } = useSWR(
+    '/ai/defaults',
+    async () => (await get('/ai/defaults')).data as NonNullable<SystemConfig['ai']>
+  );
+  if (!defaults && !props.aiConfig) return <p>{t('pages.admin.ai.testing')}</p>;
+  return <AIConfigEditor {...props} defaults={defaults || props.aiConfig!} />;
+}
+
+function AIConfigEditor({
+  defaults,
   aiConfig,
   setAiConfig,
   isSaving,
   setIsSaving,
   onMutate,
-}: AIConfigTabProps) {
+}: AIConfigTabProps & { defaults: NonNullable<SystemConfig['ai']> }) {
   const { t } = useTranslation('translation', { keyPrefix: 'pages.admin' });
   const { mutate: mutateGlobal } = useSWRConfig();
   const [busyAction, setBusyAction] = useState<string | null>(null);
-  const config = useMemo(() => mergeAiConfig(aiConfig), [aiConfig]);
+  const config = useMemo(() => mergeAiConfig(aiConfig, defaults), [aiConfig, defaults]);
+
+  const { data: savedAi, mutate: mutateSavedAi } = useSWR(
+    '/admin/settings?group=ai',
+    async () =>
+      (await get('/admin/settings?group=ai')).data as { config: NonNullable<SystemConfig['ai']> }
+  );
+  const hasUnsavedChanges =
+    !savedAi || JSON.stringify(config) !== JSON.stringify(mergeAiConfig(savedAi.config, defaults));
 
   const { data: providers = [] } = useSWR<AiProviderPreset[]>('/ai/providers', async () => {
     const res = await get('/ai/providers');
@@ -111,26 +105,26 @@ export default function AIConfigTab({
     async () => {
       const res = await get('/ai/vector/status');
       return res.data;
-    }
+    },
+    { refreshInterval: 3000 }
   );
   const { data: jobStats, mutate: mutateJobStats } = useSWR<EmbeddingJobStats>(
     '/ai/index/stats',
     async () => {
       const res = await get('/ai/index/stats');
       return res.data;
-    }
+    },
+    { refreshInterval: 3000 }
   );
-  const isVectorReady = Boolean(
-    vectorStatus?.available && vectorStatus.installed && vectorStatus.indexName
-  );
+  const isVectorReady = Boolean(vectorStatus?.ready);
 
   const updateConfig = (next: Partial<NonNullable<SystemConfig['ai']>>) => {
-    setAiConfig(mergeAiConfig({ ...config, ...next }));
+    setAiConfig(mergeAiConfig({ ...config, ...next }, defaults));
   };
 
   const updateProvider = (
     target: 'chat' | 'embedding',
-    next: Partial<AiProviderConfig & { dimensions?: number }>
+    next: Partial<AiProviderConfig & { output: import('../types').EmbeddingOutput }>
   ) => {
     updateConfig({
       [target]: {
@@ -152,16 +146,19 @@ export default function AIConfigTab({
       baseUrl: preset.baseUrl,
       model,
       apiKey: '',
+      ...(target === 'embedding' ? { output: { mode: 'native' as const } } : {}),
     });
   };
 
   const handleSave = async () => {
     setIsSaving(true);
     try {
-      await put('/admin/settings', {
+      const res = await put('/admin/settings', {
         group: 'ai',
         config,
       });
+      setAiConfig(res.data.config);
+      await mutateSavedAi();
       toast.success(t('saveSuccess'));
       await Promise.all([Promise.resolve(onMutate()), mutateGlobal('site-status')]);
     } catch (error: any) {
@@ -170,7 +167,7 @@ export default function AIConfigTab({
         error?.message ||
         error?.response?.data?.error ||
         'Unknown error';
-      toast.error(t('saveFailed', { error: errorMessage }));
+      toast.error(t('saveFailed', { error: formatEmbeddingError(error, t) || errorMessage }));
     } finally {
       setIsSaving(false);
     }
@@ -179,16 +176,22 @@ export default function AIConfigTab({
   const runAction = async (key: string, action: () => Promise<any>, success: string) => {
     setBusyAction(key);
     try {
-      const res = await action();
-      toast.success(res?.message || success);
+      await action();
+      toast.success(success);
       await Promise.all([
         mutateVectorStatus(),
+        mutateSavedAi(),
         mutateJobStats(),
         Promise.resolve(onMutate()),
         mutateGlobal('site-status'),
       ]);
     } catch (error: any) {
-      toast.error(error?.response?.data?.message || error?.message || 'Unknown error');
+      toast.error(
+        formatEmbeddingError(error, t) ||
+          error?.response?.data?.message ||
+          error?.message ||
+          t('ai.embeddingErrors.embedding_job_failed')
+      );
     } finally {
       setBusyAction(null);
     }
@@ -281,7 +284,6 @@ export default function AIConfigTab({
               busyAction={busyAction}
               updateProvider={updateProvider}
               applyPreset={applyPreset}
-              runAction={runAction}
             />
             <AIConfigProviderForm
               target="embedding"
@@ -290,13 +292,13 @@ export default function AIConfigTab({
               busyAction={busyAction}
               updateProvider={updateProvider}
               applyPreset={applyPreset}
-              runAction={runAction}
             />
           </div>
         </section>
 
         <AIConfigAdvancedSettings
           config={config}
+          hasUnsavedChanges={hasUnsavedChanges}
           vectorStatus={vectorStatus}
           jobStats={jobStats}
           busyAction={busyAction}

--- a/web/src/pages/admin/components/AIIndexingActions.test.tsx
+++ b/web/src/pages/admin/components/AIIndexingActions.test.tsx
@@ -5,6 +5,12 @@ import type { EmbeddingJobStats, VectorStatus } from './AIIndexingStatus';
 
 const readyVector: VectorStatus = {
   available: true,
+  ready: true,
+  status: 'ready',
+  revision: 1,
+  generationId: 'test-generation',
+  errorCode: null,
+  scanComplete: true,
   dimensions: 1536,
   indexName: 'document_embeddings_embedding_hnsw_1536_idx',
   installed: true,

--- a/web/src/pages/admin/components/AIIndexingActions.tsx
+++ b/web/src/pages/admin/components/AIIndexingActions.tsx
@@ -1,3 +1,4 @@
+import EmbeddingRebuildButton from './EmbeddingRebuildButton';
 import { Button } from '@/components/ui/button';
 import { post } from '@/utils/api';
 import { Database, LoaderCircle, Pause, Play, RefreshCw, Trash2 } from 'lucide-react';
@@ -6,6 +7,7 @@ import { useTranslation } from 'react-i18next';
 import type { EmbeddingJobStats, VectorStatus } from './AIIndexingStatus';
 
 interface AIIndexingActionsProps {
+  hasUnsavedChanges?: boolean;
   batchSize: number;
   busyAction: string | null;
   jobStats?: EmbeddingJobStats;
@@ -19,6 +21,7 @@ function ActionIcon({ active, children }: { active: boolean; children: ReactNode
 }
 
 export default function AIIndexingActions({
+  hasUnsavedChanges = false,
   batchSize,
   busyAction,
   jobStats,
@@ -29,8 +32,14 @@ export default function AIIndexingActions({
   const { t } = useTranslation('translation', { keyPrefix: 'pages.admin.ai' });
   const isBusy = busyAction !== null;
   const isVectorReady = Boolean(
-    vectorStatus?.available && vectorStatus.installed && vectorStatus.indexName
+    vectorStatus?.available && vectorStatus.installed && vectorStatus.ready
   );
+  const canProcess = Boolean(
+    vectorStatus?.installed &&
+    vectorStatus.generationId &&
+    ['ready', 'rebuilding', 'failed'].includes(vectorStatus.status)
+  );
+  const showRebuild = Boolean(vectorStatus?.installed && vectorStatus.status !== 'rebuilding');
   const pendingJobs = jobStats?.pending || 0;
   const failedJobs = jobStats?.failed || 0;
   const totalJobs = jobStats
@@ -38,12 +47,12 @@ export default function AIIndexingActions({
     : 0;
   const processBatchSize = Math.min(pendingJobs, Math.max(batchSize, 1));
 
-  const showSetup = Boolean(vectorStatus?.available && !isVectorReady);
-  const showResume = isVectorReady && paused;
-  const showRetry = isVectorReady && failedJobs > 0;
-  const showProcess = isVectorReady && !paused && pendingJobs > 0;
-  const showRecommendedActions = showSetup || showResume || showRetry || showProcess;
-  const showMaintenanceActions = isVectorReady || totalJobs > 0;
+  const showSetup = Boolean(vectorStatus?.available && !vectorStatus.installed);
+  const showResume = canProcess && paused;
+  const showRetry = canProcess && failedJobs > 0;
+  const showProcess = canProcess && vectorStatus?.status !== 'failed' && !paused && pendingJobs > 0;
+  const showRecommendedActions = showSetup || showResume || showRetry || showProcess || showRebuild;
+  const showMaintenanceActions = canProcess || totalJobs > 0;
 
   if (!showRecommendedActions && !showMaintenanceActions) return null;
 
@@ -53,6 +62,16 @@ export default function AIIndexingActions({
         <section className="space-y-2">
           <h3 className="text-sm font-medium">{t('recommendedActions')}</h3>
           <div className="flex flex-wrap gap-2">
+            {showRebuild && vectorStatus && (
+              <EmbeddingRebuildButton
+                disabled={isBusy || hasUnsavedChanges}
+                revision={vectorStatus.revision}
+                runAction={runAction}
+              />
+            )}
+            {showRebuild && hasUnsavedChanges && (
+              <p className="text-muted-foreground w-full text-xs">{t('saveBeforeRebuild')}</p>
+            )}
             {showSetup && (
               <Button
                 type="button"
@@ -135,7 +154,7 @@ export default function AIIndexingActions({
               </Button>
             )}
 
-            {isVectorReady && !paused && (
+            {canProcess && !paused && (
               <Button
                 type="button"
                 variant="outline"

--- a/web/src/pages/admin/components/AIIndexingStatus.tsx
+++ b/web/src/pages/admin/components/AIIndexingStatus.tsx
@@ -16,7 +16,14 @@ export interface VectorStatus {
   installed: boolean;
   version: string | null;
   indexName: string | null;
-  dimensions: number;
+  dimensions: number | null;
+  ready: boolean;
+  status: 'needs_validation' | 'needs_rebuild' | 'rebuilding' | 'ready' | 'failed';
+  revision: number;
+  generationId: string | null;
+  scanComplete: boolean;
+  errorCode: string | null;
+  errorDetails?: Record<string, string | number> | null;
 }
 
 export interface EmbeddingJobStats {
@@ -96,9 +103,7 @@ export default function AIIndexingStatus({
   jobStats,
 }: AIIndexingStatusProps) {
   const { t } = useTranslation('translation', { keyPrefix: 'pages.admin.ai.indexingStatus' });
-  const isVectorReady = Boolean(
-    vectorStatus?.available && vectorStatus.installed && vectorStatus.indexName
-  );
+  const isVectorReady = Boolean(vectorStatus?.ready);
   const stats = {
     pending: jobStats?.pending || 0,
     running: jobStats?.running || 0,
@@ -130,6 +135,13 @@ export default function AIIndexingStatus({
       tone: 'warning',
     };
   }
+
+  if (vectorStatus?.installed && !isVectorReady)
+    vectorSummary = {
+      description: t(`lifecycle.${vectorStatus.status}Description`),
+      label: t(`lifecycle.${vectorStatus.status}`),
+      tone: vectorStatus.status === 'failed' ? 'danger' : 'warning',
+    };
 
   let queueSummary = {
     description: t('checkingDescription'),
@@ -195,6 +207,20 @@ export default function AIIndexingStatus({
           <StatusBadge tone={vectorSummary.tone}>{vectorSummary.label}</StatusBadge>
         </div>
 
+        {vectorStatus?.errorCode && (
+          <p className="text-destructive mt-3 text-xs" role="alert">
+            {t(`pages.admin.ai.embeddingErrors.${vectorStatus.errorCode}`, {
+              keyPrefix: '',
+              ...(vectorStatus.errorDetails || {}),
+              defaultValue: t('lifecycle.failedDescription'),
+            })}
+          </p>
+        )}
+        {vectorStatus?.status === 'rebuilding' && (
+          <p className="text-muted-foreground mt-3 text-xs">
+            {t(vectorStatus.scanComplete ? 'scanComplete' : 'scanning')}
+          </p>
+        )}
         {vectorStatus ? (
           <div className="mt-4 divide-y rounded-md border px-3 py-2">
             <ReadinessRow label={t('extensionAvailable')} ready={vectorStatus.available} />
@@ -211,7 +237,9 @@ export default function AIIndexingStatus({
         {vectorStatus && (
           <div className="text-muted-foreground mt-3 flex flex-wrap gap-x-3 gap-y-1 text-xs">
             {vectorStatus.version && <span>{t('version', { version: vectorStatus.version })}</span>}
-            <span>{t('dimensions', { dimensions: vectorStatus.dimensions })}</span>
+            {vectorStatus.dimensions !== null && (
+              <span>{t('dimensions', { dimensions: vectorStatus.dimensions })}</span>
+            )}
           </div>
         )}
         {vectorStatus?.indexName && (

--- a/web/src/pages/admin/components/EmbeddingConfig.test.tsx
+++ b/web/src/pages/admin/components/EmbeddingConfig.test.tsx
@@ -1,0 +1,88 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import AIConfigProviderForm from './AIConfigProviderForm';
+import EmbeddingRebuildButton from './EmbeddingRebuildButton';
+import type { SystemConfig } from '../types';
+import { post } from '@/utils/api';
+
+vi.mock('@/utils/api', () => ({ post: vi.fn() }));
+const config: NonNullable<SystemConfig['ai']> = {
+  schemaVersion: 2,
+  revision: 1,
+  enabled: true,
+  vectorEnabled: true,
+  embedding: {
+    providerId: 'siliconflow',
+    baseUrl: 'https://api.siliconflow.cn/v1',
+    model: 'BAAI/bge-m3',
+    output: { mode: 'native' },
+  },
+};
+function form(next = config) {
+  return (
+    <AIConfigProviderForm
+      target="embedding"
+      config={next}
+      providers={[]}
+      busyAction={null}
+      updateProvider={vi.fn()}
+      applyPreset={vi.fn()}
+    />
+  );
+}
+beforeEach(() => {
+  vi.mocked(post).mockReset();
+});
+describe('embedding configuration', () => {
+  it('does not show an editable dimension for native models, and invalidates results after edits', async () => {
+    vi.mocked(post).mockResolvedValue({ data: { dimensions: 1024 } });
+    const view = render(form());
+    expect(screen.queryByRole('spinbutton')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'ai.test' }));
+    await waitFor(() =>
+      expect(screen.getByRole('status')).toHaveTextContent('ai.detectedDimensions')
+    );
+    expect(post).toHaveBeenCalledWith('/ai/test', { target: 'embedding', config });
+    view.rerender(form({ ...config, embedding: { ...config.embedding!, model: 'different' } }));
+    expect(screen.getByRole('status')).toHaveTextContent('ai.dimensionTestRequired');
+  });
+  it('bounds requested dimensions using the storage contract', () => {
+    render(
+      form({
+        ...config,
+        embedding: { ...config.embedding!, output: { mode: 'dimensions', dimensions: 1024 } },
+      })
+    );
+    expect(screen.getByRole('spinbutton')).toHaveAttribute('max', '2000');
+    expect(screen.getByRole('spinbutton')).toHaveAttribute('min', '1');
+    expect(screen.getByRole('spinbutton')).toHaveValue(1024);
+  });
+  it('ignores a successful test for configuration edited while the test was pending', async () => {
+    let resolve!: (value: { data: { dimensions: number } }) => void;
+    vi.mocked(post).mockReturnValue(
+      new Promise((done) => {
+        resolve = done;
+      })
+    );
+    const view = render(form());
+    fireEvent.click(screen.getByRole('button', { name: 'ai.test' }));
+    view.rerender(
+      form({ ...config, embedding: { ...config.embedding!, baseUrl: 'https://other.test/v1' } })
+    );
+    resolve({ data: { dimensions: 1024 } });
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ai.test' })).toBeEnabled());
+    expect(screen.getByRole('status')).toHaveTextContent('ai.dimensionTestRequired');
+  });
+  it('requires an explicit rebuild action with its configuration revision', async () => {
+    vi.mocked(post).mockResolvedValue({ data: { status: 'rebuilding' } });
+    const runAction = vi.fn(async (_key, action) => {
+      await action();
+    });
+    render(<EmbeddingRebuildButton disabled={false} revision={7} runAction={runAction} />);
+    fireEvent.click(screen.getByRole('button', { name: 'rebuild' }));
+    expect(screen.getByText('rebuildConfirmation')).toBeVisible();
+    expect(post).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'rebuildConfirm' }));
+    await waitFor(() => expect(post).toHaveBeenCalledWith('/ai/index/rebuild', { revision: 7 }));
+  });
+});

--- a/web/src/pages/admin/components/EmbeddingRebuildButton.tsx
+++ b/web/src/pages/admin/components/EmbeddingRebuildButton.tsx
@@ -1,0 +1,61 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { post } from '@/utils/api';
+
+export default function EmbeddingRebuildButton({
+  disabled,
+  revision,
+  runAction,
+}: {
+  disabled: boolean;
+  revision: number;
+  runAction: (key: string, action: () => Promise<unknown>, success: string) => Promise<void>;
+}) {
+  const { t } = useTranslation('translation', { keyPrefix: 'pages.admin.ai' });
+  const [open, setOpen] = useState(false);
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button disabled={disabled}>{t('rebuild')}</Button>
+      </DialogTrigger>
+      <DialogContent closeLabel={t('rebuildCancel')}>
+        <DialogHeader>
+          <DialogTitle>{t('rebuild')}</DialogTitle>
+          <DialogDescription>{t('rebuildConfirmation')}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter className="flex-row gap-2">
+          <Button variant="outline" className="flex-1" onClick={() => setOpen(false)}>
+            {t('rebuildCancel')}
+          </Button>
+          <Button
+            className="flex-[2]"
+            disabled={disabled}
+            onClick={() =>
+              runAction(
+                'rebuild',
+                async () => {
+                  const result = await post('/ai/index/rebuild', { revision });
+                  setOpen(false);
+                  return result;
+                },
+                t('rebuildStarted')
+              )
+            }
+          >
+            {t('rebuildConfirm')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/pages/admin/components/embeddingErrors.ts
+++ b/web/src/pages/admin/components/embeddingErrors.ts
@@ -1,0 +1,16 @@
+import { isAxiosError } from 'axios';
+import type { TFunction } from 'i18next';
+
+export function formatEmbeddingError(
+  error: unknown,
+  t: TFunction<'translation', 'pages.admin'>
+): string | null {
+  if (!isAxiosError<{ message?: string; data?: Record<string, string | number> }>(error))
+    return null;
+  const message = error.response?.data?.message;
+  if (typeof message !== 'string' || !message.startsWith('embedding_')) return null;
+  return t(`ai.embeddingErrors.${message}`, {
+    ...(error.response?.data?.data || {}),
+    defaultValue: t('ai.embeddingErrors.embedding_job_failed'),
+  });
+}

--- a/web/src/pages/admin/types.ts
+++ b/web/src/pages/admin/types.ts
@@ -45,13 +45,15 @@ export interface SystemConfig {
     adminHooks?: AdminHooksConfig;
   };
   ai?: {
+    schemaVersion: 2;
+    revision: number;
     enabled?: boolean;
     vectorEnabled?: boolean;
     autoIndexEnabled?: boolean;
     publicExploreVectorEnabled?: boolean;
     chat?: AiProviderConfig;
     embedding?: AiProviderConfig & {
-      dimensions?: number;
+      output: EmbeddingOutput;
     };
     indexing?: {
       chunkSize?: number;
@@ -167,3 +169,5 @@ export interface DashboardStats {
     tokenUsage: number | string;
   }>;
 }
+
+export type EmbeddingOutput = { mode: 'native' } | { mode: 'dimensions'; dimensions: number };


### PR DESCRIPTION
## Description

Fixes #318.

Embedding requests now distinguish native output from an explicitly requested dimension. BGE-M3 and unlisted models use the native protocol without a `dimensions` parameter. Tests, indexing, and retrieval share response validation, including the full-precision pgvector limit of 1–2000 dimensions. Provider errors remain explicit; responses are never truncated, padded, or retried with altered parameters.

Configuration saves are verified on the server and use optimistic revisions. A persisted index lifecycle and generation isolate model changes from searchable vectors. Administrators explicitly start a resumable rebuild; vector search stays unavailable until scanning, jobs, and the generation’s HNSW index are ready. Lease tokens prevent stale workers from committing, source vectors are replaced atomically, and transactional source events capture edits across restarts. Key rotation validates credentials without rebuilding an unchanged vector contract.

The admin UI separates saving from rebuilding, shows output modes, detected dimensions, progress, and structured errors in Chinese, English, and Japanese. Chat provider behavior is unchanged.

## Type of Change

- [x] Breaking change: AI configuration schema v2 and explicit legacy index rebuild
- [x] Code refactoring
- [x] Documentation update

## Testing

- Frontend: 168 tests passed; lint and production build passed.
- Backend: 49 embedding/chat unit and runtime tests passed; lint and TypeScript build passed.
- Dedicated pgvector PostgreSQL: 14 integration tests passed, including real HNSW search at 2000 dimensions, database replacement rollback, revisions, generation isolation, transactional source events, expired leases, source changes/deletion, failure recovery, and empty rebuilds.
- Dedicated plain PostgreSQL: legacy migration passed, preserving old vectors and cancelling old tasks without installing pgvector or calling a model.
- Controllable local HTTP embedding service exercised the native/requested request contract. No real provider credentials were used.
- Browser checks at 320 px verified all three languages, output-mode changes, stale test results, rebuild confirmation, and edge/corner hit targets.
- Added contract and PostgreSQL matrix jobs to CI.

Reproduce with `bun run test` in `web/`; backend test commands and both disposable database setups are captured in `.github/workflows/ci.yml`. Existing Vite chunk-size/circular-chunk warnings remain.

## Checklist

- [x] Self-reviewed module ownership and concurrency paths
- [x] ESLint and builds passed in both packages
- [x] Regression tests and upgrade documentation added
- [x] Mobile layout and full visible hit targets checked

## Additional Notes

Upgrade: migrations 0030/0031 preserve historical vectors outside the active generation and pause legacy vector retrieval. An administrator must verify configuration, enable pgvector if needed, then explicitly approve the model usage cost and start rebuilding. No production upgrade or full rebuild is performed by merging this PR. See `doc/userguide/AI-VECTOR-MIGRATION.zh.md`.
