### PR TITLE
fix: upload web attachments directly to final storage keys

### DIFF
--- a/server/attachments/attachmentUpload.test.ts
+++ b/server/attachments/attachmentUpload.test.ts
@@ -382,6 +382,164 @@ describe('attachment upload flow', () => {
     ]);
   });
 
+  it('presigns a browser-generated preview directly at the final attachment key', async () => {
+    const signed: Array<{ contentLength?: number; key: string }> = [];
+    let reservation:
+      | Parameters<
+          NonNullable<Parameters<typeof presignAttachmentUploads>[1]['createUploadReservation']>
+        >[0]
+      | undefined;
+    const result = await presignAttachmentUploads(
+      {
+        directFinalUpload: true,
+        files: [
+          {
+            compressed: { contentType: 'image/webp', size: 256 },
+            contentType: 'image/jpeg',
+            filename: 'photo.jpg',
+            mediaKind: 'image',
+            size: 1024,
+          },
+        ],
+        scopes: [],
+        userId: USER_ID,
+      },
+      {
+        createUploadReservation: async (input) => {
+          reservation = input;
+          return true;
+        },
+        getAttachmentUploadPolicy: async () => uploadPolicy,
+        getResourceStateForUserId: async () => ({
+          management: 'official',
+          source: 'official_pro',
+          storage: {
+            enforcement: 'enforce',
+            usedBytes: '0',
+            reservedBytes: '0',
+            limitBytes: '10000000000',
+            overLimit: false,
+            canUpload: true,
+          },
+          openKey: {
+            policy: 'unlimited',
+            creationThreshold: null,
+            existingCount: 2,
+            canCreate: true,
+          },
+        }),
+        presignPutUrl: async (key, _contentType, _expiresIn, contentLength) => {
+          signed.push({ contentLength, key });
+          return { putUrl: `https://put.example.com/${key}`, url: `${URL_PREFIX}/${key}` };
+        },
+        randomUUID: () => LIVE_UUID,
+        requireStorageAvailable: () => storageConfig,
+      }
+    );
+
+    const compressedKey = `users/${USER_ID}/attachments/${LIVE_UUID}/compressed.webp`;
+    expect(result.items[0].compressed?.key).toBe(compressedKey);
+    expect(reservation?.manifest.map(({ role, declaredBytes }) => [role, declaredBytes])).toEqual([
+      ['original', '1024'],
+      ['compressed', '256'],
+    ]);
+    expect(signed).toEqual([
+      {
+        contentLength: 1024,
+        key: `users/${USER_ID}/attachments/${LIVE_UUID}/original.jpg`,
+      },
+      { contentLength: 256, key: compressedKey },
+    ]);
+  });
+
+  it('finalizes an unbound direct upload without reading or copying storage objects', async () => {
+    const originalKey = `users/${USER_ID}/attachments/${LIVE_UUID}/original.jpg`;
+    const compressedKey = `users/${USER_ID}/attachments/${LIVE_UUID}/compressed.webp`;
+    const manifest = [
+      {
+        billable: true,
+        contentType: 'image/jpeg',
+        declaredBytes: '1024',
+        finalKey: originalKey,
+        role: 'original' as const,
+        stagingKey: originalKey,
+        uuid: LIVE_UUID,
+      },
+      {
+        billable: false,
+        contentType: 'image/webp',
+        declaredBytes: '256',
+        finalKey: compressedKey,
+        role: 'compressed' as const,
+        stagingKey: compressedKey,
+        uuid: LIVE_UUID,
+      },
+    ];
+    let completedObjects: Array<{ finalKey: string }> = [];
+    const managedTransaction = {
+      select: () => ({
+        from: () => ({
+          where: () => ({
+            limit: () => ({
+              for: async () => [{ id: USER_ID }],
+            }),
+          }),
+        }),
+      }),
+    };
+
+    const result = await finalizeAttachmentUploads(
+      {
+        attachments: [
+          {
+            mediaKind: 'image',
+            mimetype: 'image/jpeg',
+            compressedKey,
+            originalKey,
+            size: 1024,
+            uuid: LIVE_UUID,
+          },
+        ],
+        reservationId: LIVE_UUID,
+        scopes: [],
+        userId: USER_ID,
+      },
+      {
+        checkObjectExists: async () => {
+          throw new Error('direct final uploads must not HEAD storage');
+        },
+        completeUploadReservation: async ({ objects }) => {
+          completedObjects = objects;
+        },
+        copyObjectIfMatch: async () => {
+          throw new Error('direct final uploads must not COPY storage');
+        },
+        getAttachmentUploadPolicy: async () => uploadPolicy,
+        getObjectInfo: async () => {
+          throw new Error('direct final uploads must not inspect storage');
+        },
+        getPendingUploadReservation: async () =>
+          ({
+            manifest,
+            status: 'pending',
+          }) as never,
+        requireStorageAvailable: () => storageConfig,
+        upsertAttachmentsByOriginalKey: async (_userId, noteId, uploads, transaction) => {
+          expect(noteId).toBeUndefined();
+          expect(transaction).toBe(managedTransaction);
+          return uploads.map((upload) => ({ id: 'attachment-1', ...upload }));
+        },
+      },
+      managedTransaction,
+      { manageTransaction: false }
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].url).toBe(`${URL_PREFIX}/${originalKey}`);
+    expect(result[0].compressUrl).toBe(`${URL_PREFIX}/${compressedKey}`);
+    expect(completedObjects.map(({ finalKey }) => finalKey)).toEqual([originalKey, compressedKey]);
+  });
+
   it('presigns a direct video and its client-generated poster at final keys', async () => {
     const signed: Array<{ contentLength?: number; key: string }> = [];
     let reservation:

--- a/server/attachments/directFinalUpload.test.ts
+++ b/server/attachments/directFinalUpload.test.ts
@@ -10,6 +10,7 @@ const RESERVATION_ID = '33333333-3333-4333-8333-333333333333';
 const NOTE_ID = '44444444-4444-4444-8444-444444444444';
 const CLIENT_ID = '55555555-5555-4555-8555-555555555555';
 const ORIGINAL_KEY = `users/${USER_ID}/attachments/${ATTACHMENT_ID}/original.jpg`;
+const COMPRESSED_KEY = `users/${USER_ID}/attachments/${ATTACHMENT_ID}/compressed.webp`;
 
 const manifest = (): UploadReservationManifestItem[] => [
   {
@@ -41,6 +42,19 @@ const input = (): FinalizeAttachmentBatchInput => ({
   reservationId: RESERVATION_ID,
 });
 
+const manifestWithCompressed = (): UploadReservationManifestItem[] => [
+  ...manifest(),
+  {
+    billable: false,
+    contentType: 'image/webp',
+    declaredBytes: '256',
+    finalKey: COMPRESSED_KEY,
+    role: 'compressed',
+    stagingKey: COMPRESSED_KEY,
+    uuid: ATTACHMENT_ID,
+  },
+];
+
 describe('direct final attachment upload', () => {
   it('builds database uploads entirely from the reservation manifest', () => {
     const prepared = prepareDirectFinalUpload(
@@ -65,6 +79,21 @@ describe('direct final attachment upload', () => {
     expect(() =>
       prepareDirectFinalUpload(mismatched, manifest(), USER_ID, 'https://cdn.example.com')
     ).toThrow('resource_upload_manifest_mismatch');
+  });
+
+  it('uses a required direct-upload preview from the reservation manifest', () => {
+    const withCompressed = input();
+    withCompressed.attachments[0].compressedKey = COMPRESSED_KEY;
+
+    const prepared = prepareDirectFinalUpload(
+      withCompressed,
+      manifestWithCompressed(),
+      USER_ID,
+      'https://cdn.example.com'
+    );
+
+    expect(prepared.objects.map(({ actualBytes }) => actualBytes)).toEqual([1024n, 256n]);
+    expect(prepared.uploads[0].compressUrl).toBe(`https://cdn.example.com/${COMPRESSED_KEY}`);
   });
 
   it('does not treat staging reservations as direct final uploads', () => {

--- a/server/attachments/directFinalUpload.ts
+++ b/server/attachments/directFinalUpload.ts
@@ -2,8 +2,8 @@ import type { UploadResult } from '../types/main';
 import { inferAttachmentMediaKind } from '../utils/fileValidation';
 import { RESOURCE_ERROR_CODES, ResourcePolicyError } from '../resources/errors';
 import type { UploadReservationManifestItem } from '../resources/service';
-import type { FinalizeAttachmentBatchInput, FinalizeAttachmentInput } from './types';
-import { assertCompleteRequiredManifest, toUploadResult } from './finalizeUpload';
+import type { FinalizeAttachmentInput } from './types';
+import { assertCompleteRequiredManifest, toUploadResult } from './finalizePayload';
 
 export type PreparedDirectFinalUpload = {
   objects: Array<UploadReservationManifestItem & { actualBytes: bigint }>;
@@ -35,7 +35,7 @@ function exactDeclaredBytes(
 }
 
 export function prepareDirectFinalUpload(
-  input: FinalizeAttachmentBatchInput,
+  input: { attachments: FinalizeAttachmentInput[] },
   manifest: readonly UploadReservationManifestItem[],
   userId: string,
   urlPrefix: string
@@ -58,7 +58,6 @@ export function prepareDirectFinalUpload(
     const paired = objects.find((item) => item.role === 'paired_video');
     const poster = objects.find((item) => item.role === 'poster');
     const compressed = objects.find((item) => item.role === 'compressed');
-    if (compressed) invalid();
 
     const size = exactDeclaredBytes(attachment.size, original);
     if (
@@ -89,7 +88,7 @@ export function prepareDirectFinalUpload(
 
     const normalized: FinalizeAttachmentInput = {
       ...attachment,
-      compressedKey: undefined,
+      compressedKey: compressed?.finalKey,
       mediaKind,
       mimetype: original.contentType,
       originalKey: original.finalKey,

--- a/server/attachments/finalizePayload.ts
+++ b/server/attachments/finalizePayload.ts
@@ -1,0 +1,93 @@
+import { RESOURCE_ERROR_CODES, ResourcePolicyError } from '../resources/errors';
+import type { UploadReservationManifestItem } from '../resources/service';
+import type { UploadResult } from '../types/main';
+import { inferAttachmentMediaKind } from '../utils/fileValidation';
+import type { FinalizeAttachmentInput } from './types';
+
+export function assertCompleteRequiredManifest(
+  attachments: readonly FinalizeAttachmentInput[],
+  manifest: readonly UploadReservationManifestItem[],
+  requireDerivedParts = false
+) {
+  const submitted = new Map<
+    string,
+    { uuid: string; role: UploadReservationManifestItem['role'] }
+  >();
+  for (const attachment of attachments) {
+    const entries: Array<[string | undefined, UploadReservationManifestItem['role']]> = [
+      [attachment.originalKey, 'original'],
+      [attachment.compressedKey, 'compressed'],
+      [attachment.posterKey, 'poster'],
+      [attachment.pairedVideoKey, 'paired_video'],
+    ];
+    for (const [key, role] of entries) {
+      if (!key) continue;
+      if (submitted.has(key)) {
+        throw new ResourcePolicyError(RESOURCE_ERROR_CODES.uploadManifestMismatch);
+      }
+      submitted.set(key, { uuid: attachment.uuid, role });
+    }
+  }
+  const expectedByKey = new Map(manifest.map((item) => [item.stagingKey, item]));
+  for (const [key, actual] of submitted) {
+    const expected = expectedByKey.get(key);
+    if (!expected || expected.uuid !== actual.uuid || expected.role !== actual.role) {
+      throw new ResourcePolicyError(RESOURCE_ERROR_CODES.uploadManifestMismatch);
+    }
+  }
+  const required = requireDerivedParts
+    ? manifest
+    : manifest.filter((item) => item.role === 'original' || item.role === 'paired_video');
+  if (required.some((item) => !submitted.has(item.stagingKey))) {
+    throw new ResourcePolicyError(RESOURCE_ERROR_CODES.uploadManifestMismatch);
+  }
+  const originalUuids = manifest
+    .filter((item) => item.role === 'original')
+    .map((item) => item.uuid);
+  if (
+    new Set(originalUuids).size !== originalUuids.length ||
+    attachments.length !== originalUuids.length ||
+    new Set(attachments.map((item) => item.uuid)).size !== attachments.length
+  ) {
+    throw new ResourcePolicyError(RESOURCE_ERROR_CODES.uploadManifestMismatch);
+  }
+}
+
+export function toUploadResult(urlPrefix: string, item: FinalizeAttachmentInput): UploadResult {
+  const mediaKind = inferAttachmentMediaKind({
+    mediaKind: item.mediaKind,
+    mimetype: item.mimetype || null,
+    compressedKey: item.compressedKey,
+    posterKey: item.posterKey,
+    pairedVideoKey: item.pairedVideoKey,
+  });
+  const pairedVideoUrl =
+    mediaKind === 'livePhoto' && item.pairedVideoKey ? urlPrefix + '/' + item.pairedVideoKey : null;
+  const details: any = {
+    size: item.size || 0,
+    mimetype: item.mimetype || null,
+    mediaKind,
+    mtime: new Date().toISOString(),
+    key: item.originalKey,
+  };
+  if (item.compressedKey) details.compressKey = item.compressedKey;
+  if (item.posterKey) details.posterKey = item.posterKey;
+  if (pairedVideoUrl && item.pairedVideoKey) {
+    details.pairedVideoKey = item.pairedVideoKey;
+    details.pairedVideoUrl = pairedVideoUrl;
+    details.pairedVideoMimetype = item.pairedVideoMimetype || null;
+    details.pairedVideoSize = item.pairedVideoSize || 0;
+    if (item.pairedVideoFilename) details.pairedVideoFilename = item.pairedVideoFilename;
+  }
+  if (item.hash) details.hash = item.hash;
+
+  return {
+    url: urlPrefix + '/' + item.originalKey,
+    compressUrl:
+      (mediaKind === 'image' || mediaKind === 'livePhoto') && item.compressedKey
+        ? urlPrefix + '/' + item.compressedKey
+        : null,
+    posterUrl: mediaKind === 'video' && item.posterKey ? urlPrefix + '/' + item.posterKey : null,
+    details,
+  };
+}

--- a/server/attachments/finalizeUpload.ts
+++ b/server/attachments/finalizeUpload.ts
@@ -1,4 +1,3 @@
-import type { UploadResult } from '../types/main';
 import {
   extractCompressedUuid,
   extractOriginalUploadUuid,
@@ -35,6 +34,14 @@ import { RESOURCE_ERROR_CODES, ResourcePolicyError } from '../resources/errors';
 import db from '../utils/drizzle';
 import { users } from '../drizzle/schema';
 import { eq } from 'drizzle-orm';
+import { assertCompleteRequiredManifest, toUploadResult } from './finalizePayload';
+import {
+  isDirectFinalUploadManifest,
+  prepareDirectFinalUpload,
+  type PreparedDirectFinalUpload,
+} from './directFinalUpload';
+
+export { assertCompleteRequiredManifest, toUploadResult } from './finalizePayload';
 
 export type FinalizeAttachmentDependencies = {
   checkObjectExists: typeof checkObjectExists;
@@ -65,55 +72,6 @@ type FinalizedManagedObject = UploadReservationManifestItem & { actualBytes: big
 export function completedLegacyFinalizeResult(result: unknown): any[] {
   if (Array.isArray(result)) return result;
   throw new ResourcePolicyError(RESOURCE_ERROR_CODES.uploadManifestMismatch);
-}
-
-export function assertCompleteRequiredManifest(
-  attachments: readonly FinalizeAttachmentInput[],
-  manifest: readonly UploadReservationManifestItem[],
-  requireDerivedParts = false
-) {
-  const submitted = new Map<
-    string,
-    { uuid: string; role: UploadReservationManifestItem['role'] }
-  >();
-  for (const attachment of attachments) {
-    const entries: Array<[string | undefined, UploadReservationManifestItem['role']]> = [
-      [attachment.originalKey, 'original'],
-      [attachment.compressedKey, 'compressed'],
-      [attachment.posterKey, 'poster'],
-      [attachment.pairedVideoKey, 'paired_video'],
-    ];
-    for (const [key, role] of entries) {
-      if (!key) continue;
-      if (submitted.has(key)) {
-        throw new ResourcePolicyError(RESOURCE_ERROR_CODES.uploadManifestMismatch);
-      }
-      submitted.set(key, { uuid: attachment.uuid, role });
-    }
-  }
-  const expectedByKey = new Map(manifest.map((item) => [item.stagingKey, item]));
-  for (const [key, actual] of submitted) {
-    const expected = expectedByKey.get(key);
-    if (!expected || expected.uuid !== actual.uuid || expected.role !== actual.role) {
-      throw new ResourcePolicyError(RESOURCE_ERROR_CODES.uploadManifestMismatch);
-    }
-  }
-  const required = requireDerivedParts
-    ? manifest
-    : manifest.filter((item) => item.role === 'original' || item.role === 'paired_video');
-  if (required.some((item) => !submitted.has(item.stagingKey))) {
-    throw new ResourcePolicyError(RESOURCE_ERROR_CODES.uploadManifestMismatch);
-  }
-  const originalUuids = manifest
-    .filter((item) => item.role === 'original')
-    .map((item) => item.uuid);
-  if (
-    new Set(originalUuids).size !== originalUuids.length ||
-    attachments.length !== originalUuids.length ||
-    new Set(attachments.map((item) => item.uuid)).size !== attachments.length
-  ) {
-    throw new ResourcePolicyError(RESOURCE_ERROR_CODES.uploadManifestMismatch);
-  }
 }
 
 async function promoteManagedObjects(
@@ -313,50 +271,12 @@ async function collectValidAttachments(
   return validAttachments;
 }
 
-export function toUploadResult(urlPrefix: string, item: FinalizeAttachmentInput): UploadResult {
-  const mediaKind = inferAttachmentMediaKind({
-    mediaKind: item.mediaKind,
-    mimetype: item.mimetype || null,
-    compressedKey: item.compressedKey,
-    posterKey: item.posterKey,
-    pairedVideoKey: item.pairedVideoKey,
-  });
-  const pairedVideoUrl =
-    mediaKind === 'livePhoto' && item.pairedVideoKey ? urlPrefix + '/' + item.pairedVideoKey : null;
-  const details: any = {
-    size: item.size || 0,
-    mimetype: item.mimetype || null,
-    mediaKind,
-    mtime: new Date().toISOString(),
-    key: item.originalKey,
-  };
-  if (item.compressedKey) details.compressKey = item.compressedKey;
-  if (item.posterKey) details.posterKey = item.posterKey;
-  if (pairedVideoUrl && item.pairedVideoKey) {
-    details.pairedVideoKey = item.pairedVideoKey;
-    details.pairedVideoUrl = pairedVideoUrl;
-    details.pairedVideoMimetype = item.pairedVideoMimetype || null;
-    details.pairedVideoSize = item.pairedVideoSize || 0;
-    if (item.pairedVideoFilename) details.pairedVideoFilename = item.pairedVideoFilename;
-  }
-  if (item.hash) details.hash = item.hash;
-
-  return {
-    url: urlPrefix + '/' + item.originalKey,
-    compressUrl:
-      (mediaKind === 'image' || mediaKind === 'livePhoto') && item.compressedKey
-        ? urlPrefix + '/' + item.compressedKey
-        : null,
-    posterUrl: mediaKind === 'video' && item.posterKey ? urlPrefix + '/' + item.posterKey : null,
-    details,
-  };
-}
-
 export async function finalizeAttachmentUploads(
   input: {
     userId: string;
     scopes: string[];
     noteId?: string;
+    reservationId?: string;
     attachments?: FinalizeAttachmentInput[];
   },
   dependencyOverrides: Partial<FinalizeAttachmentDependencies> = {},
@@ -365,10 +285,16 @@ export async function finalizeAttachmentUploads(
 ): Promise<any[]> {
   const dependencies = { ...defaultDependencies, ...dependencyOverrides };
   const requestedReservationIds = new Set(
-    (input.attachments ?? [])
-      .map((item) => reservationIdFromStagingKey(item.originalKey))
-      .filter((id): id is string => Boolean(id))
+    [
+      input.reservationId?.toLowerCase(),
+      ...(input.attachments ?? []).map((item) =>
+        reservationIdFromStagingKey(item.originalKey)?.toLowerCase()
+      ),
+    ].filter((id): id is string => Boolean(id))
   );
+  if (requestedReservationIds.size > 1) {
+    throw new ResourcePolicyError(RESOURCE_ERROR_CODES.uploadManifestMismatch);
+  }
   if (
     behavior.manageTransaction !== false &&
     !managedTransaction &&
@@ -415,6 +341,7 @@ export async function finalizeAttachmentUploads(
   if (hasVideo && !uploadPolicy.canUploadVideo)
     throw new Error(attachmentErrors.capabilityVideoUpload);
 
+  let directFinalUpload: PreparedDirectFinalUpload | null = null;
   if (managedTransaction && requestedReservationIds.size === 1) {
     const [lockedUser] = await managedTransaction
       .select({ id: users.id })
@@ -432,11 +359,46 @@ export async function finalizeAttachmentUploads(
     );
     if (!claimed) throw new ResourcePolicyError(RESOURCE_ERROR_CODES.uploadManifestMismatch);
     if (claimed.status === 'completed') return completedLegacyFinalizeResult(claimed.result);
-    assertCompleteRequiredManifest(
-      input.attachments,
-      claimed.manifest,
-      behavior.strictValidation === true
+    if (isDirectFinalUploadManifest(claimed.manifest)) {
+      directFinalUpload = prepareDirectFinalUpload(
+        { attachments: input.attachments },
+        claimed.manifest,
+        input.userId,
+        storageConfig.urlPrefix
+      );
+    } else {
+      assertCompleteRequiredManifest(
+        input.attachments,
+        claimed.manifest,
+        behavior.strictValidation === true
+      );
+    }
+  }
+
+  if (directFinalUpload) {
+    if (input.noteId) {
+      const currentAttachments = await dependencies.getAttachmentDetailsByRoteId(input.noteId);
+      validateRoteAttachmentDetails([
+        ...currentAttachments,
+        ...directFinalUpload.uploads.map((upload) => ({ details: upload.details })),
+      ]);
+    }
+    const finalized = await dependencies.upsertAttachmentsByOriginalKey(
+      input.userId,
+      input.noteId,
+      directFinalUpload.uploads,
+      managedTransaction
     );
+    await dependencies.completeUploadReservation(
+      {
+        userId: input.userId,
+        reservationId: [...requestedReservationIds][0]!,
+        result: finalized,
+        objects: directFinalUpload.objects,
+      },
+      managedTransaction
+    );
+    return finalized;
   }
 
   const validAttachments = await collectValidAttachments(

--- a/server/attachments/presignUpload.ts
+++ b/server/attachments/presignUpload.ts
@@ -52,20 +52,33 @@ function validatePresignFile(
   directFinalUpload: boolean
 ) {
   validateContentType(file.contentType);
+  const compressedContentType = file.compressed?.contentType ?? file.compressedContentType;
   if (
-    file.compressedContentType !== undefined &&
-    file.compressedContentType !== 'image/jpeg' &&
-    file.compressedContentType !== 'image/webp'
+    compressedContentType !== undefined &&
+    compressedContentType !== 'image/jpeg' &&
+    compressedContentType !== 'image/webp'
   ) {
     throw new Error(attachmentErrors.compressedContentTypeInvalid);
   }
-  if (directFinalUpload && file.compressedContentType !== undefined) {
+  if (
+    file.compressed &&
+    file.compressedContentType &&
+    file.compressed.contentType !== file.compressedContentType
+  ) {
     throw new ResourcePolicyError(RESOURCE_ERROR_CODES.uploadManifestMismatch);
   }
   const mediaKind =
     file.mediaKind === 'livePhoto' ? 'livePhoto' : getMediaKindFromContentType(file.contentType);
-  if (directFinalUpload && mediaKind === 'video') {
-    if (file.poster?.contentType !== 'image/jpeg' || !file.poster.size) {
+  if (directFinalUpload && file.compressed) {
+    if (mediaKind !== 'image' && mediaKind !== 'livePhoto') {
+      throw new ResourcePolicyError(RESOURCE_ERROR_CODES.uploadManifestMismatch);
+    }
+    validateFileSize(file.compressed.size, file.compressed.contentType, maxVideoUploadSizeMB);
+  } else if (directFinalUpload && file.compressedContentType !== undefined) {
+    throw new ResourcePolicyError(RESOURCE_ERROR_CODES.uploadManifestMismatch);
+  }
+  if (directFinalUpload && file.poster) {
+    if (mediaKind !== 'video' || file.poster.contentType !== 'image/jpeg') {
       throw new ResourcePolicyError(RESOURCE_ERROR_CODES.uploadManifestMismatch);
     }
     validateFileSize(file.poster.size, file.poster.contentType, maxVideoUploadSizeMB);
@@ -135,8 +148,11 @@ export async function presignAttachmentUploads(
     const mediaKind =
       file.mediaKind === 'livePhoto' ? 'livePhoto' : getMediaKindFromContentType(file.contentType);
     const compressedContentType =
-      !directFinalUpload && (mediaKind === 'image' || mediaKind === 'livePhoto')
-        ? (file.compressedContentType ?? (mediaKind === 'livePhoto' ? 'image/jpeg' : 'image/webp'))
+      mediaKind === 'image' || mediaKind === 'livePhoto'
+        ? directFinalUpload
+          ? file.compressed?.contentType
+          : (file.compressedContentType ??
+            (mediaKind === 'livePhoto' ? 'image/jpeg' : 'image/webp'))
         : undefined;
     const finalPrefix = `users/${input.userId}`;
     const stagingPrefix = managed ? `${finalPrefix}/staging/${reservationId}` : finalPrefix;
@@ -164,15 +180,19 @@ export async function presignAttachmentUploads(
       const compressedExtension = compressedContentType === 'image/jpeg' ? 'jpg' : 'webp';
       compressed = {
         contentType: compressedContentType,
-        key: `${stagingPrefix}/compressed/${uuid}.${compressedExtension}`,
-        finalKey: `${finalPrefix}/compressed/${uuid}.${compressedExtension}`,
+        key: directFinalUpload
+          ? `${attachmentPrefix}/compressed.${compressedExtension}`
+          : `${stagingPrefix}/compressed/${uuid}.${compressedExtension}`,
+        finalKey: directFinalUpload
+          ? `${attachmentPrefix}/compressed.${compressedExtension}`
+          : `${finalPrefix}/compressed/${uuid}.${compressedExtension}`,
       };
       manifest.push({
         uuid,
         role: 'compressed',
         stagingKey: compressed.key,
         finalKey: compressed.finalKey,
-        declaredBytes: null,
+        declaredBytes: directFinalUpload ? String(file.compressed!.size) : null,
         contentType: compressed.contentType,
         billable: false,
       });
@@ -203,7 +223,7 @@ export async function presignAttachmentUploads(
       });
     }
     let poster: { key: string; finalKey: string; size: number } | undefined;
-    if (mediaKind === 'video') {
+    if (mediaKind === 'video' && (!directFinalUpload || file.poster)) {
       const posterSize = directFinalUpload ? (file.poster?.size ?? 0) : 0;
       poster = {
         key: directFinalUpload
@@ -258,19 +278,26 @@ export async function presignAttachmentUploads(
         };
 
         if ((mediaKind === 'image' || mediaKind === 'livePhoto') && compressed) {
-          const compressedUpload = managed
-            ? {
-                putUrl: dependencies.createDerivedUploadProxyUrl({
-                  reservationId: reservationId!,
-                  userId: input.userId,
-                  role: 'compressed',
-                  key: compressed.key,
-                  contentType: compressed.contentType,
-                  expiresAt: credentialExpiresAt,
-                }),
-                url: '',
-              }
-            : await dependencies.presignPutUrl(compressed.key, compressed.contentType, 15 * 60);
+          const compressedUpload = directFinalUpload
+            ? await dependencies.presignPutUrl(
+                compressed.key,
+                compressed.contentType,
+                15 * 60,
+                file.compressed!.size
+              )
+            : managed
+              ? {
+                  putUrl: dependencies.createDerivedUploadProxyUrl({
+                    reservationId: reservationId!,
+                    userId: input.userId,
+                    role: 'compressed',
+                    key: compressed.key,
+                    contentType: compressed.contentType,
+                    expiresAt: credentialExpiresAt,
+                  }),
+                  url: '',
+                }
+              : await dependencies.presignPutUrl(compressed.key, compressed.contentType, 15 * 60);
           result.compressed = {
             key: compressed.key,
             putUrl: compressedUpload.putUrl,
@@ -296,7 +323,7 @@ export async function presignAttachmentUploads(
         }
 
         if (mediaKind === 'video') {
-          if (!poster) throw new Error('Missing poster upload manifest');
+          if (!poster) return result;
           const posterUpload = directFinalUpload
             ? await dependencies.presignPutUrl(poster.key, 'image/jpeg', 15 * 60, poster.size)
             : managed

--- a/server/attachments/types.ts
+++ b/server/attachments/types.ts
@@ -8,6 +8,10 @@ export type PresignFileInput = {
   size?: number;
   mediaKind?: 'image' | 'video' | 'livePhoto';
   compressedContentType?: 'image/jpeg' | 'image/webp';
+  compressed?: {
+    contentType: 'image/jpeg' | 'image/webp';
+    size: number;
+  };
   pairedVideo?: {
     filename?: string;
     contentType?: string;

--- a/server/route/v2/attachment.ts
+++ b/server/route/v2/attachment.ts
@@ -185,10 +185,14 @@ attachmentsRouter.post(
   requireStorageConfig,
   async (c: HonoContext) => {
     const user = c.get('user') as User;
-    const { attachments, noteId } = (await c.req.json()) as {
+    const { attachments, noteId, reservationId } = (await c.req.json()) as {
       attachments?: FinalizeAttachmentInput[];
       noteId?: string;
+      reservationId?: string;
     };
+    if (reservationId && !isValidUUID(reservationId)) {
+      throw new ResourcePolicyError(RESOURCE_ERROR_CODES.uploadManifestMismatch, 400);
+    }
     const uploadPolicy = await getAttachmentUploadPolicy(user.id);
     if (!uploadPolicy.canUploadAttachments) {
       return c.json(createResponse(null, 'capability_required:attachment.upload'), 403);
@@ -203,6 +207,7 @@ attachmentsRouter.post(
     const result = await finalizeAttachmentUploads({
       attachments,
       noteId,
+      reservationId,
       scopes: ['video:upload'],
       userId: user.id,
     });

--- a/server/utils/zod.ts
+++ b/server/utils/zod.ts
@@ -138,6 +138,13 @@ export const AttachmentPresignZod = z.object({
         contentType: z.string().min(1, 'Content type cannot be empty'),
         size: z.number().int().positive('File size must be greater than 0'),
         mediaKind: z.enum(['image', 'video', 'livePhoto']).optional(),
+        compressedContentType: z.enum(['image/jpeg', 'image/webp']).optional(),
+        compressed: z
+          .object({
+            contentType: z.enum(['image/jpeg', 'image/webp']),
+            size: z.number().int().positive('Compressed image size must be greater than 0'),
+          })
+          .optional(),
         pairedVideo: z
           .object({
             filename: z.string().max(255, 'Filename cannot exceed 255 characters').optional(),

--- a/web/src/components/editor/RoteEditor.tsx
+++ b/web/src/components/editor/RoteEditor.tsx
@@ -6,9 +6,11 @@ import type { Article, Attachment, Rote } from '@/types/main';
 import { del, post, put } from '@/utils/api';
 import {
   finalize as finalizeUpload,
+  finalizeDirect,
   getUploadErrorMessage,
   isResourceUploadPolicyError,
   presign,
+  presignDirect,
   uploadToSignedUrl,
 } from '@/utils/directUpload';
 // 压缩与并发工具
@@ -68,6 +70,7 @@ function RoteEditor({ roteAtom, callback }: { roteAtom: RoteAtomType; callback?:
     siteStatus?.ui?.allowUploadFile !== false &&
     capabilities?.['attachment.upload'].allowed === true;
   const canUploadVideo = canUpload && capabilities?.['attachment.video.upload'].allowed === true;
+  const canUploadDirectlyToFinalKey = siteStatus?.ui?.attachmentDirectFinalUpload === true;
   const maxVideoUploadSizeMB =
     siteStatus?.ui?.maxVideoUploadSizeMB || DEFAULT_MAX_VIDEO_UPLOAD_SIZE_MB;
   const maxVideoUploadSizeBytes = maxVideoUploadSizeMB * 1024 * 1024;
@@ -311,17 +314,50 @@ function RoteEditor({ roteAtom, callback }: { roteAtom: RoteAtomType; callback?:
       });
 
       try {
-        const signItems = await presign(
-          files.map((f) => ({
-            filename: f.name,
-            contentType: f.type || 'application/octet-stream',
-            size: f.size,
-          }))
-        );
-
-        const pairs = signItems.map((item, idx) => ({ item, file: files[idx] }));
-
         const CONCURRENCY = 3;
+        const preparedFiles = canUploadDirectlyToFinalKey
+          ? await runConcurrency(
+              files,
+              async (file) => ({
+                compressedBlob: await maybeCompressToWebp(file, {
+                  maxWidthOrHeight: 2560,
+                  initialQuality: qualityForSize(file.size),
+                }),
+                file,
+                posterBlob: isVideoFile(file) ? await generateVideoPoster(file) : null,
+              }),
+              CONCURRENCY
+            ).then((results) =>
+              results.map((result) => {
+                if (!result.success || !result.result) {
+                  throw result.error || new Error(t('uploadFailed'));
+                }
+                return result.result;
+              })
+            )
+          : files.map((file) => ({ compressedBlob: null, file, posterBlob: null }));
+        const presignFiles = preparedFiles.map(({ compressedBlob, file, posterBlob }) => ({
+          filename: file.name,
+          contentType: file.type || 'application/octet-stream',
+          size: file.size,
+          ...(compressedBlob
+            ? {
+                compressed: {
+                  contentType: compressedBlob.type as 'image/jpeg' | 'image/webp',
+                  size: compressedBlob.size,
+                },
+              }
+            : {}),
+          ...(posterBlob
+            ? { poster: { contentType: 'image/jpeg' as const, size: posterBlob.size } }
+            : {}),
+        }));
+        const useDirectFinalUpload = canUploadDirectlyToFinalKey;
+        const directPresign = useDirectFinalUpload ? await presignDirect(presignFiles) : null;
+        const signItems = directPresign ? directPresign.items : await presign(presignFiles);
+
+        const pairs = signItems.map((item, idx) => ({ item, prepared: preparedFiles[idx] }));
+
         const toFinalize: Array<{
           uuid: string;
           originalKey: string;
@@ -334,19 +370,24 @@ function RoteEditor({ roteAtom, callback }: { roteAtom: RoteAtomType; callback?:
         // 使用改进后的 runConcurrency，获取每个任务的成功/失败状态
         const results = await runConcurrency(
           pairs,
-          async ({ item, file }, _index) => {
+          async ({ item, prepared }, _index) => {
+            const { compressedBlob, file, posterBlob } = prepared;
             // 防御：空文件不上传
             if (!file || (file as File).size === 0) {
               throw new Error('Empty file');
             }
 
-            const posterBlob = isVideoFile(file) ? await generateVideoPoster(file) : null;
-
-            // 先压缩图片（如果支持）
-            const compressedBlob = await maybeCompressToWebp(file, {
-              maxWidthOrHeight: 2560,
-              initialQuality: qualityForSize(file.size),
-            });
+            const derivedCompressedBlob = useDirectFinalUpload
+              ? compressedBlob
+              : await maybeCompressToWebp(file, {
+                  maxWidthOrHeight: 2560,
+                  initialQuality: qualityForSize(file.size),
+                });
+            const derivedPosterBlob = useDirectFinalUpload
+              ? posterBlob
+              : isVideoFile(file)
+                ? await generateVideoPoster(file)
+                : null;
 
             // 原图上传（必须成功）
             await uploadToSignedUrl(item.original.putUrl, file, (progress) => {
@@ -357,30 +398,16 @@ function RoteEditor({ roteAtom, callback }: { roteAtom: RoteAtomType; callback?:
               });
             });
 
-            // 压缩图上传（可选，失败不影响原图）
             let compressedKey: string | undefined;
             let posterKey: string | undefined;
-            if (compressedBlob && item.compressed) {
-              try {
-                await uploadToSignedUrl(item.compressed.putUrl, compressedBlob);
-                // 只有上传成功才记录 compressedKey
-                compressedKey = item.compressed.key;
-              } catch (error) {
-                // 压缩图上传失败，但不影响原图，只记录错误
-                // eslint-disable-next-line no-console
-                console.warn(`Compressed image upload failed for ${item.uuid}:`, error);
-                // 不设置 compressedKey，表示压缩图未成功上传
-              }
+            if (derivedCompressedBlob && item.compressed) {
+              await uploadToSignedUrl(item.compressed.putUrl, derivedCompressedBlob);
+              compressedKey = item.compressed.key;
             }
 
-            if (posterBlob && item.poster) {
-              try {
-                await uploadToSignedUrl(item.poster.putUrl, posterBlob);
-                posterKey = item.poster.key;
-              } catch (error) {
-                // eslint-disable-next-line no-console
-                console.warn(`Video poster upload failed for ${item.uuid}:`, error);
-              }
+            if (derivedPosterBlob && item.poster) {
+              await uploadToSignedUrl(item.poster.putUrl, derivedPosterBlob);
+              posterKey = item.poster.key;
             }
 
             // 只有原图上传成功（且压缩图上传成功或不需要压缩）才添加到 toFinalize
@@ -422,6 +449,10 @@ function RoteEditor({ roteAtom, callback }: { roteAtom: RoteAtomType; callback?:
 
         // 如果有部分文件失败，提示用户
         const failedCount = results.filter((r) => !r.success).length;
+        if (useDirectFinalUpload && failedCount > 0) {
+          const firstFailure = results.find((result) => !result.success);
+          throw firstFailure?.error || new Error(t('uploadFailed'));
+        }
         if (failedCount > 0) {
           toast.warning(
             `${failedCount} file(s) failed to upload, ${toFinalize.length} file(s) uploaded successfully.`
@@ -431,7 +462,9 @@ function RoteEditor({ roteAtom, callback }: { roteAtom: RoteAtomType; callback?:
         const finalizeData = toFinalize;
         // 批量 finalize，减少请求数
         const finalized = finalizeData.length
-          ? await finalizeUpload(finalizeData, rote.id || undefined)
+          ? directPresign
+            ? await finalizeDirect(finalizeData, directPresign.reservationId, rote.id || undefined)
+            : await finalizeUpload(finalizeData, rote.id || undefined)
           : [];
 
         // 用后端返回结果替换本地 File 占位
@@ -482,6 +515,7 @@ function RoteEditor({ roteAtom, callback }: { roteAtom: RoteAtomType; callback?:
     },
     [
       canUploadVideo,
+      canUploadDirectlyToFinalKey,
       maxVideoUploadSizeBytes,
       maxVideoUploadSizeMB,
       rote.attachments,

--- a/web/src/hooks/useSiteStatus.ts
+++ b/web/src/hooks/useSiteStatus.ts
@@ -48,6 +48,7 @@ interface SiteStatusData {
     allowRegistration: boolean;
     allowUploadFile: boolean;
     maxVideoUploadSizeMB: number;
+    attachmentDirectFinalUpload?: boolean;
   };
   oauth?: {
     enabled: boolean;

--- a/web/src/pages/article/edit.tsx
+++ b/web/src/pages/article/edit.tsx
@@ -5,10 +5,18 @@ import { Button } from '@/components/ui/button';
 import { ArticleDeleteConfirmDialog } from '@/components/article/ArticleDeleteConfirmDialog';
 import { Textarea } from '@/components/ui/textarea';
 import { useArticleActions } from '@/hooks/useArticleActions';
+import { useSiteStatus } from '@/hooks/useSiteStatus';
 import ContainerWithSideBar from '@/layout/ContainerWithSideBar';
 import { profileAtom } from '@/state/profile';
 import { createArticle, getArticleFull, updateArticle } from '@/utils/articleApi';
-import { finalize, getUploadErrorMessage, presign, uploadToSignedUrl } from '@/utils/directUpload';
+import {
+  finalize,
+  finalizeDirect,
+  getUploadErrorMessage,
+  presign,
+  presignDirect,
+  uploadToSignedUrl,
+} from '@/utils/directUpload';
 import { parseMarkdownMeta } from '@/utils/markdownParser';
 import { maybeCompressToWebp } from '@/utils/uploadHelpers';
 import { ArrowUpRight, Edit3, Eye, Heading1, Save, Signature, Trash2, X } from 'lucide-react';
@@ -38,6 +46,8 @@ export default function ArticleEditPage() {
   const [, startTransition] = useTransition();
   const [minRows, setMinRows] = useState(20);
   const profile = useAtomValue(profileAtom);
+  const { data: siteStatus } = useSiteStatus();
+  const supportsDirectFinalUpload = siteStatus?.ui?.attachmentDirectFinalUpload === true;
 
   useEffect(() => {
     const lineHeight = 21; // font-mono text-sm ≈ 1.375 * 14px ≈ 21px
@@ -195,9 +205,23 @@ export default function ArticleEditPage() {
     for (const { file, placeholder } of uploads) {
       try {
         const compressed = await maybeCompressToWebp(file);
-        const presignFiles = [{ filename: file.name, contentType: file.type, size: file.size }];
-        const presignResult = await presign(presignFiles);
-        const item = presignResult[0];
+        const presignFiles = [
+          {
+            filename: file.name,
+            contentType: file.type,
+            size: file.size,
+            ...(compressed && supportsDirectFinalUpload
+              ? {
+                  compressed: {
+                    contentType: compressed.type as 'image/jpeg' | 'image/webp',
+                    size: compressed.size,
+                  },
+                }
+              : {}),
+          },
+        ];
+        const directPresign = supportsDirectFinalUpload ? await presignDirect(presignFiles) : null;
+        const item = directPresign ? directPresign.items[0] : (await presign(presignFiles))[0];
 
         await uploadToSignedUrl(item.original.putUrl, file);
         if (compressed && item.compressed) {
@@ -212,7 +236,9 @@ export default function ArticleEditPage() {
           mimetype: file.type,
         };
 
-        const [finalized] = await finalize([finalizePayload]);
+        const [finalized] = directPresign
+          ? await finalizeDirect([finalizePayload], directPresign.reservationId)
+          : await finalize([finalizePayload]);
         const finalUrl = finalized.compressUrl || finalized.url;
         const finalMarkdown = `![${file.name}](${finalUrl})`;
 

--- a/web/src/pages/profile/index.tsx
+++ b/web/src/pages/profile/index.tsx
@@ -230,7 +230,9 @@ function ProfilePage() {
       const generation = ++avatarUploadGenerationRef.current;
       setAvatarUploading(true);
       const croppedImage = await createCroppedImage(avatarFile, croppedAreaPixels);
-      const attachment = await uploadAvatar(croppedImage);
+      const attachment = await uploadAvatar(croppedImage, {
+        directFinalUpload: siteStatus?.ui?.attachmentDirectFinalUpload === true,
+      });
       const accepted = await acceptPendingAvatarAttachment(attachment, session, generation);
       if (!accepted) {
         setAvatarUploading(false);
@@ -324,7 +326,9 @@ function ProfilePage() {
     setCoverChangeing(true);
     let uploadedAttachment: Attachment | null = null;
     try {
-      uploadedAttachment = await uploadCover(selectedFile);
+      uploadedAttachment = await uploadCover(selectedFile, {
+        directFinalUpload: siteStatus?.ui?.attachmentDirectFinalUpload === true,
+      });
       if (!isMountedRef.current || generation !== coverUploadGenerationRef.current) {
         await deletePendingAttachmentQuietly(uploadedAttachment.id);
         return;

--- a/web/src/pages/profile/utils/avatarUpload.ts
+++ b/web/src/pages/profile/utils/avatarUpload.ts
@@ -1,6 +1,12 @@
 import type { Attachment } from '@/types/main';
 import { del } from '@/utils/api';
-import { finalize, presign, uploadToSignedUrl } from '@/utils/directUpload';
+import {
+  finalize,
+  finalizeDirect,
+  presign,
+  presignDirect,
+  uploadToSignedUrl,
+} from '@/utils/directUpload';
 import { maybeCompressToWebp } from '@/utils/uploadHelpers';
 import type { Area } from 'react-easy-crop';
 
@@ -56,128 +62,104 @@ export async function createCroppedImage(imageSrc: File | Blob, pixelCrop: Area)
   });
 }
 
+type ProfileImageUploadOptions = {
+  directFinalUpload?: boolean;
+  initialQuality: number;
+  maxWidthOrHeight: number;
+};
+
+async function uploadProfileImage(
+  file: File,
+  options: ProfileImageUploadOptions
+): Promise<Attachment> {
+  const contentType = file.type || 'image/jpeg';
+  const compressedBlob = await maybeCompressToWebp(file, {
+    maxWidthOrHeight: options.maxWidthOrHeight,
+    initialQuality: options.initialQuality,
+  });
+  const presignFiles = [
+    {
+      filename: file.name,
+      contentType,
+      size: file.size,
+      ...(compressedBlob && options.directFinalUpload
+        ? {
+            compressed: {
+              contentType: compressedBlob.type as 'image/jpeg' | 'image/webp',
+              size: compressedBlob.size,
+            },
+          }
+        : {}),
+    },
+  ];
+  const directPresign = options.directFinalUpload ? await presignDirect(presignFiles) : null;
+  const item = directPresign ? directPresign.items[0] : (await presign(presignFiles))[0];
+  if (!item) throw new Error('Failed to get presign URL');
+
+  await uploadToSignedUrl(item.original.putUrl, file);
+
+  let compressedKey: string | undefined;
+  if (compressedBlob && item.compressed) {
+    if (directPresign) {
+      await uploadToSignedUrl(item.compressed.putUrl, compressedBlob);
+      compressedKey = item.compressed.key;
+    } else {
+      try {
+        await uploadToSignedUrl(item.compressed.putUrl, compressedBlob);
+        compressedKey = item.compressed.key;
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.warn(`Compressed profile image upload failed for ${item.uuid}:`, error);
+      }
+    }
+  }
+
+  const finalizePayload = [
+    {
+      uuid: item.uuid,
+      originalKey: item.original.key,
+      compressedKey,
+      size: file.size,
+      mimetype: contentType,
+    },
+  ];
+  const finalized = directPresign
+    ? await finalizeDirect(finalizePayload, directPresign.reservationId)
+    : await finalize(finalizePayload);
+
+  if (!finalized?.length) throw new Error('Failed to finalize upload');
+  return finalized[0] as Attachment;
+}
+
 // 上传头像
 export async function uploadAvatar(
   croppedImageBlob: Blob,
-  options?: { maxWidthOrHeight?: number; initialQuality?: number }
+  options?: {
+    directFinalUpload?: boolean;
+    maxWidthOrHeight?: number;
+    initialQuality?: number;
+  }
 ): Promise<Attachment> {
-  // 将 Blob 转换为 File
   const croppedFile = new File([croppedImageBlob], 'cropped_image.png', {
     type: 'image/png',
   });
-
-  // 获取预签名 URL
-  const signItems = await presign([
-    {
-      filename: croppedFile.name,
-      contentType: croppedFile.type,
-      size: croppedFile.size,
-    },
-  ]);
-
-  const item = signItems[0];
-  if (!item) {
-    throw new Error('Failed to get presign URL');
-  }
-
-  // 压缩图片（用于压缩图）
-  const compressedBlob = await maybeCompressToWebp(croppedFile, {
+  return uploadProfileImage(croppedFile, {
+    directFinalUpload: options?.directFinalUpload,
     maxWidthOrHeight: options?.maxWidthOrHeight || 512,
     initialQuality: options?.initialQuality || 0.8,
   });
-
-  // 上传原图（必须成功）
-  await uploadToSignedUrl(item.original.putUrl, croppedFile);
-
-  // 上传压缩图（可选，失败不影响原图）
-  let compressedKey: string | undefined;
-  if (compressedBlob && item.compressed) {
-    try {
-      await uploadToSignedUrl(item.compressed.putUrl, compressedBlob);
-      // 只有上传成功才记录 compressedKey
-      compressedKey = item.compressed.key;
-    } catch (error) {
-      // 压缩图上传失败，但不影响原图，只记录警告
-      // eslint-disable-next-line no-console
-      console.warn(`Compressed avatar upload failed for ${item.uuid}:`, error);
-      // 不设置 compressedKey，表示压缩图未成功上传
-    }
-  }
-
-  // 完成上传
-  const finalized = await finalize([
-    {
-      uuid: item.uuid,
-      originalKey: item.original.key,
-      compressedKey,
-      size: croppedFile.size,
-      mimetype: croppedFile.type,
-    },
-  ]);
-
-  if (finalized && finalized.length > 0) {
-    return finalized[0] as Attachment;
-  } else {
-    throw new Error('Failed to finalize upload');
-  }
 }
 
 // 上传封面
-export async function uploadCover(file: File): Promise<Attachment> {
-  // 获取预签名 URL
-  const signItems = await presign([
-    {
-      filename: file.name,
-      contentType: file.type || 'image/jpeg',
-      size: file.size,
-    },
-  ]);
-
-  const item = signItems[0];
-  if (!item) {
-    throw new Error('Failed to get presign URL');
-  }
-
-  // 压缩图片（用于压缩图）
-  const compressedBlob = await maybeCompressToWebp(file, {
+export async function uploadCover(
+  file: File,
+  options?: { directFinalUpload?: boolean }
+): Promise<Attachment> {
+  return uploadProfileImage(file, {
+    directFinalUpload: options?.directFinalUpload,
     maxWidthOrHeight: 2560,
     initialQuality: 0.8,
   });
-
-  // 上传原图（必须成功）
-  await uploadToSignedUrl(item.original.putUrl, file);
-
-  // 上传压缩图（可选，失败不影响原图）
-  let compressedKey: string | undefined;
-  if (compressedBlob && item.compressed) {
-    try {
-      await uploadToSignedUrl(item.compressed.putUrl, compressedBlob);
-      // 只有上传成功才记录 compressedKey
-      compressedKey = item.compressed.key;
-    } catch (error) {
-      // 压缩图上传失败，但不影响原图，只记录警告
-      // eslint-disable-next-line no-console
-      console.warn(`Compressed cover upload failed for ${item.uuid}:`, error);
-      // 不设置 compressedKey，表示压缩图未成功上传
-    }
-  }
-
-  // 完成上传
-  const finalized = await finalize([
-    {
-      uuid: item.uuid,
-      originalKey: item.original.key,
-      compressedKey,
-      size: file.size,
-      mimetype: file.type || 'image/jpeg',
-    },
-  ]);
-
-  if (finalized && finalized.length > 0) {
-    return finalized[0] as Attachment;
-  } else {
-    throw new Error('Failed to finalize upload');
-  }
 }
 
 export async function deletePendingProfileAttachment(attachmentId: string): Promise<void> {

--- a/web/src/utils/__tests__/directUpload.test.ts
+++ b/web/src/utils/__tests__/directUpload.test.ts
@@ -1,10 +1,19 @@
 import i18n from 'i18next';
-import { beforeAll, describe, expect, it } from 'vitest';
+import { post } from '../api';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import {
+  finalizeDirect,
   getResourceUploadErrorCode,
   getUploadErrorMessage,
   isResourceUploadPolicyError,
+  presignDirect,
 } from '../directUpload';
+
+vi.mock('../api', () => ({ post: vi.fn() }));
+
+afterEach(() => {
+  vi.mocked(post).mockReset();
+});
 
 beforeAll(async () => {
   await i18n.init({
@@ -49,5 +58,77 @@ describe('resource upload errors', () => {
     const error = new Error('Network Error');
     expect(getResourceUploadErrorCode(error)).toBeNull();
     expect(isResourceUploadPolicyError(error)).toBe(false);
+  });
+});
+
+describe('direct final uploads', () => {
+  it('requests final object keys and preserves the reservation identifier', async () => {
+    vi.mocked(post).mockResolvedValue({
+      code: 0,
+      data: {
+        items: [
+          {
+            original: {
+              key: 'users/user/attachments/upload/original.jpg',
+              putUrl: 'https://put.example.com/original.jpg',
+              url: 'https://cdn.example.com/original.jpg',
+            },
+            uuid: 'upload',
+          },
+        ],
+        reservationId: 'reservation',
+      },
+    });
+
+    const result = await presignDirect([
+      {
+        compressed: { contentType: 'image/webp', size: 256 },
+        contentType: 'image/jpeg',
+        filename: 'photo.jpg',
+        size: 1024,
+      },
+    ]);
+
+    expect(post).toHaveBeenCalledWith('/attachments/presign', {
+      directFinalUpload: true,
+      files: [
+        {
+          compressed: { contentType: 'image/webp', size: 256 },
+          contentType: 'image/jpeg',
+          filename: 'photo.jpg',
+          size: 1024,
+        },
+      ],
+    });
+    expect(result.reservationId).toBe('reservation');
+  });
+
+  it('passes the reservation identifier when finalizing an unbound attachment', async () => {
+    vi.mocked(post).mockResolvedValue({ code: 0, data: [{ id: 'attachment' }] });
+
+    await finalizeDirect(
+      [
+        {
+          mimetype: 'image/jpeg',
+          originalKey: 'users/user/attachments/upload/original.jpg',
+          size: 1024,
+          uuid: 'upload',
+        },
+      ],
+      'reservation'
+    );
+
+    expect(post).toHaveBeenCalledWith('/attachments/finalize', {
+      attachments: [
+        {
+          mimetype: 'image/jpeg',
+          originalKey: 'users/user/attachments/upload/original.jpg',
+          size: 1024,
+          uuid: 'upload',
+        },
+      ],
+      noteId: undefined,
+      reservationId: 'reservation',
+    });
   });
 });

--- a/web/src/utils/directUpload.ts
+++ b/web/src/utils/directUpload.ts
@@ -46,7 +46,9 @@ export type PresignFile = {
   contentType?: string;
   size?: number;
   mediaKind?: MediaKind;
+  compressed?: { contentType: 'image/jpeg' | 'image/webp'; size: number };
   pairedVideo?: { filename?: string; contentType?: string; size?: number };
+  poster?: { contentType: 'image/jpeg'; size: number };
 };
 
 export type PresignItem = {
@@ -67,13 +69,29 @@ export interface PresignResponse {
   message?: string;
   data: {
     items: PresignItem[];
+    reservationId?: string;
   };
 }
 
-export async function presign(files: PresignFile[]) {
-  const res = (await post('/attachments/presign', { files })) as PresignResponse;
+async function requestPresign(files: PresignFile[], directFinalUpload = false) {
+  const res = (await post('/attachments/presign', {
+    files,
+    ...(directFinalUpload ? { directFinalUpload: true } : {}),
+  })) as PresignResponse;
   if (res.code !== 0) throw new Error(res.message || 'presign failed');
-  return res.data.items as PresignItem[];
+  return res.data;
+}
+
+export async function presign(files: PresignFile[]) {
+  return (await requestPresign(files)).items;
+}
+
+export async function presignDirect(files: PresignFile[]) {
+  const data = await requestPresign(files, true);
+  if (!data.reservationId) {
+    throw new Error('resource_upload_manifest_mismatch');
+  }
+  return { items: data.items, reservationId: data.reservationId };
 }
 
 export type UploadProgressCallback = (_progress: number) => void;
@@ -196,6 +214,20 @@ export type FinalizeAttachment = {
 
 export async function finalize(attachments: FinalizeAttachment[], noteId?: string) {
   const res = (await post('/attachments/finalize', { attachments, noteId })) as Record<string, any>;
+  if (res.code !== 0) throw new Error(res.message || 'finalize failed');
+  return (res.data as any[]) || [];
+}
+
+export async function finalizeDirect(
+  attachments: FinalizeAttachment[],
+  reservationId: string,
+  noteId?: string
+) {
+  const res = (await post('/attachments/finalize', {
+    attachments,
+    noteId,
+    reservationId,
+  })) as Record<string, any>;
   if (res.code !== 0) throw new Error(res.message || 'finalize failed');
   return (res.data as any[]) || [];
 }


### PR DESCRIPTION
## What changed

- prepare image previews and video posters in the browser before requesting upload credentials
- presign original and derived objects at their final Tencent COS keys with exact content lengths
- finalize unbound browser uploads using the reservation manifest without storage HEAD/COPY calls inside the database transaction
- use the direct-final flow for note, article, avatar, and profile cover uploads on managed instances

## Why

The legacy managed flow uploaded derived objects through the API and copied staging objects during finalize. Slow COS operations held the user row lock, causing finalize retries to queue until the web client timed out after 60 seconds.

## Validation

- server attachment tests: 22 passed
- server lint and build passed
- web tests: 195 passed
- web lint and build passed