### PR TITLE
fix(web): restore shared note navigation and author interactions

### DIFF
--- a/web/src/components/layout/navBar.tsx
+++ b/web/src/components/layout/navBar.tsx
@@ -79,12 +79,13 @@ export default function NavBar({
           {(icon || title) && (
             <div className="flex min-w-0 items-center gap-2 p-3 [&>svg]:shrink-0">
               {icon}
-              <div
-                className="min-w-0 truncate"
-                title={typeof title === 'string' ? title : undefined}
-              >
-                {title}
-              </div>
+              {typeof title === 'string' ? (
+                <div className="min-w-0 truncate" title={title}>
+                  {title}
+                </div>
+              ) : (
+                title
+              )}
             </div>
           )}
         </div>

--- a/web/src/components/layout/navBar.tsx
+++ b/web/src/components/layout/navBar.tsx
@@ -62,10 +62,10 @@ export default function NavBar({
         className={`noScrollBar bg-background/99 sticky top-0 z-10 flex w-full items-center gap-2 overflow-x-scroll pr-4 text-lg font-semibold backdrop-blur-xl duration-300 ${onNavClick && 'cursor-pointer'}`}
         onClick={onNavClick}
       >
-        <div className="flex items-center divide-x">
+        <div className="flex min-w-0 items-center divide-x">
           {showBack && !isMainNavPage && (
             <div
-              className="hover:text-theme flex cursor-pointer items-center gap-2 p-3 duration-300"
+              className="hover:text-theme flex shrink-0 cursor-pointer items-center gap-2 p-3 duration-300"
               onClick={(e) => {
                 e.stopPropagation();
                 back();
@@ -77,9 +77,14 @@ export default function NavBar({
           )}
 
           {(icon || title) && (
-            <div className="flex items-center gap-2 p-3">
+            <div className="flex min-w-0 items-center gap-2 p-3 [&>svg]:shrink-0">
               {icon}
-              {title}
+              <div
+                className="min-w-0 truncate"
+                title={typeof title === 'string' ? title : undefined}
+              >
+                {title}
+              </div>
             </div>
           )}
         </div>

--- a/web/src/features/note-sharing/SharedNoteLayout.tsx
+++ b/web/src/features/note-sharing/SharedNoteLayout.tsx
@@ -1,53 +1,20 @@
 import type { ReactNode } from 'react';
-import { BookOpen, StickyNote } from 'lucide-react';
-import { useTranslation } from 'react-i18next';
 import { SideContentLayout } from '@/components/layout/SideContentLayout';
-import { Button } from '@/components/ui/button';
+import LayoutDashboard from '@/layout/dashboard';
 
 export function SharedNoteLayout({
   children,
   sidebar,
-  hasArticle,
 }: {
   children: ReactNode;
   sidebar: ReactNode;
-  hasArticle: boolean;
 }) {
-  const { t } = useTranslation('translation', { keyPrefix: 'pages.sharedNote' });
-
   return (
-    <div className="bg-background text-primary mx-auto w-full max-w-6xl">
-      <div className="mx-auto flex min-h-screen w-full max-w-[1440px] font-sans sm:divide-x xl:w-[90%]">
-        <nav
-          aria-label={t('readingNavigation')}
-          className="bg-background/90 sticky top-0 hidden h-dvh shrink-0 flex-col items-center justify-center gap-4 px-2 sm:flex lg:w-[200px] lg:px-4"
-        >
-          <Button asChild variant="ghost" className="rounded-full">
-            <a href="#shared-note" aria-label={t('note')} title={t('note')}>
-              <StickyNote className="size-4" />
-              <span className="hidden text-base tracking-widest lg:block">{t('note')}</span>
-            </a>
-          </Button>
-          {hasArticle && (
-            <Button asChild variant="ghost" className="rounded-full">
-              <a href="#shared-article" aria-label={t('article')} title={t('article')}>
-                <BookOpen className="size-4" />
-                <span className="hidden text-base tracking-widest lg:block">{t('article')}</span>
-              </a>
-            </Button>
-          )}
-        </nav>
-        <div className="flex min-w-0 flex-1 md:divide-x">
-          <main
-            id="shared-note"
-            tabIndex={-1}
-            className="relative min-w-0 flex-1 scroll-mt-4 divide-y focus:outline-none"
-          >
-            {children}
-          </main>
-          <SideContentLayout>{sidebar}</SideContentLayout>
-        </div>
+    <LayoutDashboard anonymousReader>
+      <div className="flex min-h-screen min-w-0 md:divide-x">
+        <main className="relative min-w-0 flex-1 divide-y pb-20 sm:pb-0">{children}</main>
+        <SideContentLayout>{sidebar}</SideContentLayout>
       </div>
-    </div>
+    </LayoutDashboard>
   );
 }

--- a/web/src/features/note-sharing/SharedNotePage.test.tsx
+++ b/web/src/features/note-sharing/SharedNotePage.test.tsx
@@ -1,12 +1,27 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { HelmetProvider } from '@dr.pogodin/react-helmet';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { createStore, Provider } from 'jotai';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { authReadyAtom, profileAtom } from '@/state/profile';
+import { get } from '@/utils/api';
+import type { Profile } from '@/types/main';
 import SharedNotePage from './SharedNotePage';
 import { getSharedNote } from './api';
 import type { SharedNote } from './types';
 
 vi.mock('./api', () => ({ getSharedNote: vi.fn() }));
+vi.mock('@/utils/api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/utils/api')>()),
+  get: vi.fn(),
+}));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, values?: { name?: string }) =>
+      key === 'sharedBy' ? `Shared by ${values?.name}` : key,
+    i18n: { language: 'en' },
+  }),
+}));
 
 const note: SharedNote = {
   title: 'A shared thought',
@@ -20,21 +35,27 @@ const note: SharedNote = {
   article: { content: '# Article in full\n\nArticle body', createdAt: '', updatedAt: '' },
 };
 
-function renderPage() {
+function renderPage(profile?: Profile, authReady = false) {
+  const store = createStore();
+  store.set(profileAtom, profile);
+  store.set(authReadyAtom, authReady);
   return render(
-    <HelmetProvider>
-      <MemoryRouter initialEntries={['/s/test-token']}>
-        <Routes>
-          <Route path="/s/:token" element={<SharedNotePage />} />
-        </Routes>
-      </MemoryRouter>
-    </HelmetProvider>
+    <Provider store={store}>
+      <HelmetProvider>
+        <MemoryRouter initialEntries={['/s/test-token']}>
+          <Routes>
+            <Route path="/s/:token" element={<SharedNotePage />} />
+          </Routes>
+        </MemoryRouter>
+      </HelmetProvider>
+    </Provider>
   );
 }
 
 describe('anonymous share reader', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
     vi.mocked(getSharedNote).mockResolvedValue(note);
   });
 
@@ -45,12 +66,70 @@ describe('anonymous share reader', () => {
     expect(screen.getByText('Article body')).toBeInTheDocument();
     expect(screen.getByText('family').closest('a')).toBeNull();
     expect(screen.getAllByRole('link').map((link) => link.getAttribute('href'))).toEqual([
-      '#shared-note',
-      '#shared-article',
+      '/login',
     ]);
+    expect(screen.getByRole('link', { name: 'leftNavBar.login' })).toBeInTheDocument();
+    expect(screen.getByText('Shared by Author')).toBeInTheDocument();
     expect(screen.getByText('@author')).toBeInTheDocument();
     expect(screen.queryByText('back')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /edit|delete|reaction/ })).not.toBeInTheDocument();
+  });
+
+  it.each([
+    'broken-refresh-token',
+    `header.${btoa(JSON.stringify({ exp: 1 }))}.signature`,
+    `header.${btoa(JSON.stringify({ userId: 'old-account' }))}.signature`,
+  ])('keeps reading and shows login with an unusable stored session: %s', async (token) => {
+    localStorage.setItem('rote_refresh_token', token);
+    renderPage();
+    await screen.findByText(note.content);
+    expect(screen.getByRole('link', { name: 'leftNavBar.login' })).toHaveAttribute(
+      'href',
+      '/login'
+    );
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it('uses the existing signed-in navigation without starting profile requests', async () => {
+    localStorage.setItem(
+      'rote_refresh_token',
+      `header.${btoa(JSON.stringify({ exp: Date.now() / 1000 + 3600 }))}.signature`
+    );
+    renderPage(undefined, true);
+    await screen.findByText(note.content);
+    expect(screen.getAllByRole('link').map((link) => link.getAttribute('href'))).toEqual([
+      '/home',
+      '/explore',
+      '/ai',
+      '/profile',
+      '/experiment',
+    ]);
+    expect(screen.getByText('leftNavBar.logout')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'leftNavBar.login' })).not.toBeInTheDocument();
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it('keeps the existing role-dependent navigation for an established administrator session', async () => {
+    localStorage.setItem(
+      'rote_refresh_token',
+      `header.${btoa(JSON.stringify({ exp: Date.now() / 1000 + 3600 }))}.signature`
+    );
+    renderPage({ id: 'admin', role: 'admin' } as Profile, true);
+    await screen.findByText(note.content);
+    expect(screen.getByRole('link', { name: 'leftNavBar.admin' })).toHaveAttribute(
+      'href',
+      '/admin'
+    );
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it('uses the username in the header when the author has no nickname', async () => {
+    vi.mocked(getSharedNote).mockResolvedValueOnce({
+      ...note,
+      author: { ...note.author, nickname: null },
+    });
+    renderPage();
+    expect(await screen.findByText('Shared by author')).toBeInTheDocument();
   });
 
   it('refreshes changed content on focus and clears already-read content after revocation', async () => {
@@ -65,6 +144,7 @@ describe('anonymous share reader', () => {
     expect(screen.queryByText('Latest edit')).not.toBeInTheDocument();
     expect(screen.queryByText('Article body')).not.toBeInTheDocument();
     expect(screen.queryByText('@author')).not.toBeInTheDocument();
+    expect(screen.queryByText('Shared by Author')).not.toBeInTheDocument();
     expect(screen.queryByRole('link', { name: 'article' })).not.toBeInTheDocument();
   });
 

--- a/web/src/features/note-sharing/SharedNotePage.test.tsx
+++ b/web/src/features/note-sharing/SharedNotePage.test.tsx
@@ -67,6 +67,9 @@ describe('anonymous share reader', () => {
     expect(screen.getByText('family').closest('a')).toBeNull();
     expect(screen.getAllByRole('link').map((link) => link.getAttribute('href'))).toEqual([
       '/login',
+      '/author',
+      '/author',
+      '/author',
     ]);
     expect(screen.getByRole('link', { name: 'leftNavBar.login' })).toBeInTheDocument();
     expect(screen.getByText('Shared by Author')).toBeInTheDocument();
@@ -103,6 +106,9 @@ describe('anonymous share reader', () => {
       '/ai',
       '/profile',
       '/experiment',
+      '/author',
+      '/author',
+      '/author',
     ]);
     expect(screen.getByText('leftNavBar.logout')).toBeInTheDocument();
     expect(screen.queryByRole('link', { name: 'leftNavBar.login' })).not.toBeInTheDocument();
@@ -145,6 +151,9 @@ describe('anonymous share reader', () => {
     expect(screen.queryByText('Article body')).not.toBeInTheDocument();
     expect(screen.queryByText('@author')).not.toBeInTheDocument();
     expect(screen.queryByText('Shared by Author')).not.toBeInTheDocument();
+    expect(
+      screen.queryAllByRole('link').some((link) => link.getAttribute('href') === '/author')
+    ).toBe(false);
     expect(screen.queryByRole('link', { name: 'article' })).not.toBeInTheDocument();
   });
 

--- a/web/src/features/note-sharing/SharedNotePage.tsx
+++ b/web/src/features/note-sharing/SharedNotePage.tsx
@@ -18,18 +18,19 @@ import { SharedNoteSidebar } from './SharedNoteSidebar';
 function SharedNoteReader({ token }: { token: string }) {
   const { t, i18n } = useTranslation('translation', { keyPrefix: 'pages.sharedNote' });
   const { state, retry } = useSharedNote(token);
+  const heading =
+    state.status === 'ready'
+      ? t('sharedBy', { name: state.note.author.nickname || state.note.author.username })
+      : t('title');
 
   return (
-    <SharedNoteLayout
-      hasArticle={state.status === 'ready' && Boolean(state.note.article)}
-      sidebar={<SharedNoteSidebar note={state.note} />}
-    >
+    <SharedNoteLayout sidebar={<SharedNoteSidebar note={state.note} />}>
       <Helmet>
-        <title>{t('title')}</title>
+        <title>{heading}</title>
         <meta name="robots" content="noindex, nofollow, noarchive" />
         <meta name="referrer" content="no-referrer" />
       </Helmet>
-      <NavBar title={t('title')} icon={<Share className="size-5" />} showBack={false}>
+      <NavBar title={heading} icon={<Share className="size-5" />} showBack={false}>
         <Button
           variant="ghost"
           size="icon"
@@ -63,8 +64,11 @@ function SharedNoteReader({ token }: { token: string }) {
         <article className="space-y-4 px-5 py-4">
           <div className="flex items-center gap-3">
             <UserAvatar avatar={state.note.author.avatar || ''} className="size-10" />
-            <div>
-              <p className="font-medium">
+            <div className="min-w-0">
+              <p
+                className="truncate font-medium"
+                title={state.note.author.nickname || state.note.author.username}
+              >
                 {state.note.author.nickname || state.note.author.username}
               </p>
               <time dateTime={state.note.createdAt} className="text-muted-foreground text-xs">
@@ -82,10 +86,8 @@ function SharedNoteReader({ token }: { token: string }) {
           </div>
           {state.note.article && (
             <section
-              id="shared-article"
-              tabIndex={-1}
               aria-label={t('article')}
-              className="prose prose-sm dark:prose-invert max-w-full scroll-mt-20 border-t pt-4 wrap-break-word focus:outline-none"
+              className="prose prose-sm dark:prose-invert max-w-full border-t pt-4 wrap-break-word"
             >
               <ReactMarkdown remarkPlugins={[remarkGfm]}>
                 {state.note.article.content}

--- a/web/src/features/note-sharing/SharedNotePage.tsx
+++ b/web/src/features/note-sharing/SharedNotePage.tsx
@@ -4,7 +4,7 @@ import { RefreshCw, Share } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import AttachmentsGrid from '@/components/rote/AttachmentsGrid';
 import { LinkPreviewCard } from '@/components/rote/LinkPreviewCard';
 import { Button } from '@/components/ui/button';
@@ -63,14 +63,25 @@ function SharedNoteReader({ token }: { token: string }) {
       ) : (
         <article className="space-y-4 px-5 py-4">
           <div className="flex items-center gap-3">
-            <UserAvatar avatar={state.note.author.avatar || ''} className="size-10" />
+            <Link
+              to={`/${encodeURIComponent(state.note.author.username)}`}
+              reloadDocument
+              aria-label={t('viewAuthor', {
+                name: state.note.author.nickname || state.note.author.username,
+              })}
+              className="shrink-0 rounded-full"
+            >
+              <UserAvatar avatar={state.note.author.avatar || ''} className="size-10" />
+            </Link>
             <div className="min-w-0">
-              <p
-                className="truncate font-medium"
+              <Link
+                to={`/${encodeURIComponent(state.note.author.username)}`}
+                reloadDocument
+                className="block truncate font-medium hover:underline"
                 title={state.note.author.nickname || state.note.author.username}
               >
                 {state.note.author.nickname || state.note.author.username}
-              </p>
+              </Link>
               <time dateTime={state.note.createdAt} className="text-muted-foreground text-xs">
                 {new Date(state.note.createdAt).toLocaleString(i18n.language)}
               </time>

--- a/web/src/features/note-sharing/SharedNoteSidebar.tsx
+++ b/web/src/features/note-sharing/SharedNoteSidebar.tsx
@@ -1,5 +1,6 @@
 import { Navigation } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
 import UserAvatar from '@/components/others/UserAvatar';
 import type { SharedNote } from './types';
 
@@ -17,7 +18,12 @@ export function SharedNoteSidebar({ note }: { note?: SharedNote }) {
         {t('about')}
       </div>
       {note && (
-        <div className="flex items-center gap-3 p-4">
+        <Link
+          to={`/${encodeURIComponent(note.author.username)}`}
+          reloadDocument
+          aria-label={t('viewAuthor', { name: note.author.nickname || note.author.username })}
+          className="hover:bg-foreground/5 flex items-center gap-3 p-4"
+        >
           <UserAvatar
             avatar={note.author.avatar}
             className="bg-foreground/5 text-primary size-12 shrink-0"
@@ -33,7 +39,7 @@ export function SharedNoteSidebar({ note }: { note?: SharedNote }) {
               @{note.author.username}
             </p>
           </div>
-        </div>
+        </Link>
       )}
       <div className="space-y-2 p-4 text-sm">
         <p className="font-medium">{t('readOnly')}</p>

--- a/web/src/layout/dashboard/index.tsx
+++ b/web/src/layout/dashboard/index.tsx
@@ -146,7 +146,13 @@ function LayoutDashboard({
 
   function IconRenderItem(icon: IconType) {
     return icon.link ? (
-      <Link key={icon.link} to={icon.link} aria-label={t(`leftNavBar.${icon.name}`)}>
+      <Link
+        key={icon.link}
+        to={icon.link}
+        // Account scripts must not survive a history navigation back to the reader.
+        reloadDocument={anonymousReader}
+        aria-label={t(`leftNavBar.${icon.name}`)}
+      >
         <div
           className={`flex cursor-pointer items-center justify-center gap-2 rounded-full p-2 px-3 text-base duration-300 ${
             location.pathname === icon.link

--- a/web/src/layout/dashboard/index.tsx
+++ b/web/src/layout/dashboard/index.tsx
@@ -12,7 +12,7 @@ import { tagsAtom } from '@/state/tags';
 import { authService } from '@/utils/auth';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { BrainCircuit, Globe2, Home, LogIn, LogOut, ScanFace, Shield, Snail } from 'lucide-react';
-import type { JSX } from 'react';
+import type { JSX, ReactNode } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, Outlet, useLocation } from 'react-router-dom';
@@ -80,7 +80,13 @@ export const tabsData: IconType[][] = [
   ],
 ];
 
-function LayoutDashboard() {
+function LayoutDashboard({
+  children,
+  anonymousReader = false,
+}: {
+  children?: ReactNode;
+  anonymousReader?: boolean;
+}) {
   const location = useLocation();
   const loadProfile = useSetAtom(loadProfileAtom);
   const setProfile = useSetAtom(profileAtom);
@@ -90,10 +96,12 @@ function LayoutDashboard() {
   const [isLogoutDialogOpen, setIsLogoutDialogOpen] = useState(false);
 
   useEffect(() => {
-    if (authReady && tokenValid && !profile) {
+    // The anonymous reader may display the existing local session's navigation,
+    // but reading must never trigger profile loading or a login redirect.
+    if (!anonymousReader && authReady && tokenValid && !profile) {
       loadProfile();
     }
-  }, [authReady, loadProfile, profile, tokenValid]);
+  }, [anonymousReader, authReady, loadProfile, profile, tokenValid]);
 
   const { t } = useTranslation('translation', { keyPrefix: 'pages.mine' });
 
@@ -138,7 +146,7 @@ function LayoutDashboard() {
 
   function IconRenderItem(icon: IconType) {
     return icon.link ? (
-      <Link key={icon.link} to={icon.link}>
+      <Link key={icon.link} to={icon.link} aria-label={t(`leftNavBar.${icon.name}`)}>
         <div
           className={`flex cursor-pointer items-center justify-center gap-2 rounded-full p-2 px-3 text-base duration-300 ${
             location.pathname === icon.link
@@ -177,14 +185,12 @@ function LayoutDashboard() {
           <div className="bg-background/90 text-primary fixed bottom-0 z-50 flex w-full shrink-0 flex-row items-start justify-around px-1 py-2 pb-6 backdrop-blur-xl sm:sticky sm:top-0 sm:h-dvh sm:w-fit sm:flex-col sm:justify-center sm:gap-4 sm:px-2 lg:w-[200px] lg:px-4">
             {tokenValid
               ? userTabs.map((icon) => IconRenderItem(icon))
-              : authReady
+              : authReady || anonymousReader
                 ? tabsData[1].map((icon) => IconRenderItem(icon))
                 : null}
           </div>
 
-          <div className="relative min-w-0 flex-1 overflow-visible">
-            <Outlet />
-          </div>
+          <div className="relative min-w-0 flex-1 overflow-visible">{children ?? <Outlet />}</div>
         </div>
 
         <Dialog open={isLogoutDialogOpen} onOpenChange={setIsLogoutDialogOpen}>

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1855,8 +1855,7 @@
       "saveFailed": "Save failed: {{error}}"
     },
     "sharedNote": {
-      "readingNavigation": "Reading navigation",
-      "note": "Note",
+      "sharedBy": "Note shared by {{name}}",
       "about": "About this note",
       "readOnly": "Read-only sharing",
       "readOnlyDescription": "Read without signing in. Refresh the page to see the author's latest changes.",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1856,6 +1856,7 @@
     },
     "sharedNote": {
       "sharedBy": "Note shared by {{name}}",
+      "viewAuthor": "View {{name}}'s profile",
       "about": "About this note",
       "readOnly": "Read-only sharing",
       "readOnlyDescription": "Read without signing in. Refresh the page to see the author's latest changes.",

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -1860,6 +1860,7 @@
     },
     "sharedNote": {
       "sharedBy": "{{name}}さんの共有ノート",
+      "viewAuthor": "{{name}}さんのプロフィールを見る",
       "about": "このノートについて",
       "readOnly": "閲覧専用の共有",
       "readOnlyDescription": "ログインせずに読めます。作者が内容を更新したら、ページを再読み込みしてください。",

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -1859,8 +1859,7 @@
       "saveFailed": "保存に失敗しました：{{error}}"
     },
     "sharedNote": {
-      "readingNavigation": "ページ内ナビゲーション",
-      "note": "ノート",
+      "sharedBy": "{{name}}さんの共有ノート",
       "about": "このノートについて",
       "readOnly": "閲覧専用の共有",
       "readOnlyDescription": "ログインせずに読めます。作者が内容を更新したら、ページを再読み込みしてください。",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1845,8 +1845,7 @@
       "saveFailed": "保存失败: {{error}}"
     },
     "sharedNote": {
-      "readingNavigation": "阅读导航",
-      "note": "笔记",
+      "sharedBy": "{{name}}分享的笔记",
       "about": "关于这篇笔记",
       "readOnly": "只读分享",
       "readOnlyDescription": "无需登录即可阅读。作者更新内容后，刷新页面即可查看。",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1846,6 +1846,7 @@
     },
     "sharedNote": {
       "sharedBy": "{{name}}分享的笔记",
+      "viewAuthor": "查看{{name}}的主页",
       "about": "关于这篇笔记",
       "readOnly": "只读分享",
       "readOnlyDescription": "无需登录即可阅读。作者更新内容后，刷新页面即可查看。",

--- a/web/src/utils/main.ts
+++ b/web/src/utils/main.ts
@@ -97,10 +97,13 @@ export function isTokenValid() {
     return false;
   }
 
-  const payload = jwtDecode(token) as { exp: number };
-  const isExpired = payload.exp * 1000 < Date.now();
-
-  return !isExpired;
+  try {
+    const { exp } = jwtDecode<{ exp?: number }>(token);
+    return typeof exp === 'number' && Number.isFinite(exp) && exp * 1000 > Date.now();
+  } catch {
+    // Malformed stored sessions are guests, including on anonymous reading pages.
+    return false;
+  }
 }
 
 export function formatBytes(bytes: number, decimals = 2) {


### PR DESCRIPTION
## Description

The anonymous reader used a separate reading-navigation rail instead of the public note page's account sidebar, its header did not identify the person sharing the note, and author references did not navigate anywhere. Reuse `LayoutDashboard` so guests see Login and signed-in visitors see the existing account navigation, including the mobile bottom bar. Replace the generic header with the author's nickname (or username) in Chinese, English and Japanese. Link the body avatar and nickname, and the sidebar's entire author card, to the author's existing public profile.

Anonymous content still loads independently of the account session: the layout does not bootstrap a profile or refresh credentials on this page. Malformed or expired stored refresh tokens are treated as guest sessions. Long author names truncate within the existing header, preserving the refresh button at narrow widths.

Account navigation from the reader loads a fresh document so account-page scripts do not persist when navigating back to shared content.

Text truncation only wraps string titles. Composed titles, including the public profile's avatar, name and verification badge, retain their existing horizontal flex layout.

## Type of Change

- [x] Bug fix and UI correction

## Testing

- [x] `bun run test -- src/features/note-sharing src/components/AppSession.test.tsx src/utils/__tests__/api.test.ts` (19 tests)
- [x] `bun run lint` and `bun run build` in `web/`
- [x] Browser: guest Login link, password login and existing signed-in navigation, malformed stored credentials, 320px bottom navigation, desktop layout and author header
- [x] Browser: body avatar and name clicks, sidebar edge click and all four corner hit targets; the destination is the public author profile, which does not expose the private shared note
- [x] Returning from an account page restores the anonymous reader without retaining account-page scripts
- [x] Long-name sizing check keeps the page within 320px and leaves the refresh button visible
- [x] Browser: public profile avatar, name and verification badge stay aligned horizontally on desktop and at 320px after the shared-header change

## Checklist

- [x] Existing layout, navigation labels and action hierarchy reused
- [x] Regression coverage for passive account navigation, nickname fallback and clearing author data after revocation
- [x] Normal commit workflow used without bypassing hooks

## Acceptance

Merge is on hold until the owner explicitly confirms local acceptance. This PR must not be auto-merged.
