### PR TITLE
feat(web): reuse public note layout for anonymous sharing

### DIFF
--- a/web/src/features/note-sharing/SharedNoteLayout.tsx
+++ b/web/src/features/note-sharing/SharedNoteLayout.tsx
@@ -1,0 +1,53 @@
+import type { ReactNode } from 'react';
+import { BookOpen, StickyNote } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { SideContentLayout } from '@/components/layout/SideContentLayout';
+import { Button } from '@/components/ui/button';
+
+export function SharedNoteLayout({
+  children,
+  sidebar,
+  hasArticle,
+}: {
+  children: ReactNode;
+  sidebar: ReactNode;
+  hasArticle: boolean;
+}) {
+  const { t } = useTranslation('translation', { keyPrefix: 'pages.sharedNote' });
+
+  return (
+    <div className="bg-background text-primary mx-auto w-full max-w-6xl">
+      <div className="mx-auto flex min-h-screen w-full max-w-[1440px] font-sans sm:divide-x xl:w-[90%]">
+        <nav
+          aria-label={t('readingNavigation')}
+          className="bg-background/90 sticky top-0 hidden h-dvh shrink-0 flex-col items-center justify-center gap-4 px-2 sm:flex lg:w-[200px] lg:px-4"
+        >
+          <Button asChild variant="ghost" className="rounded-full">
+            <a href="#shared-note" aria-label={t('note')} title={t('note')}>
+              <StickyNote className="size-4" />
+              <span className="hidden text-base tracking-widest lg:block">{t('note')}</span>
+            </a>
+          </Button>
+          {hasArticle && (
+            <Button asChild variant="ghost" className="rounded-full">
+              <a href="#shared-article" aria-label={t('article')} title={t('article')}>
+                <BookOpen className="size-4" />
+                <span className="hidden text-base tracking-widest lg:block">{t('article')}</span>
+              </a>
+            </Button>
+          )}
+        </nav>
+        <div className="flex min-w-0 flex-1 md:divide-x">
+          <main
+            id="shared-note"
+            tabIndex={-1}
+            className="relative min-w-0 flex-1 scroll-mt-4 divide-y focus:outline-none"
+          >
+            {children}
+          </main>
+          <SideContentLayout>{sidebar}</SideContentLayout>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/features/note-sharing/SharedNotePage.test.tsx
+++ b/web/src/features/note-sharing/SharedNotePage.test.tsx
@@ -44,7 +44,11 @@ describe('anonymous share reader', () => {
     expect(screen.getByRole('heading', { name: 'Article in full' })).toBeInTheDocument();
     expect(screen.getByText('Article body')).toBeInTheDocument();
     expect(screen.getByText('family').closest('a')).toBeNull();
-    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(screen.getAllByRole('link').map((link) => link.getAttribute('href'))).toEqual([
+      '#shared-note',
+      '#shared-article',
+    ]);
+    expect(screen.getByText('@author')).toBeInTheDocument();
     expect(screen.queryByText('back')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /edit|delete|reaction/ })).not.toBeInTheDocument();
   });
@@ -60,6 +64,8 @@ describe('anonymous share reader', () => {
     await screen.findByText('unavailableTitle');
     expect(screen.queryByText('Latest edit')).not.toBeInTheDocument();
     expect(screen.queryByText('Article body')).not.toBeInTheDocument();
+    expect(screen.queryByText('@author')).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'article' })).not.toBeInTheDocument();
   });
 
   it('shows retry for a network failure and fetches again', async () => {

--- a/web/src/features/note-sharing/SharedNotePage.tsx
+++ b/web/src/features/note-sharing/SharedNotePage.tsx
@@ -12,13 +12,18 @@ import UserAvatar from '@/components/others/UserAvatar';
 import NavBar from '@/components/layout/navBar';
 import LoadingPlaceholder from '@/components/others/LoadingPlaceholder';
 import { useSharedNote } from './useSharedNote';
+import { SharedNoteLayout } from './SharedNoteLayout';
+import { SharedNoteSidebar } from './SharedNoteSidebar';
 
 function SharedNoteReader({ token }: { token: string }) {
   const { t, i18n } = useTranslation('translation', { keyPrefix: 'pages.sharedNote' });
   const { state, retry } = useSharedNote(token);
 
   return (
-    <main className="mx-auto min-h-screen w-full max-w-2xl divide-y sm:border-x">
+    <SharedNoteLayout
+      hasArticle={state.status === 'ready' && Boolean(state.note.article)}
+      sidebar={<SharedNoteSidebar note={state.note} />}
+    >
       <Helmet>
         <title>{t('title')}</title>
         <meta name="robots" content="noindex, nofollow, noarchive" />
@@ -77,8 +82,10 @@ function SharedNoteReader({ token }: { token: string }) {
           </div>
           {state.note.article && (
             <section
+              id="shared-article"
+              tabIndex={-1}
               aria-label={t('article')}
-              className="prose prose-sm dark:prose-invert max-w-full border-t pt-4 wrap-break-word"
+              className="prose prose-sm dark:prose-invert max-w-full scroll-mt-20 border-t pt-4 wrap-break-word focus:outline-none"
             >
               <ReactMarkdown remarkPlugins={[remarkGfm]}>
                 {state.note.article.content}
@@ -104,7 +111,7 @@ function SharedNoteReader({ token }: { token: string }) {
           )}
         </article>
       )}
-    </main>
+    </SharedNoteLayout>
   );
 }
 

--- a/web/src/features/note-sharing/SharedNoteSidebar.tsx
+++ b/web/src/features/note-sharing/SharedNoteSidebar.tsx
@@ -1,0 +1,57 @@
+import { Navigation } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import UserAvatar from '@/components/others/UserAvatar';
+import type { SharedNote } from './types';
+
+export function SharedNoteSidebar({ note }: { note?: SharedNote }) {
+  const { t, i18n } = useTranslation('translation', { keyPrefix: 'pages.sharedNote' });
+  const updatedAt =
+    note?.article && Date.parse(note.article.updatedAt) > Date.parse(note.updatedAt)
+      ? note.article.updatedAt
+      : note?.updatedAt;
+
+  return (
+    <aside aria-label={t('about')} className="divide-y">
+      <div className="flex items-center gap-2 p-3 text-lg font-semibold">
+        <Navigation className="size-5 shrink-0" />
+        {t('about')}
+      </div>
+      {note && (
+        <div className="flex items-center gap-3 p-4">
+          <UserAvatar
+            avatar={note.author.avatar}
+            className="bg-foreground/5 text-primary size-12 shrink-0"
+          />
+          <div className="min-w-0 flex-1">
+            <p
+              className="truncate font-semibold"
+              title={note.author.nickname || note.author.username}
+            >
+              {note.author.nickname || note.author.username}
+            </p>
+            <p className="text-info truncate text-sm" title={`@${note.author.username}`}>
+              @{note.author.username}
+            </p>
+          </div>
+        </div>
+      )}
+      <div className="space-y-2 p-4 text-sm">
+        <p className="font-medium">{t('readOnly')}</p>
+        <p className="text-muted-foreground leading-relaxed">{t('readOnlyDescription')}</p>
+      </div>
+      {updatedAt && (
+        <dl className="space-y-2 p-4 text-sm">
+          <dt className="text-muted-foreground">{t('updatedAt')}</dt>
+          <dd>
+            <time dateTime={updatedAt}>
+              {new Date(updatedAt).toLocaleString(i18n.language, {
+                dateStyle: 'medium',
+                timeStyle: 'short',
+              })}
+            </time>
+          </dd>
+        </dl>
+      )}
+    </aside>
+  );
+}

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1855,6 +1855,12 @@
       "saveFailed": "Save failed: {{error}}"
     },
     "sharedNote": {
+      "readingNavigation": "Reading navigation",
+      "note": "Note",
+      "about": "About this note",
+      "readOnly": "Read-only sharing",
+      "readOnlyDescription": "Read without signing in. Refresh the page to see the author's latest changes.",
+      "updatedAt": "Last updated",
       "title": "Rote · Shared note",
       "refresh": "Refresh content",
       "loading": "Loading note…",

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -1859,6 +1859,12 @@
       "saveFailed": "保存に失敗しました：{{error}}"
     },
     "sharedNote": {
+      "readingNavigation": "ページ内ナビゲーション",
+      "note": "ノート",
+      "about": "このノートについて",
+      "readOnly": "閲覧専用の共有",
+      "readOnlyDescription": "ログインせずに読めます。作者が内容を更新したら、ページを再読み込みしてください。",
+      "updatedAt": "最終更新",
       "title": "Rote · 共有ノート",
       "refresh": "内容を更新",
       "loading": "ノートを読み込み中…",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1845,6 +1845,12 @@
       "saveFailed": "保存失败: {{error}}"
     },
     "sharedNote": {
+      "readingNavigation": "阅读导航",
+      "note": "笔记",
+      "about": "关于这篇笔记",
+      "readOnly": "只读分享",
+      "readOnlyDescription": "无需登录即可阅读。作者更新内容后，刷新页面即可查看。",
+      "updatedAt": "最近更新",
       "title": "Rote · 分享的笔记",
       "refresh": "刷新内容",
       "loading": "正在读取笔记…",


### PR DESCRIPTION
## Description

The anonymous reader previously placed the note in an isolated centered column, leaving both sides empty. It now follows the public single-note page's three-column proportions: a compact reading navigation rail, the note body, and an author sidebar using the existing `SideContentLayout` and avatar styling.

Navigation stays within the note and linked article. The sidebar shows read-only context and the latest note/article update time, and clears author data when a share becomes unavailable. On phones the reader remains a single column. English, Chinese and Japanese labels are included.

## Type of Change

- [x] Non-breaking UI improvement

## Testing

- [x] `bun run test -- src/features/note-sharing` (9 tests)
- [x] `bun run lint` and `bun run build` in `web/`
- [x] Browser at 320px, 768px and 1440px; no horizontal overflow
- [x] Light/dark appearance, keyboard anchor navigation and visible edge hit testing
- [x] Reader regression checks keep navigation local and clear sidebar identity on revocation

## Checklist

- [x] Self-reviewed layout, responsive behavior and localization
- [x] Existing media, note and anonymous API behavior preserved
- [x] Normal commit workflow used without bypassing hooks
