### PR TITLE
fix(ai): repair AI settings saves on legacy databases

### DIFF
--- a/doc/userguide/AI-VECTOR-MIGRATION.zh.md
+++ b/doc/userguide/AI-VECTOR-MIGRATION.zh.md
@@ -258,6 +258,14 @@ docker exec -i rote-postgres pg_restore -U rote -d rote --clean --if-exists < ro
 
 模型实际输出与指定维度或已验证维度不一致。请检查模型能力，选择默认输出或模型支持的指定维度，保存验证后明确启动重建。
 
+### 模型测试成功，但保存配置失败
+
+从 Prisma 时期保留的旧数据库可能缺少 `settings.updatedAt` 的数据库默认值。模型测试不写配置，因此可以成功；保存、暂停或恢复队列时，PostgreSQL 会在 upsert 冲突处理前因非空约束拒绝写入。
+
+正式迁移 `0032_settings_updated_at_default` 将该字段默认值补齐为 `now()`，与当前 Drizzle schema 一致，不重写已有配置或向量。更新后端并完成正常数据库迁移后即可再次保存，无需修改模型或清空数据库。该迁移不调用模型，也不启动索引重建。
+
+数据库写入失败时，接口返回 HTTP 500、非零 `code` 和 `embedding_settings_save_failed`，原配置及索引状态保持不变；`data.databaseCode` 和服务端日志中的 SQLSTATE 可用于定位故障，响应与日志不会包含这次配置写入的 SQL 参数。
+
 ### backfill 很慢
 
 存量笔记多、文章长、模型供应商速率限制较低时，重建会比较慢。可以保持站点正常使用，让后台 worker 处理；重建期间创建或编辑的内容会通过数据库变更事件进入任务队列，即使日常自动索引关闭。

--- a/server/drizzle/migrations/0032_settings_updated_at_default.sql
+++ b/server/drizzle/migrations/0032_settings_updated_at_default.sql
@@ -1,0 +1,5 @@
+-- The initial Drizzle baseline retained existing settings tables. Prisma-era
+-- updatedAt values were supplied by the client, so those tables have no SQL
+-- default. PostgreSQL checks NOT NULL before resolving an upsert conflict.
+-- Align the retained table with schema.ts without rewriting existing settings.
+ALTER TABLE "settings" ALTER COLUMN "updatedAt" SET DEFAULT now();

--- a/server/drizzle/migrations/meta/_journal.json
+++ b/server/drizzle/migrations/meta/_journal.json
@@ -225,6 +225,13 @@
       "when": 1788676603359,
       "tag": "0031_embedding_source_events",
       "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1788683900000,
+      "tag": "0032_settings_updated_at_default",
+      "breakpoints": true
     }
   ]
 }

--- a/server/embeddings/configStore.ts
+++ b/server/embeddings/configStore.ts
@@ -1,4 +1,5 @@
-import { eq } from 'drizzle-orm';
+import { DrizzleQueryError, eq } from 'drizzle-orm';
+import postgres from 'postgres';
 import { z } from 'zod';
 import { embeddingIndexState, settings } from '../drizzle/schema';
 import type { AiConfig } from '../types/config';
@@ -36,6 +37,19 @@ const configSchema = z.strictObject({
     paused: z.boolean().optional(),
   }),
 });
+function configurationWriteFailed(error: unknown): never {
+  if (error instanceof EmbeddingError) throw error;
+  const cause = error instanceof DrizzleQueryError ? error.cause : error;
+  const databaseCode = cause instanceof postgres.PostgresError ? cause.code : undefined;
+  // Query errors include configuration values and credentials; log metadata only.
+  // eslint-disable-next-line no-console -- Persistence failures need safe server diagnostics.
+  console.error('AI configuration transaction failed', { databaseCode });
+  throw new EmbeddingError(
+    'embedding_settings_save_failed',
+    500,
+    databaseCode ? { databaseCode } : {}
+  );
+}
 export async function readAiSnapshot(executor: EmbeddingExecutor = db) {
   const [row] = await executor
     .select({ config: settings.config, state: embeddingIndexState })
@@ -107,69 +121,76 @@ export async function saveAiSettings(incoming: Partial<AiConfig>): Promise<AiCon
     enabledNow && needsValidation ? await testEmbeddingProvider(next.embedding) : null;
   const invalidatesIndex =
     identityChanged || (verified !== null && verified.dimensions !== before.state.dimensions);
-  await db.transaction(async (tx) => {
-    const state = await lockIndexState(tx);
-    if (state.revision !== incoming.revision)
-      throw new EmbeddingError('embedding_revision_conflict', 409);
-    next.revision = state.revision + 1;
-    await tx
-      .insert(settings)
-      .values({
-        group: 'ai',
-        config: next,
-        isRequired: false,
-        isSystem: false,
-        isInitialized: true,
-      })
-      .onConflictDoUpdate({ target: settings.group, set: { config: next, updatedAt: new Date() } });
-    await tx
-      .update(embeddingIndexState)
-      .set({
-        revision: next.revision,
-        ...(verified
-          ? {
-              fingerprint,
-              dimensions: verified.dimensions,
-              validatedAt: new Date(),
-              errorCode: null,
-              errorDetails: null,
-              status:
-                invalidatesIndex || contractFailed || state.status === 'needs_validation'
-                  ? ('needs_rebuild' as const)
-                  : state.status,
-            }
-          : needsValidation
+  await db
+    .transaction(async (tx) => {
+      const state = await lockIndexState(tx);
+      if (state.revision !== incoming.revision)
+        throw new EmbeddingError('embedding_revision_conflict', 409);
+      next.revision = state.revision + 1;
+      await tx
+        .insert(settings)
+        .values({
+          group: 'ai',
+          config: next,
+          isRequired: false,
+          isSystem: false,
+          isInitialized: true,
+        })
+        .onConflictDoUpdate({
+          target: settings.group,
+          set: { config: next, updatedAt: new Date() },
+        });
+      await tx
+        .update(embeddingIndexState)
+        .set({
+          revision: next.revision,
+          ...(verified
             ? {
-                fingerprint: null,
-                dimensions: null,
-                status: 'needs_validation' as const,
-                validatedAt: null,
+                fingerprint,
+                dimensions: verified.dimensions,
+                validatedAt: new Date(),
                 errorCode: null,
                 errorDetails: null,
+                status:
+                  invalidatesIndex || contractFailed || state.status === 'needs_validation'
+                    ? ('needs_rebuild' as const)
+                    : state.status,
               }
-            : {}),
-        updatedAt: new Date(),
-      })
-      .where(eq(embeddingIndexState.id, 1));
-  });
+            : needsValidation
+              ? {
+                  fingerprint: null,
+                  dimensions: null,
+                  status: 'needs_validation' as const,
+                  validatedAt: null,
+                  errorCode: null,
+                  errorDetails: null,
+                }
+              : {}),
+          updatedAt: new Date(),
+        })
+        .where(eq(embeddingIndexState.id, 1));
+    })
+    .catch(configurationWriteFailed);
   await refreshConfigCache();
   return next;
 }
 export async function setIndexingPaused(paused: boolean): Promise<AiConfig> {
-  await db.transaction(async (tx) => {
-    await lockIndexState(tx);
-    const { config } = await readAiSnapshot(tx);
-    config.indexing.paused = paused;
-    config.revision += 1;
-    await tx
-      .insert(settings)
-      .values({ group: 'ai', config, isInitialized: true })
-      .onConflictDoUpdate({ target: settings.group, set: { config, updatedAt: new Date() } });
-    await tx
-      .update(embeddingIndexState)
-      .set({ revision: config.revision, updatedAt: new Date() })
-      .where(eq(embeddingIndexState.id, 1));
-  });
+  await db
+    .transaction(async (tx) => {
+      await lockIndexState(tx);
+      const { config } = await readAiSnapshot(tx);
+      config.indexing.paused = paused;
+      config.revision += 1;
+      await tx
+        .insert(settings)
+        .values({ group: 'ai', config, isInitialized: true })
+        .onConflictDoUpdate({ target: settings.group, set: { config, updatedAt: new Date() } });
+      await tx
+        .update(embeddingIndexState)
+        .set({ revision: config.revision, updatedAt: new Date() })
+        .where(eq(embeddingIndexState.id, 1));
+    })
+    .catch(configurationWriteFailed);
   await refreshConfigCache();
   return getStoredAiConfig();
 }

--- a/server/embeddings/errors.ts
+++ b/server/embeddings/errors.ts
@@ -1,7 +1,7 @@
 export class EmbeddingError extends Error {
   constructor(
     public readonly code: string,
-    public readonly status: 400 | 409 | 422 | 502 | 503 | 504 = 422,
+    public readonly status: 400 | 409 | 422 | 500 | 502 | 503 | 504 = 422,
     public readonly details: Record<string, string | number> = {},
     public readonly retryable = false
   ) {

--- a/server/embeddings/migration.test.ts
+++ b/server/embeddings/migration.test.ts
@@ -1,10 +1,13 @@
-import { expect, it } from 'bun:test';
+import { expect, it, spyOn } from 'bun:test';
+import { Hono } from 'hono';
 import { cpSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import postgres from 'postgres';
 import { drizzle } from 'drizzle-orm/postgres-js';
 import { migrate } from 'drizzle-orm/postgres-js/migrator';
+import type { HonoVariables } from '../types/hono';
+import { DEFAULT_AI_CONFIG } from '../utils/ai/providers';
 
 it('migrates a legacy database without pgvector, retaining configuration and vectors', async () => {
   const url = process.env.POSTGRESQL_URL;
@@ -12,6 +15,16 @@ it('migrates a legacy database without pgvector, retaining configuration and vec
     throw new Error('Use an empty legacy_embedding_test database');
   const client = postgres(url, { max: 1 });
   const folder = mkdtempSync(join(tmpdir(), 'rote-embedding-migrations-'));
+  const log = spyOn(console, 'error').mockImplementation(() => {});
+  const modelRequests: Record<string, unknown>[] = [];
+  const model = Bun.serve({
+    port: 0,
+    async fetch(request) {
+      modelRequests.push(await request.json());
+      return Response.json({ data: [{ embedding: Array(1024).fill(0.1) }] });
+    },
+  });
+  let closeDatabase: (() => Promise<void>) | undefined;
   try {
     const [tables] =
       await client`SELECT count(*)::int AS count FROM information_schema.tables WHERE table_schema = 'public'`;
@@ -20,8 +33,15 @@ it('migrates a legacy database without pgvector, retaining configuration and vec
     cpSync(migrationFolder, folder, { recursive: true });
     const journalPath = join(folder, 'meta/_journal.json');
     const journal = JSON.parse(readFileSync(journalPath, 'utf8'));
-    journal.entries = journal.entries.filter((entry: { idx: number }) => entry.idx < 30);
-    writeFileSync(journalPath, JSON.stringify(journal));
+    const selectMigrations = (before: number) =>
+      writeFileSync(
+        journalPath,
+        JSON.stringify({
+          ...journal,
+          entries: journal.entries.filter((entry: { idx: number }) => entry.idx < before),
+        })
+      );
+    selectMigrations(30);
     await migrate(drizzle(client), { migrationsFolder: folder });
     const ownerId = '13180000-0000-4000-8000-000000000011';
     const sourceId = '13180000-0000-4000-8000-000000000012';
@@ -36,13 +56,18 @@ it('migrates a legacy database without pgvector, retaining configuration and vec
         dimensions: 1024,
       },
     };
-    await client`INSERT INTO users (id, email, username) VALUES (${ownerId}, 'legacy@example.test', 'legacy-embedding')`;
+    await client`INSERT INTO users (id, email, username, role) VALUES (${ownerId}, 'legacy@example.test', 'legacy-embedding', 'admin')`;
     await client`INSERT INTO settings ("group", config) VALUES ('ai', ${JSON.stringify(oldConfig)}::jsonb)`;
+    await client`INSERT INTO settings ("group", config) VALUES ('security', ${JSON.stringify({ jwtSecret: 'isolated-migration-test-secret', jwtAccessExpiry: '5m' })}::jsonb)`;
+    // Existing Prisma-era tables were retained by the CREATE TABLE IF NOT EXISTS baseline.
+    await client`ALTER TABLE settings ALTER COLUMN "updatedAt" DROP DEFAULT`;
+    const [originalSetting] = await client`SELECT * FROM settings WHERE "group" = 'ai'`;
     const vector = JSON.stringify(Array(1024).fill(0.1));
     await client`INSERT INTO document_embeddings ("ownerId", "sourceType", "sourceId", "chunkIndex", "contentHash", "embeddingModel", "embeddingDimensions", embedding, text)
       VALUES (${ownerId}, 'rote', ${sourceId}, 0, 'old-hash', 'BAAI/bge-m3', 1024, ${vector}, 'legacy content')`;
     await client`INSERT INTO embedding_jobs ("ownerId", "sourceType", "sourceId", status) VALUES (${ownerId}, 'rote', ${sourceId}, 'running')`;
-    await migrate(drizzle(client), { migrationsFolder: migrationFolder });
+    selectMigrations(32);
+    await migrate(drizzle(client), { migrationsFolder: folder });
     const [setting] = await client`SELECT config FROM settings WHERE "group" = 'ai'`;
     expect(setting.config.schemaVersion).toBe(2);
     expect(setting.config.embedding.output).toEqual({ mode: 'dimensions', dimensions: 1024 });
@@ -57,9 +82,110 @@ it('migrates a legacy database without pgvector, retaining configuration and vec
     expect(state.status).toBe('needs_validation');
     expect(state.dimensions).toBeNull();
     expect(await client`SELECT 1 FROM pg_extension WHERE extname = 'vector'`).toHaveLength(0);
+
+    const database = await import('../utils/drizzle');
+    closeDatabase = database.closeDatabase;
+    const { refreshConfigCache } = await import('../utils/config');
+    const { generateAccessToken } = await import('../utils/jwt');
+    const { default: adminRouter } = await import('../route/v2/admin');
+    const { registerAdminAiRoutes } = await import('../route/v2/aiAdmin');
+    const { errorHandler } = await import('../utils/handlers');
+    await refreshConfigCache();
+    const app = new Hono<{ Variables: HonoVariables }>();
+    const ai = new Hono<{ Variables: HonoVariables }>();
+    registerAdminAiRoutes(ai);
+    app.route('/admin', adminRouter);
+    app.route('/ai', ai);
+    app.onError(errorHandler);
+    const token = await generateAccessToken({ userId: ownerId, username: 'legacy-embedding' });
+    const request = (path: string, method: string, body?: unknown) =>
+      app.request(path, {
+        method,
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: body === undefined ? undefined : JSON.stringify(body),
+      });
+    const incoming = {
+      ...structuredClone(DEFAULT_AI_CONFIG),
+      enabled: true,
+      vectorEnabled: true,
+      embedding: {
+        ...DEFAULT_AI_CONFIG.embedding,
+        providerId: 'siliconflow',
+        baseUrl: `http://127.0.0.1:${model.port}/v1`,
+        model: 'BAAI/bge-m3',
+        apiKey: 'migration-placeholder',
+      },
+    };
+    const probe = await request('/ai/test', 'POST', { target: 'embedding', config: incoming });
+    expect(probe.status).toBe(200);
+    expect((await probe.json()).data).toMatchObject({
+      dimensions: 1024,
+      output: { mode: 'native' },
+    });
+    expect(modelRequests[0]).not.toHaveProperty('dimensions');
+    // The provider works, but the legacy NOT NULL column rejects the upsert before conflict handling.
+    for (const [path, method, body] of [
+      ['/admin/settings', 'PUT', { group: 'ai', config: incoming }],
+      ['/ai/index/pause', 'POST', undefined],
+    ] as const) {
+      const failed = await request(path, method, body);
+      expect(failed.status).toBe(500);
+      expect(await failed.json()).toEqual({
+        code: 1,
+        message: 'embedding_settings_save_failed',
+        data: { databaseCode: '23502' },
+      });
+    }
+    expect(log.mock.calls).toHaveLength(2);
+    expect(JSON.stringify(log.mock.calls)).not.toContain('migration-placeholder');
+    expect((await client`SELECT config FROM settings WHERE "group" = 'ai'`)[0].config).toEqual(
+      setting.config
+    );
+    expect((await client`SELECT * FROM embedding_index_state`)[0]).toEqual(state);
+
+    await migrate(drizzle(client), { migrationsFolder: migrationFolder });
+    const saved = await request('/admin/settings', 'PUT', { group: 'ai', config: incoming });
+    expect(saved.status).toBe(200);
+    expect((await saved.json()).data.config).toMatchObject({
+      revision: 1,
+      embedding: { output: { mode: 'native' }, apiKey: '********' },
+    });
+    const [afterSave] = await client`SELECT * FROM settings WHERE "group" = 'ai'`;
+    expect(afterSave.id).toBe(originalSetting.id);
+    expect(afterSave.createdAt).toEqual(originalSetting.createdAt);
+    expect(new Date(afterSave.updatedAt).getTime()).toBeGreaterThan(
+      new Date(originalSetting.updatedAt).getTime()
+    );
+    expect((await client`SELECT * FROM embedding_index_state`)[0]).toMatchObject({
+      revision: 1,
+      status: 'needs_rebuild',
+      dimensions: 1024,
+      generationId: null,
+    });
+    expect(
+      (await request('/admin/settings', 'PUT', { group: 'ai', config: incoming })).status
+    ).toBe(409);
+    for (const action of ['pause', 'resume'])
+      expect((await request(`/ai/index/${action}`, 'POST')).status).toBe(200);
+    expect((await client`SELECT * FROM embedding_index_state`)[0].revision).toBe(3);
+    expect(await client`SELECT * FROM embedding_jobs WHERE status = 'pending'`).toHaveLength(0);
+    expect(await client`SELECT 1 FROM pg_extension WHERE extname = 'vector'`).toHaveLength(0);
     await migrate(drizzle(client), { migrationsFolder: migrationFolder });
     expect(await client`SELECT * FROM document_embeddings`).toHaveLength(1);
+    await client`DELETE FROM settings WHERE "group" = 'ai'`;
+    const inserted = await request('/admin/settings', 'PUT', {
+      group: 'ai',
+      config: { ...incoming, revision: 3 },
+    });
+    expect(inserted.status).toBe(200);
+    expect((await inserted.json()).data.config.revision).toBe(4);
+    expect(
+      (await client`SELECT "updatedAt" FROM settings WHERE "group" = 'ai'`)[0].updatedAt
+    ).not.toBeNull();
   } finally {
+    log.mockRestore();
+    model.stop(true);
+    await closeDatabase?.();
     await client.end();
     rmSync(folder, { recursive: true, force: true });
   }

--- a/server/route/v2/admin.ts
+++ b/server/route/v2/admin.ts
@@ -292,7 +292,7 @@ adminRouter.put('/settings', authenticateJWT, requireAdmin, async (c: HonoContex
   } catch (error: any) {
     if (error instanceof EmbeddingError) throw error;
     console.error('Failed to update settings:', error);
-    return c.json(createResponse(null, 'Failed to update settings'), 500);
+    return c.json(createResponse(null, 'Failed to update settings', 1), 500);
   }
 });
 

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1735,6 +1735,7 @@
           "embedding_disabled": "Enable AI and vector features and save the configuration first.",
           "embedding_input_empty": "Non-empty text is required.",
           "embedding_state_missing": "Index state is missing. Check database migrations.",
+          "embedding_settings_save_failed": "The database could not save the AI configuration. Previous settings were preserved. Check database migrations and server logs.",
           "embedding_lease_lost": "This job has been claimed by another worker.",
           "embedding_job_failed": "Embedding processing failed. Check the index status before retrying."
         }

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -1739,6 +1739,7 @@
           "embedding_disabled": "先に AI とベクトル機能を有効にして設定を保存してください。",
           "embedding_input_empty": "空でないテキストが必要です。",
           "embedding_state_missing": "索引の状態がありません。データベース移行を確認してください。",
+          "embedding_settings_save_failed": "AI 設定をデータベースに保存できませんでした。以前の設定は保持されています。データベース移行とサーバーログを確認してください。",
           "embedding_lease_lost": "このタスクは別のワーカーに引き継がれました。",
           "embedding_job_failed": "埋め込み処理に失敗しました。索引の状態を確認して再試行してください。"
         }

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1725,6 +1725,7 @@
           "embedding_disabled": "请先启用 AI 和向量功能并保存配置。",
           "embedding_input_empty": "需要提供非空文本。",
           "embedding_state_missing": "索引状态缺失，请检查数据库迁移。",
+          "embedding_settings_save_failed": "数据库未能保存 AI 配置，原配置已保留。请检查数据库迁移和服务端日志。",
           "embedding_lease_lost": "任务已由其他执行者接管。",
           "embedding_job_failed": "向量处理失败，请查看索引状态后重试。"
         }


### PR DESCRIPTION
Fixes AI configuration saving on existing databases where `settings.updatedAt` has no SQL default. Production returned PostgreSQL `23502` after a successful native BGE-M3 probe: the new upsert was rejected by the NOT NULL constraint before PostgreSQL could update the existing settings row.

Migration `0032_settings_updated_at_default` aligns the retained table with the existing Drizzle schema by setting its default to `now()`. Existing settings and vectors are preserved. Configuration and queue-control transaction failures now return a nonzero response code, a localized `embedding_settings_save_failed` message, and safe SQLSTATE diagnostics without logging configuration parameters.

Validation:
- Reproduced HTTP 500 before the migration in plain PostgreSQL with the legacy missing default and a controlled 1024-dimensional model server.
- Verified authenticated model testing, save and rollback, stale revision rejection, pause/resume, and first insertion after migration. Legacy vectors remain; no extension installation or rebuild is triggered. This regression runs in the existing migration CI job.
- All 14 pgvector lifecycle integration tests and 23 embedding/chat contract tests passed.
- Frontend: all 168 tests passed. Backend and frontend lint/build passed.

Follow-up to #348 and #318. No full index rebuild is started by this change.
