### PR TITLE
fix(web): prevent stale service worker from breaking share links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,22 @@ jobs:
         working-directory: ${{ matrix.path }}
         run: bun run build
 
+      - name: Verify frontend cache headers
+        if: matrix.path == 'web'
+        working-directory: web
+        shell: bash
+        run: |
+          set -euo pipefail
+          container_id=$(docker run --rm -d -p 127.0.0.1:38081:80 \
+            -v "$PWD/dist:/usr/share/nginx/html:ro" \
+            -v "$PWD/nginx.conf:/etc/nginx/conf.d/default.conf:ro" nginx:alpine)
+          trap 'docker rm -f "$container_id" >/dev/null' EXIT
+          for attempt in {1..10}; do
+            if curl --silent --fail --head http://127.0.0.1:38081/ >/dev/null; then break; fi
+            sleep 1
+          done
+          bun run scripts/verify-cache-policy.ts http://127.0.0.1:38081
+
   note-sharing:
     runs-on: ubuntu-latest
     services:

--- a/doc/frontend-cache.md
+++ b/doc/frontend-cache.md
@@ -13,10 +13,13 @@ and share APIs remain excluded from offline caching.
 ## CDN configuration and rollout
 
 Origin headers alone cannot fix a CDN rule that forces a cache lifetime.
-For `rote.ink`, configure both the **node cache TTL** and **browser cache TTL**:
+`rote.ink` uses Tencent Cloud CDN (domain `cdn-brw4s7jx`), not EdgeOne.
+Configure both the **node cache TTL** and **browser cache TTL**:
 
-- `/assets/*`: respect origin caching; immutable versioned files may be cached.
-- All other paths: do not cache, preserving the origin's `no-store` response.
+- All files: respect origin caching, without heuristic caching when origin
+  headers are absent. This preserves immutable assets and the entry `no-store`.
+- Add higher-priority no-cache rules for stable entry files such as `/sw.js`,
+  `/registerSW.js`, `/index.html`, and `/manifest.json`, and share paths `/s/`.
 - Disable any rule that overwrites entry HTML or `/sw.js` with a positive
   `max-age`. The share paths must retain `no-referrer` and `noindex` headers.
 
@@ -47,5 +50,5 @@ the CDN configuration and purge. It uses only a synthetic share path and does
 not retrieve a real note or include a bearer token.
 
 References: [Vite PWA cache guidance](https://vite-pwa-org.netlify.app/deployment/),
-[EdgeOne node cache TTL](https://cloud.tencent.com/document/product/1552/70777),
-[EdgeOne browser cache TTL](https://edgeone.ai/document/46176).
+[Tencent CDN node cache TTL](https://cloud.tencent.com/document/product/228/47672),
+[Tencent CDN browser cache TTL](https://cloud.tencent.com/document/product/228/50114).

--- a/doc/frontend-cache.md
+++ b/doc/frontend-cache.md
@@ -1,0 +1,51 @@
+# Frontend cache policy
+
+The stable entry URLs select the current release. `web/nginx.conf` serves HTML,
+SPA navigations, `/sw.js`, `/registerSW.js`, and `/manifest.json` with
+`Cache-Control: no-store`. Only fingerprinted files under `/assets/` have a
+one-year immutable cache lifetime. Missing assets return 404 instead of HTML.
+
+The service worker's navigation request also uses `cache: 'no-store'`, so an
+older HTTP cache cannot supply the app shell after this worker activates.
+Workbox's revisioned asset precache is unchanged. Anonymous `/s/` navigation
+and share APIs remain excluded from offline caching.
+
+## CDN configuration and rollout
+
+Origin headers alone cannot fix a CDN rule that forces a cache lifetime.
+For `rote.ink`, configure both the **node cache TTL** and **browser cache TTL**:
+
+- `/assets/*`: respect origin caching; immutable versioned files may be cached.
+- All other paths: do not cache, preserving the origin's `no-store` response.
+- Disable any rule that overwrites entry HTML or `/sw.js` with a positive
+  `max-age`. The share paths must retain `no-referrer` and `noindex` headers.
+
+After updating these rules, purge the old `/`, `/index.html`, `/sw.js`,
+`/registerSW.js`, `/manifest.json`, and cached `/s/` entries. Browser and CDN
+caches are separate: changing origin configuration does not remove old edge
+objects or already-stored browser responses. Do not clear account storage or
+unregister push subscriptions to perform this rollout.
+
+An old service worker may still control the first navigation. After its update
+activates, reopen the original share link and check that the reader renders.
+Verify an existing browser session as well as a fresh session; adding a query
+parameter alone does not bypass an old worker's navigation handler.
+
+## Verification
+
+Build in `web/` with `bun run build`, then serve `web/dist` through Nginx using
+`web/nginx.conf`. Run:
+
+```sh
+bun run scripts/verify-cache-policy.ts http://127.0.0.1:38081
+```
+
+CI runs this HTTP check against an actual Nginx container. It checks entry files,
+SPA and share routes, fingerprinted JavaScript, missing assets, and sharing
+privacy headers. Run the same command with the deployed frontend origin after
+the CDN configuration and purge. It uses only a synthetic share path and does
+not retrieve a real note or include a bearer token.
+
+References: [Vite PWA cache guidance](https://vite-pwa-org.netlify.app/deployment/),
+[EdgeOne node cache TTL](https://cloud.tencent.com/document/product/1552/70777),
+[EdgeOne browser cache TTL](https://edgeone.ai/document/46176).

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -37,12 +37,13 @@ FROM nginx:alpine
 
 # 从构建阶段复制 Vite 的 /dist 目录产物到 Nginx 的服务目录
 COPY --from=builder /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 # 清理 Nginx 默认文件以减小镜像
 RUN rm -rf /usr/share/nginx/html/*.md && \
     rm -rf /etc/nginx/conf.d/default.conf.bak || true
 
-# 创建启动脚本（用于运行时注入 VITE_API_BASE 和配置 Nginx）
+# 创建启动脚本（用于运行时注入 VITE_API_BASE）
 RUN cat > /docker-entrypoint.sh << 'EOFSCRIPT' && chmod +x /docker-entrypoint.sh
 #!/bin/sh
 set -e
@@ -61,53 +62,6 @@ if [ -n "$VITE_API_BASE" ] && [ -f /usr/share/nginx/html/index.html ]; then
     echo "✓ 已插入配置脚本，VITE_API_BASE: ${VITE_API_BASE}"
   fi
 fi
-
-# 配置 Nginx（SPA 路由支持、静态资源缓存、Gzip 压缩）
-cat > /etc/nginx/conf.d/default.conf << 'NGINX_EOF'
-server {
-    listen 80;
-    server_name _;
-    root /usr/share/nginx/html;
-    index index.html;
-    
-    # 隐藏 Nginx 版本信息（安全）
-    server_tokens off;
-    
-    # SPA 路由支持
-    location ^~ /s/ {
-        access_log off;
-        add_header Cache-Control "no-store" always;
-        add_header Referrer-Policy "no-referrer" always;
-        add_header X-Robots-Tag "noindex, nofollow, noarchive" always;
-        try_files /index.html =404;
-    }
-
-    location / {
-        try_files $uri $uri/ /index.html;
-    }
-    
-    # 静态资源缓存（长期缓存）
-    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot|webp|avif)$ {
-        expires 1y;
-        add_header Cache-Control "public, immutable";
-        access_log off;
-    }
-    
-    # HTML 文件不缓存
-    location ~* \.html$ {
-        expires -1;
-        add_header Cache-Control "no-store, no-cache, must-revalidate";
-    }
-    
-    # Gzip 压缩（优化传输大小）
-    gzip on;
-    gzip_vary on;
-    gzip_min_length 1024;
-    gzip_comp_level 6;
-    gzip_types text/plain text/css text/xml text/javascript application/javascript application/json application/xml+rss;
-    gzip_disable "msie6";
-}
-NGINX_EOF
 
 # 启动 Nginx
 exec nginx -g "daemon off;"

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -1,0 +1,46 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+    server_tokens off;
+
+    # Stable URLs select the current release. Only fingerprinted Vite assets
+    # below may be immutable; this also covers HTML and manifest.json.
+    add_header Cache-Control "no-store" always;
+
+    location = /sw.js {
+        try_files $uri =404;
+    }
+
+    location = /registerSW.js {
+        try_files $uri =404;
+    }
+
+    # Share bearer paths must not appear in access logs or referrers.
+    location ^~ /s/ {
+        access_log off;
+        add_header Cache-Control "no-store" always;
+        add_header Referrer-Policy "no-referrer" always;
+        add_header X-Robots-Tag "noindex, nofollow, noarchive" always;
+        try_files /index.html =404;
+    }
+
+    location ^~ /assets/ {
+        try_files $uri =404;
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+        access_log off;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_comp_level 6;
+    gzip_types text/plain text/css text/xml text/javascript application/javascript application/json application/xml+rss;
+    gzip_disable "msie6";
+}

--- a/web/scripts/verify-cache-policy.ts
+++ b/web/scripts/verify-cache-policy.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+
+const origin = process.argv[2];
+assert(origin, 'Usage: bun run scripts/verify-cache-policy.ts <frontend-origin>');
+
+async function get(path: string) {
+  return fetch(new URL(path, origin), { redirect: 'error', cache: 'no-store' });
+}
+
+const index = await get('/index.html');
+const html = await index.text();
+const asset = html.match(/src="(\/assets\/[^"\s]+\.js)"/)?.[1];
+assert(asset, 'The built entry HTML must reference a fingerprinted JavaScript asset');
+
+for (const path of [
+  '/',
+  '/index.html',
+  '/home',
+  '/sw.js',
+  '/manifest.json',
+  '/s/cache-policy-check',
+]) {
+  const response = await get(path);
+  assert.equal(response.status, 200, `${path}: status`);
+  assert.match(
+    response.headers.get('cache-control') ?? '',
+    /\bno-store\b/,
+    `${path}: cache policy`
+  );
+  assert.doesNotMatch(
+    response.headers.get('cache-control') ?? '',
+    /immutable|(?:s-)?max-age=[1-9]/,
+    `${path}: stale cache`
+  );
+  if (path.startsWith('/s/')) {
+    assert.equal(response.headers.get('referrer-policy'), 'no-referrer');
+    assert.match(response.headers.get('x-robots-tag') ?? '', /noindex/);
+  }
+  if (path === '/sw.js') {
+    assert.match(response.headers.get('content-type') ?? '', /javascript/);
+  }
+  process.stdout.write(`PASS ${path}\n`);
+}
+
+const versioned = await get(asset);
+assert.equal(versioned.status, 200);
+assert.match(versioned.headers.get('cache-control') ?? '', /immutable/);
+assert.match(versioned.headers.get('cache-control') ?? '', /max-age=31536000/);
+assert.match(versioned.headers.get('content-type') ?? '', /javascript/);
+assert.equal((await get('/assets/missing-cache-check.js')).status, 404);
+assert.equal((await get('/registerSW.js')).headers.get('cache-control'), 'no-store');
+process.stdout.write(
+  'PASS fingerprinted assets stay immutable; missing scripts never become HTML\n'
+);

--- a/web/src/sw.js
+++ b/web/src/sw.js
@@ -43,8 +43,9 @@ registerRoute(
   new StaleWhileRevalidate({ cacheName: 'api-cache' })
 );
 
-// 导航回退到 index.html（由 Workbox 预缓存）
-const handler = async () => fetch('/index.html');
+// Resolve the current shell without reusing a previously long-lived HTTP cache.
+// Workbox's revisioned precache remains separate from this navigation request.
+const handler = async () => fetch('/index.html', { cache: 'no-store' });
 const navigationRoute = new NavigationRoute(handler, {
   denylist: [/^\/api\//, /\/sw\.js$/, /^\/\.well-known\//, /^\/s\//],
 });


### PR DESCRIPTION
## Description

Existing browsers could keep an old app shell that has no anonymous share route, causing valid share links to show 404. The origin treated `sw.js` as a one-year immutable asset, while CDN rules also assigned stable entry URLs a 30-day lifetime.

Serve stable entry files and SPA navigations with `no-store`, retain immutable caching only for fingerprinted assets, and bypass the browser HTTP cache when the service worker fetches the current shell. Preserve anonymous sharing privacy headers and cache exclusions. Document the Tencent CDN rollout and add an actual Nginx HTTP policy check to CI.

## Type of Change

- [x] Bug fix
- [x] Documentation update

## Testing

- [x] Frontend `bun run lint`
- [x] Frontend `bun run build`
- [x] Note-sharing and AppSession tests: 16 passed across 3 files
- [x] Actual `nginx:alpine` container: `nginx -t` and `bun run scripts/verify-cache-policy.ts http://127.0.0.1:32778` passed
- [x] `git diff --check`

## Checklist

- [x] Self-reviewed the final diff
- [x] Updated operational documentation
- [x] Added regression coverage for entry, share, immutable asset, and missing-script responses

## Additional Notes

Production rollout completed on 2026-09-06. Tencent CDN node and browser defaults now respect origin headers, with heuristic caching disabled and higher-priority node bypass rules for stable entry files and the share directory. The five entry URLs and share directory were purged successfully.

GitHub deployment run `34040913446` passed. Dokploy deployment `na5z6tgYat2vvE2fAXcvN` completed for merge commit `8bbff9102b777dfebede7e33cae8d4128e633a5a`. The complete HTTP cache policy script passed against `https://rote.ink`, and `/sw.js` now returns `Cache-Control: no-store`. The original share rendered its note in the previously stale browser session after reload, including a second check after deployment. No account storage or push subscriptions were cleared.

No UI layout changes or real share tokens are included in this PR.
