### PR TITLE
fix: confirm embedding changes and reuse retained indexes

### DIFF
--- a/doc/userguide/AI-VECTOR-MIGRATION.zh.md
+++ b/doc/userguide/AI-VECTOR-MIGRATION.zh.md
@@ -310,3 +310,29 @@ docker exec -i rote-postgres pg_restore -U rote -d rote --clean --if-exists < ro
 - `POST /v2/api/ai/index/rebuild` 接收 `{ "revision": 1 }`，返回 HTTP 202 和持久化重建状态；重复请求同一轮重建不会重复启动。
 - `/v2/api/ai/vector/status` 返回当前代次、维度、配置版本、状态、错误码及 `ready`。`ready` 为真才表示向量检索已准备好。
 - 错误继续采用 `{ code, message, data }` 响应格式；`message` 为 `embedding_*` 错误码，`data` 提供相关数值和供应商 HTTP 状态，不返回原始供应商响应或认证信息。
+
+## 切换模型后返回原配置
+
+保存前会提示向量配置变化的影响。保存只验证配置，不启动全量重建。索引另外保存生成它时的供应商、地址、模型、输出设置、文本处理和分块配置指纹。切换后如果没有启动新的重建，切回完全匹配的配置并通过验证，可以复用保留的完整代次；暂停期间的内容变化会先补齐，即使自动索引关闭。凭据轮换不改变索引归属。索引损坏、输出契约错误或未完成的旧代次不能直接恢复。
+
+### 明确恢复升级前的旧向量
+
+没有代次的历史向量不会自动认领。只有管理员能确认它们来自当前供应商和模型时，才运行维护命令；不要手工将状态改成 `ready`。先保存原供应商、模型和输出设置（例如 DashScope `text-embedding-v4` 指定 1536 维），再使用保存接口返回的当前 revision。
+
+在 `server/` 目录执行预览，示例 revision 需要替换为实际值：
+
+```sh
+bun run scripts/recoverLegacyEmbeddings.ts --revision 3 --confirm-provider dashscope
+```
+
+预览会核对全部来源的归属、内容、分块和向量数值，并发送至多 3 次样本请求验证一致性，因此会产生少量模型调用费用。样本比对只是辅助检查，不能代替管理员对原供应商的确认。预览返回 `reusableChunks`、`incrementalSources` 等数量，不写入索引。
+
+确认数量后，显式执行。下面的限制值 `0` 表示不允许创建任何需要重新生成内容的任务；只有预览确认需要补齐时才调整为可接受的来源数量：
+
+```sh
+bun run scripts/recoverLegacyEmbeddings.ts --revision 3 --confirm-provider dashscope --apply --max-incremental-sources 0
+```
+
+正式执行重新检查配置版本、来源和数量，在事务中将合格向量原值复制到新代次、创建 HNSW 索引、登记缺失或变化来源的任务。旧行保留，失败整体回滚。该维护操作会短暂持有来源行锁，大库应在低峰执行。执行中途新增的内容由事务事件队列捕获。后台工作器完成必要的补齐和索引检查后恢复检索；队列暂停时需要管理员恢复队列。重新运行已完成的操作会拒绝重复认领。
+
+容器只有编译产物时，命令入口为 `bun dist/scripts/recoverLegacyEmbeddings.js`，参数相同。脚本使用后端已有数据库和模型配置，不接收或打印凭据，不应在迁移、部署或日常任务中自动调用。

--- a/server/drizzle/migrations/0033_embedding_generation_identity.sql
+++ b/server/drizzle/migrations/0033_embedding_generation_identity.sql
@@ -1,0 +1,14 @@
+ALTER TABLE "embedding_index_state" ADD COLUMN "generationFingerprint" text;
+--> statement-breakpoint
+ALTER TABLE "embedding_index_state" ADD COLUMN "generationDimensions" integer;
+--> statement-breakpoint
+ALTER TABLE "embedding_index_state" ADD COLUMN "generationReusable" boolean DEFAULT false NOT NULL;
+--> statement-breakpoint
+-- Only these states establish that the saved configuration belongs to this
+-- generation. An invalidated or legacy index must never be inferred from it.
+UPDATE "embedding_index_state"
+SET "generationFingerprint" = fingerprint,
+    "generationDimensions" = dimensions,
+    "generationReusable" = status = 'ready'
+WHERE "generationId" IS NOT NULL AND fingerprint IS NOT NULL
+  AND status IN ('ready', 'rebuilding', 'failed');

--- a/server/drizzle/migrations/meta/_journal.json
+++ b/server/drizzle/migrations/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1788683900000,
       "tag": "0032_settings_updated_at_default",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1788686228847,
+      "tag": "0033_embedding_generation_identity",
+      "breakpoints": true
     }
   ]
 }

--- a/server/drizzle/schema.ts
+++ b/server/drizzle/schema.ts
@@ -1226,6 +1226,9 @@ export const embeddingIndexState = pgTable(
     fingerprint: text('fingerprint'),
     dimensions: integer('dimensions'),
     generationId: uuid('generationId'),
+    generationFingerprint: text('generationFingerprint'),
+    generationDimensions: integer('generationDimensions'),
+    generationReusable: boolean('generationReusable').notNull().default(false),
     status: text('status')
       .$type<'needs_validation' | 'needs_rebuild' | 'rebuilding' | 'ready' | 'failed'>()
       .notNull()

--- a/server/embeddings/configImpact.ts
+++ b/server/embeddings/configImpact.ts
@@ -1,0 +1,21 @@
+import type { AiConfig } from '../types/config';
+import { readAiSnapshot, parseIncomingAiConfig } from './configStore';
+import { embeddingFingerprint } from './contract';
+import { EmbeddingError } from './errors';
+
+// Preview is read-only: the actual save still validates the provider and
+// decides whether the retained generation can serve the new configuration.
+export async function getAiConfigurationImpact(incoming: Partial<AiConfig>) {
+  if (!incoming || typeof incoming !== 'object')
+    throw new EmbeddingError('embedding_config_invalid', 400);
+  const { config, state } = await readAiSnapshot();
+  if (incoming.revision !== state.revision)
+    throw new EmbeddingError('embedding_revision_conflict', 409);
+  const next = parseIncomingAiConfig(incoming, config);
+  const embeddingChanged = embeddingFingerprint(next) !== embeddingFingerprint(config);
+  const enabling = next.enabled && next.vectorEnabled && !(config.enabled && config.vectorEnabled);
+  return {
+    revision: state.revision,
+    requiresConfirmation: embeddingChanged || (enabling && state.status !== 'ready'),
+  };
+}

--- a/server/embeddings/configStore.ts
+++ b/server/embeddings/configStore.ts
@@ -9,6 +9,11 @@ import db from '../utils/drizzle';
 import { testEmbeddingProvider } from './client';
 import { embeddingFingerprint, embeddingOutputSchema } from './contract';
 import { EmbeddingError, isEmbeddingContractFailure } from './errors';
+import {
+  generationMatches,
+  restoreGenerationStatus,
+  revokeGenerationClaims,
+} from './generationIdentity';
 
 export type EmbeddingTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
 export type EmbeddingExecutor = typeof db | EmbeddingTransaction;
@@ -83,6 +88,7 @@ export function canProcessIndex(config: AiConfig, state: IndexState) {
     config.vectorEnabled &&
     state.generationId !== null &&
     state.dimensions !== null &&
+    generationMatches(state, state.fingerprint, state.dimensions) &&
     (state.status === 'ready' || state.status === 'rebuilding')
   );
 }
@@ -126,6 +132,14 @@ export async function saveAiSettings(incoming: Partial<AiConfig>): Promise<AiCon
       const state = await lockIndexState(tx);
       if (state.revision !== incoming.revision)
         throw new EmbeddingError('embedding_revision_conflict', 409);
+      if (invalidatesIndex || (!enabledNow && needsValidation))
+        await revokeGenerationClaims(tx, state.generationId);
+      const restored =
+        verified &&
+        !contractFailed &&
+        (enabling || ['needs_rebuild', 'needs_validation'].includes(state.status))
+          ? await restoreGenerationStatus(tx, state, fingerprint, verified.dimensions)
+          : null;
       next.revision = state.revision + 1;
       await tx
         .insert(settings)
@@ -152,9 +166,10 @@ export async function saveAiSettings(incoming: Partial<AiConfig>): Promise<AiCon
                 errorCode: null,
                 errorDetails: null,
                 status:
-                  invalidatesIndex || contractFailed || state.status === 'needs_validation'
+                  restored ??
+                  (invalidatesIndex || contractFailed || state.status === 'needs_validation'
                     ? ('needs_rebuild' as const)
-                    : state.status,
+                    : state.status),
               }
             : needsValidation
               ? {

--- a/server/embeddings/generationIdentity.ts
+++ b/server/embeddings/generationIdentity.ts
@@ -1,0 +1,63 @@
+import { sql } from 'drizzle-orm';
+import type { EmbeddingExecutor, EmbeddingTransaction, IndexState } from './configStore';
+import { vectorIndexName } from '../utils/dbMethods/ai/documents';
+
+export function generationMatches(
+  state: IndexState,
+  fingerprint: string | null,
+  dimensions: number | null
+) {
+  return Boolean(
+    state.generationId &&
+    fingerprint &&
+    dimensions &&
+    state.generationFingerprint === fingerprint &&
+    state.generationDimensions === dimensions
+  );
+}
+
+export async function restoreGenerationStatus(
+  executor: EmbeddingExecutor,
+  state: IndexState,
+  fingerprint: string,
+  dimensions: number
+) {
+  if (
+    !state.generationReusable ||
+    !state.scanComplete ||
+    !generationMatches(state, fingerprint, dimensions)
+  )
+    return null;
+  const indexName = vectorIndexName(dimensions, state.generationId!);
+  const [status] = await executor.execute(sql`
+    SELECT EXISTS (SELECT 1 FROM pg_index i JOIN pg_class c ON c.oid=i.indexrelid
+      JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname='public'
+      AND c.relname=${indexName} AND i.indisvalid) AS valid,
+    EXISTS (SELECT 1 FROM embedding_jobs WHERE "generationId"=${state.generationId} AND status='failed') AS failed,
+    (EXISTS (SELECT 1 FROM embedding_jobs WHERE "generationId"=${state.generationId} AND status IN ('pending','running'))
+      OR EXISTS (SELECT 1 FROM embedding_source_events)) AS pending
+  `);
+  if (!status.valid) return null;
+  return status.failed
+    ? ('failed' as const)
+    : status.pending
+      ? ('rebuilding' as const)
+      : ('ready' as const);
+}
+
+export async function revokeGenerationClaims(
+  tx: EmbeddingTransaction,
+  generationId: string | null
+) {
+  if (!generationId) return;
+  // Retain a fresh successor for every interrupted source. A worker from the
+  // old configuration must not become valid again after a round-trip switch.
+  await tx.execute(sql`WITH revoked AS (
+    UPDATE embedding_jobs SET status='cancelled', "leaseToken"=NULL,
+      "leaseExpiresAt"=NULL,"lockedAt"=NULL,"updatedAt"=now()
+    WHERE "generationId"=${generationId} AND status='running'
+    RETURNING "generationId","sourceType","sourceId","ownerId"
+  ) INSERT INTO embedding_jobs ("generationId","sourceType","sourceId","ownerId",action,status)
+    SELECT "generationId","sourceType","sourceId","ownerId",'upsert','pending' FROM revoked
+    ON CONFLICT DO NOTHING`);
+}

--- a/server/embeddings/index.integration.test.ts
+++ b/server/embeddings/index.integration.test.ts
@@ -438,3 +438,183 @@ describe.serial('embedding configuration and index lifecycle', () => {
     expect((await read.json()).data.config.revision).toBe(config.revision);
   });
 });
+
+const { getAiConfigurationImpact } = await import('./configImpact');
+const { consumeSourceEvents } = await import('./sourceEvents');
+const { recoverLegacyIndex } = await import('./legacyIndexRecovery');
+
+async function legacyFixture() {
+  const config = await saveConfig();
+  await note();
+  await ensurePgvectorReady();
+  await startIndexRebuild(config.revision);
+  await completeRebuild();
+  await db.update(documentEmbeddings).set({ generationId: null });
+  await db
+    .update(embeddingIndexState)
+    .set({
+      generationId: null,
+      generationFingerprint: null,
+      generationDimensions: null,
+      generationReusable: false,
+      status: 'needs_rebuild',
+      scanComplete: false,
+    })
+    .where(eq(embeddingIndexState.id, 1));
+  return config;
+}
+
+describe.serial('configuration changes and retained index recovery', () => {
+  it('previews embedding changes without saving or calling a provider', async () => {
+    const saved = await saveConfig();
+    const count = requests.length;
+    for (const config of [
+      saved,
+      { ...saved, chat: { ...saved.chat, model: 'another-chat' } },
+      { ...saved, embedding: { ...saved.embedding, apiKey: 'rotated' } },
+      { ...saved, indexing: { ...saved.indexing, batchSize: 2 } },
+    ])
+      expect((await getAiConfigurationImpact(config)).requiresConfirmation).toBe(false);
+    for (const config of [
+      { ...saved, embedding: { ...saved.embedding, model: 'another-model' } },
+      {
+        ...saved,
+        embedding: { ...saved.embedding, output: { mode: 'dimensions' as const, dimensions: 3 } },
+      },
+      { ...saved, indexing: { ...saved.indexing, chunkOverlap: 100 } },
+    ])
+      expect((await getAiConfigurationImpact(config)).requiresConfirmation).toBe(true);
+    await expect(getAiConfigurationImpact({ ...saved, revision: 0 })).rejects.toMatchObject({
+      code: 'embedding_revision_conflict',
+    });
+    expect(requests).toHaveLength(count);
+    expect((await readAiSnapshot()).config).toEqual(saved);
+  });
+  it('restores the retained generation after switching back without regenerating content', async () => {
+    const original = await saveConfig();
+    await note();
+    await ensurePgvectorReady();
+    await startIndexRebuild(original.revision);
+    await completeRebuild();
+    const vectors = await db.select().from(documentEmbeddings);
+    const generation = (await readAiSnapshot()).state.generationId;
+    const changed = await saveAiSettings({
+      ...original,
+      embedding: { ...original.embedding, model: 'other-model' },
+    });
+    expect((await getPgvectorStatus()).ready).toBe(false);
+    const count = requests.length;
+    await saveAiSettings({ ...original, revision: changed.revision });
+    expect(requests).toHaveLength(count + 1); // Validation only.
+    expect((await readAiSnapshot()).state).toMatchObject({
+      status: 'ready',
+      generationId: generation,
+      generationReusable: true,
+    });
+    expect((await getPgvectorStatus()).ready).toBe(true);
+    expect(await db.select().from(documentEmbeddings)).toEqual(vectors);
+  });
+  it('retains edits while a different model is saved and catches up with auto indexing disabled', async () => {
+    const initial = await saveConfig();
+    const original = await saveAiSettings({ ...initial, autoIndexEnabled: false });
+    await note();
+    await ensurePgvectorReady();
+    await startIndexRebuild(original.revision);
+    await completeRebuild();
+    const generation = (await readAiSnapshot()).state.generationId;
+    await enqueueEmbeddingJob('rote', noteId, ownerId, 'upsert', true);
+    const expiredWorker = await claimEmbeddingJob();
+    expect(expiredWorker).toBeTruthy();
+    const changed = await saveAiSettings({
+      ...original,
+      embedding: { ...original.embedding, model: 'other-model' },
+    });
+    await note('edited while the model was different');
+    await consumeSourceEvents();
+    expect(await db.select().from(embeddingSourceEvents)).toHaveLength(1);
+    await saveAiSettings({ ...original, revision: changed.revision });
+    expect((await readAiSnapshot()).state).toMatchObject({
+      status: 'rebuilding',
+      generationId: generation,
+      scanComplete: true,
+    });
+    await expect(
+      processEmbeddingJob(
+        expiredWorker!.job,
+        expiredWorker!.config,
+        expiredWorker!.state.dimensions!
+      )
+    ).rejects.toMatchObject({ code: 'embedding_lease_lost' });
+    await completeRebuild();
+    const rows = await db.select().from(documentEmbeddings);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].text).toBe('edited while the model was different');
+    expect(rows[0].generationId).toBe(generation);
+  });
+  it('does not restore a generation without a valid physical index', async () => {
+    const original = await saveConfig();
+    await ensurePgvectorReady();
+    const index = await startIndexRebuild(original.revision);
+    await completeRebuild();
+    const changed = await saveAiSettings({
+      ...original,
+      embedding: { ...original.embedding, model: 'other-model' },
+    });
+    await db.execute(sql.raw(`DROP INDEX "${index.indexName}"`));
+    await saveAiSettings({ ...original, revision: changed.revision });
+    expect((await readAiSnapshot()).state.status).toBe('needs_rebuild');
+  });
+  it('explicitly adopts verified legacy vectors, preserving originals and only generating missing content', async () => {
+    const config = await legacyFixture();
+    const [old] = await db.select().from(documentEmbeddings);
+    await db
+      .insert(articles)
+      .values({ id: articleId, authorId: ownerId, content: 'a missing article' });
+    const options = { revision: config.revision, confirmedProvider: config.embedding.providerId };
+    const preview = await recoverLegacyIndex(options);
+    expect(preview).toMatchObject({ applied: false, reusableChunks: 1, incrementalSources: 1 });
+    expect(await db.select().from(documentEmbeddings)).toEqual([old]);
+    await expect(recoverLegacyIndex({ ...options, apply: true })).rejects.toMatchObject({
+      code: 'embedding_legacy_incremental_limit',
+    });
+    expect((await readAiSnapshot()).state.generationId).toBeNull();
+    const recovered = await recoverLegacyIndex({
+      ...options,
+      apply: true,
+      maxIncrementalSources: 1,
+    });
+    const copies = await db.select().from(documentEmbeddings);
+    expect(copies).toHaveLength(2);
+    expect(copies.find((row) => row.id === old.id)).toEqual(old);
+    expect(copies.find((row) => row.generationId === recovered.generationId)?.embedding).toBe(
+      old.embedding
+    );
+    const count = requests.length;
+    await completeRebuild();
+    expect(requests).toHaveLength(count + 1);
+    expect((await getPgvectorStatus()).ready).toBe(true);
+    expect(await semanticSearch({ query: 'fixture', ownerId, viewerId: ownerId })).toHaveLength(2);
+  });
+  it('rejects unconfirmed provenance, stale revisions and incompatible model samples without changing data', async () => {
+    const config = await legacyFixture();
+    const options = {
+      revision: config.revision,
+      confirmedProvider: config.embedding.providerId,
+      apply: true,
+    };
+    const previous = await db.select().from(documentEmbeddings);
+    await expect(
+      recoverLegacyIndex({ ...options, confirmedProvider: 'wrong-provider' })
+    ).rejects.toMatchObject({ code: 'embedding_legacy_recovery_unavailable' });
+    await expect(recoverLegacyIndex({ ...options, revision: 0 })).rejects.toMatchObject({
+      code: 'embedding_revision_conflict',
+    });
+    globalThis.fetch = (async () =>
+      Response.json({ data: [{ embedding: [1, 0, 0] }] })) as typeof fetch;
+    await expect(recoverLegacyIndex(options)).rejects.toMatchObject({
+      code: 'embedding_legacy_sample_mismatch',
+    });
+    expect(await db.select().from(documentEmbeddings)).toEqual(previous);
+    expect((await readAiSnapshot()).state.status).toBe('needs_rebuild');
+  });
+});

--- a/server/embeddings/index.integration.test.ts
+++ b/server/embeddings/index.integration.test.ts
@@ -618,3 +618,22 @@ describe.serial('configuration changes and retained index recovery', () => {
     expect((await readAiSnapshot()).state.status).toBe('needs_rebuild');
   });
 });
+
+it('rejects duplicate legacy chunks that conceal missing chunk coverage', async () => {
+  const config = await legacyFixture();
+  await note('a'.repeat(1900));
+  const { hashText } = await import('../utils/dbMethods/ai/documents');
+  const [old] = await db
+    .update(documentEmbeddings)
+    .set({ text: 'a'.repeat(1800), contentHash: hashText('a'.repeat(1800)) })
+    .returning();
+  await db.insert(documentEmbeddings).values({ ...old, id: crypto.randomUUID() });
+  await expect(
+    recoverLegacyIndex({
+      revision: config.revision,
+      confirmedProvider: config.embedding.providerId,
+      apply: true,
+    })
+  ).rejects.toMatchObject({ code: 'embedding_legacy_recovery_unavailable' });
+  expect((await readAiSnapshot()).state.generationId).toBeNull();
+});

--- a/server/embeddings/indexLifecycle.ts
+++ b/server/embeddings/indexLifecycle.ts
@@ -52,6 +52,9 @@ export async function startIndexRebuild(revision: unknown) {
         fingerprint: embeddingFingerprint(before.config),
         dimensions: verified.dimensions,
         generationId,
+        generationFingerprint: embeddingFingerprint(before.config),
+        generationDimensions: verified.dimensions,
+        generationReusable: false,
         scanSource: 'rote',
         scanCursor: null,
         scanComplete: false,
@@ -92,7 +95,7 @@ export async function retryFailedEmbeddingJobs() {
         leaseToken: null,
         leaseExpiresAt: null,
         lockedAt: null,
-        nextAttemptAt: new Date(),
+        nextAttemptAt: sql`now()`,
         updatedAt: new Date(),
       })
       .where(
@@ -119,6 +122,9 @@ export async function clearAllEmbeddings() {
       .set({
         status: state.dimensions ? 'needs_rebuild' : 'needs_validation',
         generationId: null,
+        generationFingerprint: null,
+        generationDimensions: null,
+        generationReusable: false,
         scanComplete: false,
         scanCursor: null,
         errorCode: null,
@@ -158,7 +164,13 @@ export async function finishIndexRebuild() {
     if (event) return;
     await tx
       .update(embeddingIndexState)
-      .set({ status: 'ready', errorCode: null, errorDetails: null, updatedAt: new Date() })
+      .set({
+        status: 'ready',
+        generationReusable: true,
+        errorCode: null,
+        errorDetails: null,
+        updatedAt: new Date(),
+      })
       .where(eq(embeddingIndexState.id, 1));
   });
 }

--- a/server/embeddings/jobClaims.ts
+++ b/server/embeddings/jobClaims.ts
@@ -103,6 +103,7 @@ export async function failClaim(job: EmbeddingJob, error: unknown, maxRetries: n
         .set({
           status: 'needs_validation',
           fingerprint: null,
+          generationReusable: false,
           errorCode: failure.code,
           errorDetails: failure.details,
           updatedAt: new Date(),
@@ -113,6 +114,7 @@ export async function failClaim(job: EmbeddingJob, error: unknown, maxRetries: n
         .update(embeddingIndexState)
         .set({
           status: 'failed',
+          ...(contractFailure ? { generationReusable: false } : {}),
           errorCode: failure.code,
           errorDetails: failure.details,
           updatedAt: new Date(),

--- a/server/embeddings/legacyIndexAudit.ts
+++ b/server/embeddings/legacyIndexAudit.ts
@@ -58,6 +58,7 @@ export async function auditLegacyIndex(
       const rows = bySource.get(`${sourceType}:${source.id}`) ?? [];
       const matches =
         rows.length === chunks.length &&
+        new Set(rows.map((row) => row.chunkIndex)).size === chunks.length &&
         rows.every((row) => {
           const chunk = chunks[row.chunkIndex];
           if (

--- a/server/embeddings/legacyIndexAudit.ts
+++ b/server/embeddings/legacyIndexAudit.ts
@@ -1,0 +1,84 @@
+import { asc, isNull } from 'drizzle-orm';
+import { articles, documentEmbeddings, rotes } from '../drizzle/schema';
+import { hasCapability } from '../authz/capabilityService';
+import {
+  buildSourceDocument,
+  getSourceOwner,
+  hashText,
+  splitIntoChunks,
+} from '../utils/dbMethods/ai/documents';
+import type { AiSourceType } from '../utils/dbMethods/ai/types';
+import type { AiConfig } from '../types/config';
+import type { EmbeddingTransaction } from './configStore';
+import { validateVector } from './contract';
+
+// An operator must establish provider provenance separately. This audit proves
+// source ownership, complete chunk coverage and the stored vector contract.
+export async function auditLegacyIndex(
+  tx: EmbeddingTransaction,
+  config: AiConfig,
+  dimensions: number
+) {
+  const notes = await tx.select().from(rotes).orderBy(asc(rotes.id)).for('share');
+  const documents = await tx.select().from(articles).orderBy(asc(articles.id)).for('share');
+  const auditedSources = new Set<string>();
+  const legacy = await tx
+    .select()
+    .from(documentEmbeddings)
+    .where(isNull(documentEmbeddings.generationId))
+    .orderBy(asc(documentEmbeddings.id))
+    .for('share');
+  const bySource = new Map<string, typeof legacy>();
+  for (const row of legacy) {
+    const key = `${row.sourceType}:${row.sourceId}`;
+    const rows = bySource.get(key) ?? [];
+    rows.push(row);
+    bySource.set(key, rows);
+  }
+  const reusable: typeof legacy = [];
+  const pending: { sourceType: AiSourceType; sourceId: string; ownerId: string }[] = [];
+  const capabilities = new Map<string, boolean>();
+  let sources = 0;
+  for (const sourceType of ['rote', 'article'] as const) {
+    const records = sourceType === 'rote' ? notes : documents;
+    for (const source of records) {
+      const ownerId = getSourceOwner(sourceType, source);
+      if (!capabilities.has(ownerId))
+        capabilities.set(ownerId, await hasCapability(ownerId, 'ai.chat'));
+      if (!capabilities.get(ownerId)) continue;
+      auditedSources.add(`${sourceType}:${source.id}`);
+      const document = buildSourceDocument(sourceType, source);
+      const chunks = splitIntoChunks(
+        document.text,
+        config.indexing.chunkSize,
+        config.indexing.chunkOverlap
+      );
+      if (!chunks.length) continue;
+      sources++;
+      const rows = bySource.get(`${sourceType}:${source.id}`) ?? [];
+      const matches =
+        rows.length === chunks.length &&
+        rows.every((row) => {
+          const chunk = chunks[row.chunkIndex];
+          if (
+            chunk === undefined ||
+            row.ownerId !== ownerId ||
+            row.text !== chunk ||
+            row.contentHash !== hashText(chunk) ||
+            row.embeddingModel !== config.embedding.model ||
+            row.embeddingDimensions !== dimensions
+          )
+            return false;
+          try {
+            validateVector(JSON.parse(row.embedding), dimensions);
+            return true;
+          } catch {
+            return false;
+          } // Invalid legacy sources require regeneration; never adopt their vectors.
+        });
+      if (matches) reusable.push(...rows.map((row) => ({ ...row, metadata: document.metadata })));
+      else pending.push({ sourceType, sourceId: source.id, ownerId });
+    }
+  }
+  return { legacyChunks: legacy.length, sources, reusable, pending, auditedSources };
+}

--- a/server/embeddings/legacyIndexRecovery.ts
+++ b/server/embeddings/legacyIndexRecovery.ts
@@ -1,0 +1,147 @@
+import { randomUUID } from 'node:crypto';
+import { eq, inArray, sql } from 'drizzle-orm';
+import { documentEmbeddings, embeddingIndexState, embeddingSourceEvents } from '../drizzle/schema';
+import db from '../utils/drizzle';
+import { vectorIndexName } from '../utils/dbMethods/ai/documents';
+import { getPgvectorStatus } from '../utils/dbMethods/ai/vector';
+import { createEmbedding } from './client';
+import { lockIndexState, readAiSnapshot } from './configStore';
+import { embeddingFingerprint, validateVector } from './contract';
+import { EmbeddingError } from './errors';
+import { auditLegacyIndex } from './legacyIndexAudit';
+import { queueSource } from './queue';
+
+export type LegacyRecoveryOptions = {
+  revision: number;
+  confirmedProvider: string;
+  apply?: boolean;
+  maxIncrementalSources?: number;
+};
+
+// Explicit maintenance operation, never called by migration, save or worker.
+// A matching model name cannot establish the origin of unversioned vectors.
+export async function recoverLegacyIndex(options: LegacyRecoveryOptions) {
+  const before = await readAiSnapshot();
+  const assertRecoverable = (snapshot: typeof before) => {
+    if (snapshot.state.revision !== options.revision)
+      throw new EmbeddingError('embedding_revision_conflict', 409);
+    if (
+      !options.confirmedProvider ||
+      snapshot.config.embedding.providerId !== options.confirmedProvider ||
+      !snapshot.config.enabled ||
+      !snapshot.config.vectorEnabled ||
+      snapshot.state.status !== 'needs_rebuild' ||
+      snapshot.state.generationId ||
+      !snapshot.state.dimensions ||
+      snapshot.state.fingerprint !== embeddingFingerprint(snapshot.config)
+    ) {
+      throw new EmbeddingError('embedding_legacy_recovery_unavailable', 409);
+    }
+  };
+  assertRecoverable(before);
+  if (!(await getPgvectorStatus()).installed)
+    throw new EmbeddingError('embedding_database_unavailable', 503);
+  const preview = await db.transaction(async (tx) => {
+    await lockIndexState(tx);
+    const snapshot = await readAiSnapshot(tx);
+    assertRecoverable(snapshot);
+    return auditLegacyIndex(tx, snapshot.config, snapshot.state.dimensions!);
+  });
+  if (!preview.reusable.length)
+    throw new EmbeddingError('embedding_legacy_recovery_unavailable', 409);
+  // Samples are a sanity check in addition to explicit operator provenance,
+  // never an automatic inference of provider identity.
+  const sampleIndexes = [
+    ...new Set([0, Math.floor(preview.reusable.length / 2), preview.reusable.length - 1]),
+  ];
+  for (const index of sampleIndexes) {
+    const row = preview.reusable[index];
+    const old = validateVector(JSON.parse(row.embedding), before.state.dimensions!);
+    const { embedding: current } = await createEmbedding(before.config.embedding, row.text, {
+      expectedDimensions: old.length,
+    });
+    let dot = 0,
+      oldNorm = 0,
+      newNorm = 0,
+      error = 0;
+    for (let i = 0; i < old.length; i++) {
+      dot += old[i] * current[i];
+      oldNorm += old[i] ** 2;
+      newNorm += current[i] ** 2;
+      error += (old[i] - current[i]) ** 2;
+    }
+    if (dot / Math.sqrt(oldNorm * newNorm) < 0.99999 || Math.sqrt(error / oldNorm) > 0.01)
+      throw new EmbeddingError('embedding_legacy_sample_mismatch', 409);
+  }
+  return db.transaction(async (tx) => {
+    await lockIndexState(tx);
+    const snapshot = await readAiSnapshot(tx);
+    assertRecoverable(snapshot);
+    // Re-audit under locks after provider requests. All existing sources remain
+    // locked until registration commits; concurrent inserts leave durable events.
+    const events = await tx.select().from(embeddingSourceEvents);
+    const audit = await auditLegacyIndex(tx, snapshot.config, snapshot.state.dimensions!);
+    const report = {
+      revision: snapshot.state.revision,
+      legacyChunks: audit.legacyChunks,
+      reusableChunks: audit.reusable.length,
+      incrementalSources: audit.pending.length,
+      eligibleSources: audit.sources,
+      verifiedSamples: sampleIndexes.length,
+    };
+    if (!options.apply) return { ...report, applied: false, generationId: null };
+    if (
+      !Number.isInteger(options.maxIncrementalSources ?? 0) ||
+      (options.maxIncrementalSources ?? 0) < audit.pending.length
+    )
+      throw new EmbeddingError('embedding_legacy_incremental_limit', 409, report);
+    if (!audit.reusable.length)
+      throw new EmbeddingError('embedding_legacy_recovery_unavailable', 409);
+    const generationId = randomUUID();
+    // Keep historical rows untouched. Copy validated values without model calls.
+    for (let offset = 0; offset < audit.reusable.length; offset += 100) {
+      await tx
+        .insert(documentEmbeddings)
+        .values(
+          audit.reusable
+            .slice(offset, offset + 100)
+            .map((row) => ({ ...row, id: randomUUID(), generationId }))
+        );
+    }
+    const indexName = vectorIndexName(snapshot.state.dimensions!, generationId);
+    await tx.execute(
+      sql.raw(
+        `CREATE INDEX "${indexName}" ON document_embeddings USING hnsw ((embedding::vector(${snapshot.state.dimensions})) vector_cosine_ops) WHERE "generationId"='${generationId}'::uuid AND "embeddingDimensions"=${snapshot.state.dimensions}`
+      )
+    );
+    for (const source of audit.pending)
+      await queueSource(tx, generationId, source.sourceType, source.sourceId, source.ownerId);
+    // Only events visible to this audit are superseded. Later commits stay queued.
+    const superseded = events
+      .filter(
+        (event) =>
+          event.action === 'upsert' &&
+          audit.auditedSources.has(`${event.sourceType}:${event.sourceId}`)
+      )
+      .map((event) => event.id);
+    if (superseded.length)
+      await tx.delete(embeddingSourceEvents).where(inArray(embeddingSourceEvents.id, superseded));
+    await tx
+      .update(embeddingIndexState)
+      .set({
+        generationId,
+        generationFingerprint: snapshot.state.fingerprint,
+        generationDimensions: snapshot.state.dimensions,
+        generationReusable: false,
+        status: 'rebuilding',
+        scanSource: 'article',
+        scanCursor: null,
+        scanComplete: true,
+        errorCode: null,
+        errorDetails: null,
+        updatedAt: new Date(),
+      })
+      .where(eq(embeddingIndexState.id, 1));
+    return { ...report, applied: true, generationId };
+  });
+}

--- a/server/embeddings/migration.test.ts
+++ b/server/embeddings/migration.test.ts
@@ -66,8 +66,14 @@ it('migrates a legacy database without pgvector, retaining configuration and vec
     await client`INSERT INTO document_embeddings ("ownerId", "sourceType", "sourceId", "chunkIndex", "contentHash", "embeddingModel", "embeddingDimensions", embedding, text)
       VALUES (${ownerId}, 'rote', ${sourceId}, 0, 'old-hash', 'BAAI/bge-m3', 1024, ${vector}, 'legacy content')`;
     await client`INSERT INTO embedding_jobs ("ownerId", "sourceType", "sourceId", status) VALUES (${ownerId}, 'rote', ${sourceId}, 'running')`;
-    selectMigrations(32);
+    selectMigrations(34);
     await migrate(drizzle(client), { migrationsFolder: folder });
+    // The formal repair runs during upgrade, including ordinary PostgreSQL.
+    const [column] =
+      await client`SELECT column_default FROM information_schema.columns WHERE table_name='settings' AND column_name='updatedAt'`;
+    expect(column.column_default).not.toBeNull();
+    // Recreate the historical defect to exercise safe error handling independently.
+    await client`ALTER TABLE settings ALTER COLUMN "updatedAt" DROP DEFAULT`;
     const [setting] = await client`SELECT config FROM settings WHERE "group" = 'ai'`;
     expect(setting.config.schemaVersion).toBe(2);
     expect(setting.config.embedding.output).toEqual({ mode: 'dimensions', dimensions: 1024 });
@@ -81,6 +87,8 @@ it('migrates a legacy database without pgvector, retaining configuration and vec
     const [state] = await client`SELECT * FROM embedding_index_state`;
     expect(state.status).toBe('needs_validation');
     expect(state.dimensions).toBeNull();
+    expect(state.generationFingerprint).toBeNull();
+    expect(state.generationReusable).toBe(false);
     expect(await client`SELECT 1 FROM pg_extension WHERE extname = 'vector'`).toHaveLength(0);
 
     const database = await import('../utils/drizzle');
@@ -143,6 +151,9 @@ it('migrates a legacy database without pgvector, retaining configuration and vec
     );
     expect((await client`SELECT * FROM embedding_index_state`)[0]).toEqual(state);
 
+    await client.unsafe(
+      readFileSync(join(migrationFolder, '0032_settings_updated_at_default.sql'), 'utf8')
+    );
     await migrate(drizzle(client), { migrationsFolder: migrationFolder });
     const saved = await request('/admin/settings', 'PUT', { group: 'ai', config: incoming });
     expect(saved.status).toBe(200);

--- a/server/embeddings/query.ts
+++ b/server/embeddings/query.ts
@@ -30,6 +30,7 @@ export async function createQueryEmbedding(
         .set({
           status: 'needs_validation',
           fingerprint: null,
+          generationReusable: false,
           errorCode: error.code,
           errorDetails: error.details,
           updatedAt: new Date(),

--- a/server/embeddings/queue.ts
+++ b/server/embeddings/queue.ts
@@ -11,6 +11,7 @@ import {
 } from './configStore';
 import type { AiConfig } from '../types/config';
 import { EmbeddingError } from './errors';
+import { generationMatches } from './generationIdentity';
 import type {
   AiSourceType,
   EmbeddingJobAction,
@@ -24,6 +25,7 @@ export function canQueueIndex(config: AiConfig, state: IndexState) {
       state.status === 'failed') &&
     state.generationId !== null &&
     state.dimensions !== null &&
+    generationMatches(state, state.fingerprint, state.dimensions) &&
     ['ready', 'rebuilding', 'failed'].includes(state.status)
   );
 }

--- a/server/embeddings/sourceEvents.ts
+++ b/server/embeddings/sourceEvents.ts
@@ -23,6 +23,7 @@ export async function consumeSourceEvents(pageSize = 100) {
       .orderBy(asc(embeddingSourceEvents.createdAt), asc(embeddingSourceEvents.id))
       .limit(pageSize)
       .for('update', { skipLocked: true });
+    const consumed: string[] = [];
     for (const event of events) {
       const table = event.sourceType === 'rote' ? rotes : articles;
       const owner = event.sourceType === 'rote' ? rotes.authorid : articles.authorId;
@@ -63,14 +64,14 @@ export async function consumeSourceEvents(pageSize = 100) {
           event.sourceId,
           source.ownerId
         );
+      } else if (state.generationReusable && !canQueueIndex(config, state)) {
+        // Keep changes while another model is configured. Returning to the
+        // retained generation must catch up even if auto indexing is disabled.
+        continue;
       }
+      consumed.push(event.id);
     }
-    if (events.length)
-      await tx.delete(embeddingSourceEvents).where(
-        inArray(
-          embeddingSourceEvents.id,
-          events.map((event) => event.id)
-        )
-      );
+    if (consumed.length)
+      await tx.delete(embeddingSourceEvents).where(inArray(embeddingSourceEvents.id, consumed));
   });
 }

--- a/server/route/v2/aiAdmin.ts
+++ b/server/route/v2/aiAdmin.ts
@@ -1,4 +1,5 @@
 import { parseIncomingAiConfig } from '../../embeddings/configStore';
+import { getAiConfigurationImpact } from '../../embeddings/configImpact';
 import { startIndexRebuild } from '../../embeddings/indexLifecycle';
 import { DEFAULT_AI_CONFIG } from '../../utils/ai/providers';
 import type { Hono } from 'hono';
@@ -20,6 +21,16 @@ import {
 import { bodyTypeCheck, createResponse } from '../../utils/main';
 
 export function registerAdminAiRoutes(router: Hono<{ Variables: HonoVariables }>) {
+  router.post(
+    '/config/impact',
+    authenticateJWT,
+    requireAdmin,
+    bodyTypeCheck,
+    async (c: HonoContext) => {
+      const { config } = await c.req.json();
+      return c.json(createResponse(await getAiConfigurationImpact(config)), 200);
+    }
+  );
   router.get('/defaults', authenticateJWT, requireAdmin, (c: HonoContext) =>
     c.json(createResponse(DEFAULT_AI_CONFIG), 200)
   );

--- a/server/scripts/recoverLegacyEmbeddings.ts
+++ b/server/scripts/recoverLegacyEmbeddings.ts
@@ -1,0 +1,40 @@
+import { parseArgs } from 'node:util';
+import { recoverLegacyIndex } from '../embeddings/legacyIndexRecovery';
+import { EmbeddingError } from '../embeddings/errors';
+import { closeDatabase } from '../utils/drizzle';
+
+async function main() {
+  const { values } = parseArgs({
+    options: {
+      revision: { type: 'string' },
+      'confirm-provider': { type: 'string' },
+      apply: { type: 'boolean', default: false },
+      'max-incremental-sources': { type: 'string', default: '0' },
+    },
+    strict: true,
+  });
+  try {
+    if (
+      values.revision === undefined ||
+      !/^\d+$/.test(values.revision) ||
+      !values['confirm-provider'] ||
+      !/^\d+$/.test(values['max-incremental-sources']!)
+    )
+      throw new EmbeddingError('embedding_config_invalid', 400);
+    const result = await recoverLegacyIndex({
+      revision: Number(values.revision),
+      confirmedProvider: values['confirm-provider'],
+      apply: values.apply,
+      maxIncrementalSources: Number(values['max-incremental-sources']),
+    });
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+  } catch (error) {
+    process.stderr.write(
+      `${JSON.stringify(error instanceof EmbeddingError ? { code: error.code, details: error.details } : { code: 'embedding_legacy_recovery_failed' })}\n`
+    );
+    process.exitCode = 1;
+  } finally {
+    await closeDatabase();
+  }
+}
+void main();

--- a/server/utils/dbMethods/ai/vector.ts
+++ b/server/utils/dbMethods/ai/vector.ts
@@ -3,6 +3,7 @@ import db from '../../drizzle';
 import { readAiSnapshot } from '../../../embeddings/configStore';
 import { EmbeddingError } from '../../../embeddings/errors';
 import { vectorIndexName } from './documents';
+import { generationMatches } from '../../../embeddings/generationIdentity';
 
 export async function getPgvectorStatus() {
   const { config, state } = await readAiSnapshot();
@@ -35,6 +36,7 @@ export async function getPgvectorStatus() {
       config.enabled &&
       config.vectorEnabled &&
       state.status === 'ready' &&
+      generationMatches(state, state.fingerprint, state.dimensions) &&
       Boolean(row.installed && row.hasIndex),
   };
 }

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1718,6 +1718,12 @@
         "rebuildConfirm": "Start rebuilding",
         "rebuildStarted": "Rebuild started",
         "saveBeforeRebuild": "Save your configuration before rebuilding.",
+        "saveChangeTitle": "Save embedding configuration?",
+        "saveChangeDescription": "If the new configuration is incompatible with the existing index, saving pauses vector search and requires a manual full rebuild. Rebuilding incurs model usage charges; saving does not start it.",
+        "saveChangeReuse": "Returning to the model, output dimensions and chunk settings of the retained generation reuses its verified index and catches up on content changes. Chat and keyword search remain available.",
+        "saveChangeCancel": "Cancel",
+        "saveChangeConfirm": "Confirm save",
+        "saveImpactCheckFailed": "Could not check the configuration change. Please try again.",
         "embeddingErrors": {
           "embedding_config_invalid": "Invalid embedding configuration. Check the output mode, dimensions and chunk settings.",
           "embedding_dimensions_limit": "The model returned {{actual}} dimensions; this index supports up to {{limit}}. Use a model that supports a smaller output.",

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -1722,6 +1722,12 @@
         "rebuildConfirm": "再構築を開始",
         "rebuildStarted": "再構築を開始しました",
         "saveBeforeRebuild": "再構築の前に設定を保存してください。",
+        "saveChangeTitle": "ベクトル設定を保存しますか？",
+        "saveChangeDescription": "新しい設定が既存の索引と互換性を持たない場合、保存後にベクトル検索が停止し、手動で全件再構築する必要があります。再構築にはモデル利用料金が発生します。保存だけでは再構築を開始しません。",
+        "saveChangeReuse": "保持中の世代と同じモデル、出力次元数、分割設定に戻すと、検証済みの索引を再利用し、その間の内容変更のみを反映します。チャットとキーワード検索は引き続き利用できます。",
+        "saveChangeCancel": "キャンセル",
+        "saveChangeConfirm": "保存する",
+        "saveImpactCheckFailed": "設定変更の影響を確認できませんでした。もう一度お試しください。",
         "embeddingErrors": {
           "embedding_config_invalid": "埋め込み設定が無効です。出力モード、次元数、分割設定を確認してください。",
           "embedding_dimensions_limit": "モデルは {{actual}} 次元を返しました。索引の上限は {{limit}} 次元です。より小さい出力に対応するモデルを使用してください。",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1708,6 +1708,12 @@
         "rebuildConfirm": "开始重建",
         "rebuildStarted": "重建已启动",
         "saveBeforeRebuild": "请先保存当前配置，再启动重建。",
+        "saveChangeTitle": "保存向量配置？",
+        "saveChangeDescription": "如果新配置与现有索引不兼容，保存后向量检索将暂停，需要手动启动全量重建。重建会产生模型调用费用；保存本身不会启动重建。",
+        "saveChangeReuse": "切回同一代索引的原模型、输出维度和分块设置时，可复用经过验证的索引，仅补齐期间的内容变化。普通聊天和关键词搜索不受影响。",
+        "saveChangeCancel": "取消",
+        "saveChangeConfirm": "确认保存",
+        "saveImpactCheckFailed": "无法检查配置变更的影响，请稍后重试。",
         "embeddingErrors": {
           "embedding_config_invalid": "向量模型配置无效，请检查输出模式、维度和分块设置。",
           "embedding_dimensions_limit": "模型返回 {{actual}} 维，当前索引最多支持 {{limit}} 维。请使用支持指定较小维度的模型。",

--- a/web/src/pages/admin/components/AIConfigSaveButton.tsx
+++ b/web/src/pages/admin/components/AIConfigSaveButton.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { post } from '@/utils/api';
+import type { SystemConfig } from '../types';
+import { formatEmbeddingError } from './embeddingErrors';
+
+type AiConfiguration = NonNullable<SystemConfig['ai']>;
+
+export default function AIConfigSaveButton({
+  config,
+  disabled,
+  onSave,
+}: {
+  config: AiConfiguration;
+  disabled: boolean;
+  onSave: (config: AiConfiguration) => Promise<boolean>;
+}) {
+  const { t } = useTranslation('translation', { keyPrefix: 'pages.admin' });
+  const [busy, setBusy] = useState(false);
+  const [pending, setPending] = useState<{ config: AiConfiguration; signature: string } | null>(
+    null
+  );
+  const button = useRef<HTMLButtonElement>(null);
+  const signature = JSON.stringify(config);
+  const currentSignature = useRef(signature);
+  useEffect(() => {
+    currentSignature.current = signature;
+  }, [signature]);
+  const save = async () => {
+    if (!pending || pending.signature !== signature) return;
+    setBusy(true);
+    try {
+      if (await onSave(pending.config)) setPending(null);
+    } finally {
+      setBusy(false);
+    }
+  };
+  const checkImpact = async () => {
+    const snapshot = structuredClone(config);
+    setBusy(true);
+    try {
+      const result = await post('/ai/config/impact', { config: snapshot });
+      if (currentSignature.current !== signature) return;
+      if (result.data.requiresConfirmation) setPending({ config: snapshot, signature });
+      else await onSave(snapshot);
+    } catch (error) {
+      toast.error(formatEmbeddingError(error, t) || t('ai.saveImpactCheckFailed'));
+    } finally {
+      setBusy(false);
+    }
+  };
+  return (
+    <Dialog
+      open={pending !== null && pending.signature === signature}
+      onOpenChange={(open) => {
+        if (!open && !busy) setPending(null);
+      }}
+    >
+      <Button ref={button} onClick={checkImpact} disabled={disabled || busy} className="w-full">
+        {busy ? t('saving') : t('save')}
+      </Button>
+      <DialogContent
+        showCloseButton={false}
+        onCloseAutoFocus={(event) => {
+          event.preventDefault();
+          button.current?.focus();
+        }}
+      >
+        <DialogHeader>
+          <DialogTitle>{t('ai.saveChangeTitle')}</DialogTitle>
+          <DialogDescription className="text-pretty">
+            {t('ai.saveChangeDescription')}
+          </DialogDescription>
+        </DialogHeader>
+        <p className="text-muted-foreground text-sm">{t('ai.saveChangeReuse')}</p>
+        <DialogFooter className="flex-row gap-2">
+          <Button
+            variant="outline"
+            className="flex-1"
+            disabled={busy}
+            onClick={() => setPending(null)}
+          >
+            {t('ai.saveChangeCancel')}
+          </Button>
+          <Button className="flex-[2]" disabled={disabled || busy} onClick={save}>
+            {busy ? t('saving') : t('ai.saveChangeConfirm')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/pages/admin/components/AIConfigTab.tsx
+++ b/web/src/pages/admin/components/AIConfigTab.tsx
@@ -1,5 +1,5 @@
 import { formatEmbeddingError } from './embeddingErrors';
-import { Button } from '@/components/ui/button';
+import AIConfigSaveButton from './AIConfigSaveButton';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import Divider from '@/components/ui/divider';
 import { Label } from '@/components/ui/label';
@@ -150,17 +150,19 @@ function AIConfigEditor({
     });
   };
 
-  const handleSave = async () => {
+  const handleSave = async (snapshot: NonNullable<SystemConfig['ai']>): Promise<boolean> => {
     setIsSaving(true);
     try {
       const res = await put('/admin/settings', {
         group: 'ai',
-        config,
+        config: snapshot,
       });
       setAiConfig(res.data.config);
       await mutateSavedAi();
       toast.success(t('saveSuccess'));
       await Promise.all([Promise.resolve(onMutate()), mutateGlobal('site-status')]);
+      await Promise.all([mutateVectorStatus(), mutateJobStats()]);
+      return true;
     } catch (error: any) {
       const errorMessage =
         error?.response?.data?.message ||
@@ -168,6 +170,7 @@ function AIConfigEditor({
         error?.response?.data?.error ||
         'Unknown error';
       toast.error(t('saveFailed', { error: formatEmbeddingError(error, t) || errorMessage }));
+      return false;
     } finally {
       setIsSaving(false);
     }
@@ -306,9 +309,11 @@ function AIConfigEditor({
           runAction={runAction}
         />
 
-        <Button onClick={handleSave} disabled={isSaving} className="w-full">
-          {isSaving ? t('saving') : t('save')}
-        </Button>
+        <AIConfigSaveButton
+          config={config}
+          disabled={isSaving || busyAction !== null}
+          onSave={handleSave}
+        />
       </CardContent>
     </Card>
   );

--- a/web/src/pages/admin/components/EmbeddingConfig.test.tsx
+++ b/web/src/pages/admin/components/EmbeddingConfig.test.tsx
@@ -1,3 +1,4 @@
+import AIConfigSaveButton from './AIConfigSaveButton';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import AIConfigProviderForm from './AIConfigProviderForm';
@@ -84,5 +85,71 @@ describe('embedding configuration', () => {
     expect(post).not.toHaveBeenCalled();
     fireEvent.click(screen.getByRole('button', { name: 'rebuildConfirm' }));
     await waitFor(() => expect(post).toHaveBeenCalledWith('/ai/index/rebuild', { revision: 7 }));
+  });
+});
+
+describe('saving embedding configuration', () => {
+  it('asks before saving an index change, and cancellation writes nothing', async () => {
+    vi.mocked(post).mockResolvedValue({ data: { requiresConfirmation: true } });
+    const onSave = vi.fn().mockResolvedValue(true);
+    render(<AIConfigSaveButton config={config} disabled={false} onSave={onSave} />);
+    const button = screen.getByRole('button', { name: 'save' });
+    fireEvent.click(button);
+    await screen.findByRole('dialog');
+    expect(onSave).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'ai.saveChangeCancel' }));
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    expect(onSave).not.toHaveBeenCalled();
+    expect(button).toHaveFocus();
+  });
+  it('saves the reviewed configuration only after confirmation', async () => {
+    vi.mocked(post).mockResolvedValue({ data: { requiresConfirmation: true } });
+    const onSave = vi.fn().mockResolvedValue(true);
+    render(<AIConfigSaveButton config={config} disabled={false} onSave={onSave} />);
+    fireEvent.click(screen.getByRole('button', { name: 'save' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'ai.saveChangeConfirm' }));
+    await waitFor(() => expect(onSave).toHaveBeenCalledExactlyOnceWith(config));
+    expect(post).toHaveBeenCalledExactlyOnceWith('/ai/config/impact', { config });
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+  });
+  it('directly saves unrelated changes and fails closed when the impact check fails', async () => {
+    vi.mocked(post)
+      .mockResolvedValueOnce({ data: { requiresConfirmation: false } })
+      .mockRejectedValueOnce(new Error('offline'));
+    const onSave = vi.fn().mockResolvedValue(true);
+    render(<AIConfigSaveButton config={config} disabled={false} onSave={onSave} />);
+    fireEvent.click(screen.getByRole('button', { name: 'save' }));
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.getByRole('button', { name: 'save' })).toBeEnabled());
+    fireEvent.click(screen.getByRole('button', { name: 'save' }));
+    await waitFor(() => expect(screen.getByRole('button', { name: 'save' })).toBeEnabled());
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+  it('discards an impact check when the form changes during the request', async () => {
+    let finish!: (value: { data: { requiresConfirmation: boolean } }) => void;
+    vi.mocked(post).mockReturnValue(
+      new Promise((resolve) => {
+        finish = resolve;
+      })
+    );
+    const onSave = vi.fn().mockResolvedValue(true);
+    const view = render(<AIConfigSaveButton config={config} disabled={false} onSave={onSave} />);
+    fireEvent.click(screen.getByRole('button', { name: 'save' }));
+    view.rerender(
+      <AIConfigSaveButton config={{ ...config, revision: 2 }} disabled={false} onSave={onSave} />
+    );
+    finish({ data: { requiresConfirmation: false } });
+    await waitFor(() => expect(screen.getByRole('button', { name: 'save' })).toBeEnabled());
+    expect(onSave).not.toHaveBeenCalled();
+  });
+  it('keeps the confirmation open after a rejected save', async () => {
+    vi.mocked(post).mockResolvedValue({ data: { requiresConfirmation: true } });
+    const onSave = vi.fn().mockResolvedValue(false);
+    render(<AIConfigSaveButton config={config} disabled={false} onSave={onSave} />);
+    fireEvent.click(screen.getByRole('button', { name: 'save' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'ai.saveChangeConfirm' }));
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+    expect(screen.getByRole('dialog')).toBeVisible();
   });
 });


### PR DESCRIPTION
Saving a different embedding model now explains retrieval suspension and rebuild costs before applying the configuration. Returning to the retained generation's exact validated configuration reuses its vectors and catches up queued source edits, including when automatic indexing is off.

The index stores its generation fingerprint and dimensions independently of the saved configuration. Configuration switches revoke old worker leases, preserve change events, and restore availability only for a complete matching generation with a valid HNSW index. Contract failures revoke reuse eligibility.

An explicit maintenance command can register unversioned legacy vectors after the operator confirms their provider origin. It audits source ownership, content, complete chunk coverage and vector validity, checks up to three model samples, preserves legacy rows, and transactionally copies qualified values into a new generation. Dry-run output, revision checks and an explicit incremental-source limit prevent accidental bulk regeneration. Migration and deployment never invoke recovery or a paid rebuild.

Validation: 21 pgvector integration tests, 1 ordinary PostgreSQL legacy migration test, 23 embedding/chat contract tests, 173 frontend tests; server and web lint/build passed. Chinese, English and Japanese confirmation dialogs verified at 320px, including all four corners of both buttons and keyboard focus restoration.

Related to #318.
