### PR TITLE
fix(attachments): close reservation review gaps

### DIFF
--- a/server/attachments/attachmentUpload.test.ts
+++ b/server/attachments/attachmentUpload.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'bun:test';
 import type { UploadResult } from '../types/main';
 import { presignPutUrlForConfig } from '../utils/r2';
-import { presignAttachmentUploads, signedUploadLifetimeSeconds } from './presignUpload';
+import {
+  presignAttachmentUploads,
+  refreshAttachmentUploadReservation,
+  signedUploadLifetimeSeconds,
+} from './presignUpload';
+import { normalizeFinalizeAttachmentsFromManifest } from './finalizePayload';
 import { getUploadExtension } from './uploadKeys';
 
 process.env.POSTGRESQL_URL ||= 'postgres://test:test@localhost:5432/rote_test';
@@ -120,6 +125,90 @@ describe('attachment upload flow', () => {
         manifest
       )
     ).toThrow();
+  });
+
+  it('derives persisted media metadata from the signed reservation manifest', () => {
+    const reservationId = LIVE_UUID;
+    const originalKey = `users/${USER_ID}/staging/${reservationId}/uploads/live.heic`;
+    const pairedVideoKey = `users/${USER_ID}/staging/${reservationId}/paired-videos/live.mov`;
+    const normalized = normalizeFinalizeAttachmentsFromManifest(
+      [
+        {
+          uuid: 'live',
+          originalKey,
+          pairedVideoKey,
+          mimetype: 'video/mp4',
+          mediaKind: 'video',
+          pairedVideoMimetype: 'image/jpeg',
+          pairedVideoSize: 1,
+        },
+      ],
+      [
+        {
+          uuid: 'live',
+          role: 'original',
+          stagingKey: originalKey,
+          finalKey: `users/${USER_ID}/uploads/live.heic`,
+          declaredBytes: '1024',
+          contentType: 'image/heic',
+          billable: true,
+        },
+        {
+          uuid: 'live',
+          role: 'paired_video',
+          stagingKey: pairedVideoKey,
+          finalKey: `users/${USER_ID}/paired-videos/live.mov`,
+          declaredBytes: '2048',
+          contentType: 'video/quicktime',
+          billable: true,
+        },
+      ]
+    );
+
+    expect(normalized[0]).toMatchObject({
+      mimetype: 'image/heic',
+      mediaKind: 'livePhoto',
+      size: 1024,
+      pairedVideoMimetype: 'video/quicktime',
+      pairedVideoSize: 2048,
+    });
+  });
+
+  it('cancels legacy direct-final reservations before refreshing credentials', async () => {
+    let cancelled = false;
+    let refreshed = false;
+    const finalKey = `users/${USER_ID}/uploads/${LIVE_UUID}.jpg`;
+    await expect(
+      refreshAttachmentUploadReservation(USER_ID, LIVE_UUID, {
+        getPendingUploadReservation: async () =>
+          ({
+            id: LIVE_UUID,
+            manifest: [
+              {
+                uuid: LIVE_UUID,
+                role: 'original',
+                stagingKey: finalKey,
+                finalKey,
+                declaredBytes: '1024',
+                contentType: 'image/jpeg',
+                billable: true,
+              },
+            ],
+          }) as never,
+        cancelUploadReservation: async () => {
+          cancelled = true;
+        },
+        refreshUploadReservationCredentialExpiry: async () => {
+          refreshed = true;
+          throw new Error('must not refresh');
+        },
+      })
+    ).rejects.toMatchObject({
+      code: 'resource_upload_manifest_mismatch',
+      status: 409,
+    });
+    expect(cancelled).toBe(true);
+    expect(refreshed).toBe(false);
   });
   it('uses the signed Content-Type to choose the key extension', () => {
     expect(getUploadExtension('photo.webp', 'image/jpeg')).toBe('.jpg');

--- a/server/attachments/finalizeBatch.ts
+++ b/server/attachments/finalizeBatch.ts
@@ -17,6 +17,7 @@ import { MAX_FILES, validateRoteAttachmentDetails } from '../utils/fileValidatio
 import { RESOURCE_ERROR_CODES, ResourcePolicyError } from '../resources/errors';
 import { finalizeAttachmentUploads } from './finalizeUpload';
 import { isDirectFinalUploadManifest } from './directFinalUpload';
+import { normalizeFinalizeAttachmentsFromManifest } from './finalizePayload';
 import type {
   AttachmentBatchOrderReference,
   FinalizeAttachmentBatchInput,
@@ -427,10 +428,17 @@ export async function finalizeAttachmentBatch(params: {
   }
 
   try {
-    const prepared = await prepareUploadsOutsideTransaction(input, claim, params.userId);
+    const normalizedInput = {
+      ...input,
+      attachments: normalizeFinalizeAttachmentsFromManifest(
+        input.attachments,
+        claim.reservation.manifest
+      ),
+    };
+    const prepared = await prepareUploadsOutsideTransaction(normalizedInput, claim, params.userId);
     const result = await persistBatch({
       claim,
-      input,
+      input: normalizedInput,
       objects: prepared.objects,
       uploads: prepared.uploads,
       userId: params.userId,

--- a/server/attachments/finalizePayload.ts
+++ b/server/attachments/finalizePayload.ts
@@ -1,7 +1,7 @@
 import { RESOURCE_ERROR_CODES, ResourcePolicyError } from '../resources/errors';
 import type { UploadReservationManifestItem } from '../resources/service';
 import type { UploadResult } from '../types/main';
-import { inferAttachmentMediaKind } from '../utils/fileValidation';
+import { getMediaKindFromContentType, inferAttachmentMediaKind } from '../utils/fileValidation';
 import type { FinalizeAttachmentInput } from './types';
 
 export function assertCompleteRequiredManifest(
@@ -51,6 +51,43 @@ export function assertCompleteRequiredManifest(
   ) {
     throw new ResourcePolicyError(RESOURCE_ERROR_CODES.uploadManifestMismatch);
   }
+}
+
+export function normalizeFinalizeAttachmentsFromManifest(
+  attachments: readonly FinalizeAttachmentInput[],
+  manifest: readonly UploadReservationManifestItem[]
+): FinalizeAttachmentInput[] {
+  assertCompleteRequiredManifest(attachments, manifest, true);
+  return attachments.map((attachment) => {
+    const objects = manifest.filter((item) => item.uuid === attachment.uuid);
+    const original = objects.find((item) => item.role === 'original');
+    if (!original) {
+      throw new ResourcePolicyError(RESOURCE_ERROR_CODES.uploadManifestMismatch);
+    }
+    const compressed = objects.find((item) => item.role === 'compressed');
+    const poster = objects.find((item) => item.role === 'poster');
+    const pairedVideo = objects.find((item) => item.role === 'paired_video');
+    const mediaKind = pairedVideo ? 'livePhoto' : getMediaKindFromContentType(original.contentType);
+    if (!mediaKind) {
+      throw new ResourcePolicyError(RESOURCE_ERROR_CODES.uploadManifestMismatch);
+    }
+    return {
+      ...attachment,
+      originalKey: original.stagingKey,
+      compressedKey: compressed?.stagingKey,
+      posterKey: poster?.stagingKey,
+      pairedVideoKey: pairedVideo?.stagingKey,
+      mimetype: original.contentType,
+      mediaKind,
+      size: original.declaredBytes === null ? attachment.size : Number(original.declaredBytes),
+      pairedVideoMimetype: pairedVideo?.contentType,
+      pairedVideoSize:
+        pairedVideo?.declaredBytes === null || pairedVideo === undefined
+          ? undefined
+          : Number(pairedVideo.declaredBytes),
+      pairedVideoFilename: undefined,
+    };
+  });
 }
 
 export function toUploadResult(urlPrefix: string, item: FinalizeAttachmentInput): UploadResult {

--- a/server/attachments/finalizeReservation.ts
+++ b/server/attachments/finalizeReservation.ts
@@ -16,6 +16,7 @@ import { upsertAttachmentsByOriginalKey } from '../utils/dbMethods';
 import { validateRoteAttachmentDetails } from '../utils/fileValidation';
 import { isDirectFinalUploadManifest } from './directFinalUpload';
 import { completedLegacyFinalizeResult, finalizeAttachmentUploads } from './finalizeUpload';
+import { normalizeFinalizeAttachmentsFromManifest } from './finalizePayload';
 import type { FinalizeAttachmentInput } from './types';
 
 type ActiveFinalizeClaim = Extract<UploadReservationFinalizeClaim, { kind: 'claimed' }>;
@@ -147,7 +148,6 @@ export async function finalizeAttachmentReservation(
 ): Promise<any[]> {
   const dependencies = { ...defaultDependencies, ...dependencyOverrides };
   const reservationId = input.reservationId.toLowerCase();
-  const normalizedInput = { ...input, reservationId };
   const claimResult = await dependencies.claimUploadReservationForFinalize({
     batchId: reservationId,
     reservationId,
@@ -170,6 +170,14 @@ export async function finalizeAttachmentReservation(
   }
 
   try {
+    const normalizedInput = {
+      ...input,
+      reservationId,
+      attachments: normalizeFinalizeAttachmentsFromManifest(
+        input.attachments,
+        claim.reservation.manifest
+      ),
+    };
     const prepared = await dependencies.prepareReservationUpload(normalizedInput, claim);
     return await dependencies.persistPreparedReservationUpload({
       claim,

--- a/server/attachments/presignUpload.ts
+++ b/server/attachments/presignUpload.ts
@@ -17,12 +17,14 @@ import attachmentErrors from './errorCodes.json';
 import {
   createUploadReservation,
   cancelUploadReservation,
+  getPendingUploadReservation,
   getResourceStateForUserId,
   refreshUploadReservationCredentialExpiry,
   type UploadReservationManifestItem,
 } from '../resources/service';
 import { createDerivedUploadProxyUrl } from '../resources/uploadProxy';
 import { RESOURCE_ERROR_CODES, ResourcePolicyError } from '../resources/errors';
+import { isDirectFinalUploadManifest } from './directFinalUpload';
 
 export type PresignAttachmentDependencies = {
   createDerivedUploadProxyUrl: typeof createDerivedUploadProxyUrl;
@@ -44,6 +46,22 @@ const defaultDependencies: PresignAttachmentDependencies = {
   getResourceStateForUserId,
   createUploadReservation,
   cancelUploadReservation,
+};
+
+type RefreshAttachmentDependencies = {
+  cancelUploadReservation: typeof cancelUploadReservation;
+  createDerivedUploadProxyUrl: typeof createDerivedUploadProxyUrl;
+  getPendingUploadReservation: typeof getPendingUploadReservation;
+  presignPutUrl: typeof presignPutUrl;
+  refreshUploadReservationCredentialExpiry: typeof refreshUploadReservationCredentialExpiry;
+};
+
+const defaultRefreshDependencies: RefreshAttachmentDependencies = {
+  cancelUploadReservation,
+  createDerivedUploadProxyUrl,
+  getPendingUploadReservation,
+  presignPutUrl,
+  refreshUploadReservationCredentialExpiry,
 };
 
 const UPLOAD_RESERVATION_LIFETIME_MS = 24 * 60 * 60 * 1000;
@@ -361,9 +379,22 @@ export async function presignAttachmentUploads(
   };
 }
 
-export async function refreshAttachmentUploadReservation(userId: string, reservationId: string) {
+export async function refreshAttachmentUploadReservation(
+  userId: string,
+  reservationId: string,
+  dependencyOverrides: Partial<RefreshAttachmentDependencies> = {}
+) {
+  const dependencies = { ...defaultRefreshDependencies, ...dependencyOverrides };
   const signingDate = new Date();
-  const reservation = await refreshUploadReservationCredentialExpiry(
+  const pending = await dependencies.getPendingUploadReservation(userId, reservationId);
+  if (!pending) {
+    throw new ResourcePolicyError(RESOURCE_ERROR_CODES.uploadManifestMismatch);
+  }
+  if (isDirectFinalUploadManifest(pending.manifest)) {
+    await dependencies.cancelUploadReservation(userId, reservationId);
+    throw new ResourcePolicyError(RESOURCE_ERROR_CODES.uploadManifestMismatch, 409);
+  }
+  const reservation = await dependencies.refreshUploadReservationCredentialExpiry(
     userId,
     reservationId,
     new Date(signingDate.getTime() + 15 * 60 * 1000)
@@ -372,7 +403,7 @@ export async function refreshAttachmentUploadReservation(userId: string, reserva
   try {
     signedUploadLifetimeSeconds(expiresAt, signingDate);
   } catch (error) {
-    await cancelUploadReservation(userId, reservationId);
+    await dependencies.cancelUploadReservation(userId, reservationId);
     throw error;
   }
   const manifest = reservation.manifest as UploadReservationManifestItem[];
@@ -386,7 +417,7 @@ export async function refreshAttachmentUploadReservation(userId: string, reserva
     [...byUuid.entries()].map(async ([uuid, objects]) => {
       const original = objects.find((item) => item.role === 'original');
       if (!original) throw new ResourcePolicyError(RESOURCE_ERROR_CODES.uploadManifestMismatch);
-      const signedOriginal = await presignPutUrl(
+      const signedOriginal = await dependencies.presignPutUrl(
         original.stagingKey,
         original.contentType,
         signedUploadLifetimeSeconds(expiresAt, signingDate),
@@ -407,7 +438,7 @@ export async function refreshAttachmentUploadReservation(userId: string, reserva
         const object = objects.find((item) => item.role === role);
         if (!object) return undefined;
         if (object.declaredBytes !== null) {
-          const signed = await presignPutUrl(
+          const signed = await dependencies.presignPutUrl(
             object.stagingKey,
             object.contentType,
             signedUploadLifetimeSeconds(expiresAt, signingDate),
@@ -423,7 +454,7 @@ export async function refreshAttachmentUploadReservation(userId: string, reserva
         }
         return {
           key: object.stagingKey,
-          putUrl: createDerivedUploadProxyUrl({
+          putUrl: dependencies.createDerivedUploadProxyUrl({
             reservationId,
             userId,
             role,
@@ -441,7 +472,7 @@ export async function refreshAttachmentUploadReservation(userId: string, reserva
       if (poster) response.poster = poster;
       const paired = objects.find((item) => item.role === 'paired_video');
       if (paired) {
-        const signed = await presignPutUrl(
+        const signed = await dependencies.presignPutUrl(
           paired.stagingKey,
           paired.contentType,
           signedUploadLifetimeSeconds(expiresAt, signingDate),

--- a/server/resources/service.ts
+++ b/server/resources/service.ts
@@ -124,49 +124,9 @@ export async function cancelPendingUploadReservationsForUser(
       .for('update');
     if (activeReservations.length === 0) return;
     const now = new Date();
-    const cleanupNotBefore = activeReservations.reduce(
-      (
-        latest: Date,
-        reservation: {
-          credentialExpiresAt: Date | null;
-          finalizingLeaseExpiresAt: Date | null;
-        }
-      ) => reservationCleanupNotBefore(reservation, latest),
-      now
-    );
-    await enqueueStorageObjectCleanup(
-      transaction,
-      activeReservations.flatMap(({ manifest }: { manifest: unknown }) =>
-        reservationCleanupKeys(manifest as UploadReservationManifestItem[], true)
-      ),
-      cleanupNotBefore
-    );
-    const reservedBytes = activeReservations.reduce(
-      (total: bigint, reservation: { reservedBytes: bigint }) => total + reservation.reservedBytes,
-      BigInt(0)
-    );
-    await transaction
-      .update(resourceStorageAccounts)
-      .set({
-        reservedBytes: sql`GREATEST(0, ${resourceStorageAccounts.reservedBytes} - ${reservedBytes})`,
-        updatedAt: new Date(),
-      })
-      .where(eq(resourceStorageAccounts.userId, userId));
-    await transaction
-      .update(resourceUploadReservations)
-      .set({
-        status: 'cancelled',
-        finalizingBatchId: null,
-        finalizingLeaseToken: null,
-        finalizingLeaseExpiresAt: null,
-        completedAt: new Date(),
-      })
-      .where(
-        and(
-          eq(resourceUploadReservations.userId, userId),
-          inArray(resourceUploadReservations.status, ['pending', 'finalizing'])
-        )
-      );
+    for (const reservation of activeReservations) {
+      await cancelLockedUploadReservation(transaction, reservation, now);
+    }
   };
   if (transactionOverride) await execute(transactionOverride);
   else await db.transaction(execute);
@@ -464,14 +424,17 @@ async function cancelLockedUploadReservation(
   reservation: typeof resourceUploadReservations.$inferSelect,
   now: Date
 ): Promise<void> {
-  await transaction
-    .update(resourceStorageAccounts)
-    .set({
-      reservedBytes: sql`GREATEST(0, ${resourceStorageAccounts.reservedBytes} - ${reservation.reservedBytes})`,
-      updatedAt: now,
-    })
-    .where(eq(resourceStorageAccounts.userId, reservation.userId));
   const cleanupAt = reservationCleanupNotBefore(reservation, now);
+  const releaseChargeNow = cleanupAt.getTime() <= now.getTime();
+  if (releaseChargeNow) {
+    await transaction
+      .update(resourceStorageAccounts)
+      .set({
+        reservedBytes: sql`GREATEST(0, ${resourceStorageAccounts.reservedBytes} - ${reservation.reservedBytes})`,
+        updatedAt: now,
+      })
+      .where(eq(resourceStorageAccounts.userId, reservation.userId));
+  }
   await enqueueStorageObjectCleanup(
     transaction,
     reservationCleanupKeys(reservation.manifest as UploadReservationManifestItem[], true),
@@ -480,11 +443,13 @@ async function cancelLockedUploadReservation(
   await transaction
     .update(resourceUploadReservations)
     .set({
-      status: 'cancelled',
+      status: releaseChargeNow ? 'cancelled' : 'cancelling',
       finalizingBatchId: null,
       finalizingLeaseToken: null,
       finalizingLeaseExpiresAt: null,
       completedAt: now,
+      expiresAt: releaseChargeNow ? reservation.expiresAt : cleanupAt,
+      reservedBytes: releaseChargeNow ? BigInt(0) : reservation.reservedBytes,
     })
     .where(eq(resourceUploadReservations.id, reservation.id));
 }
@@ -887,22 +852,7 @@ export async function cancelUploadReservation(userId: string, id: string) {
       .limit(1)
       .for('update');
     if (!reservation || reservation.status !== 'pending') return;
-    await transaction
-      .update(resourceStorageAccounts)
-      .set({
-        reservedBytes: sql`GREATEST(0, ${resourceStorageAccounts.reservedBytes} - ${reservation.reservedBytes})`,
-        updatedAt: new Date(),
-      })
-      .where(eq(resourceStorageAccounts.userId, userId));
-    await transaction
-      .update(resourceUploadReservations)
-      .set({ status: 'cancelled', completedAt: new Date() })
-      .where(eq(resourceUploadReservations.id, id));
-    await enqueueStorageObjectCleanup(
-      transaction,
-      reservationCleanupKeys(reservation.manifest as UploadReservationManifestItem[], true),
-      reservationCleanupNotBefore(reservation, new Date())
-    );
+    await cancelLockedUploadReservation(transaction, reservation, new Date());
   });
 }
 
@@ -956,21 +906,7 @@ export async function getPendingUploadReservation(
       current.status !== 'grace_period';
     if (replacedEarly) {
       if (transactionOverride) {
-        await transactionOverride
-          .update(resourceStorageAccounts)
-          .set({
-            reservedBytes: sql`GREATEST(0, ${resourceStorageAccounts.reservedBytes} - ${reservation.reservedBytes})`,
-            updatedAt: new Date(),
-          })
-          .where(eq(resourceStorageAccounts.userId, userId));
-        await enqueueStorageObjectCleanup(
-          transactionOverride,
-          reservationCleanupKeys(reservation.manifest as UploadReservationManifestItem[], true)
-        );
-        await transactionOverride
-          .update(resourceUploadReservations)
-          .set({ status: 'cancelled', completedAt: new Date() })
-          .where(eq(resourceUploadReservations.id, reservationId));
+        await cancelLockedUploadReservation(transactionOverride, reservation, new Date());
       } else {
         await cancelUploadReservation(userId, reservationId);
       }

--- a/server/resources/worker.ts
+++ b/server/resources/worker.ts
@@ -289,7 +289,8 @@ export async function runResourceMaintenance(now = new Date()) {
       and(
         or(
           eq(resourceUploadReservations.status, 'pending'),
-          eq(resourceUploadReservations.status, 'finalizing')
+          eq(resourceUploadReservations.status, 'finalizing'),
+          eq(resourceUploadReservations.status, 'cancelling')
         ),
         lte(resourceUploadReservations.expiresAt, now)
       )
@@ -305,7 +306,7 @@ export async function runResourceMaintenance(now = new Date()) {
         .for('update');
       if (
         !locked ||
-        (locked.status !== 'pending' && locked.status !== 'finalizing') ||
+        !['pending', 'finalizing', 'cancelling'].includes(locked.status) ||
         locked.expiresAt > now
       )
         return;
@@ -336,7 +337,7 @@ export async function runResourceMaintenance(now = new Date()) {
       }
       await transaction
         .update(resourceUploadReservations)
-        .set({ status: 'expired', completedAt: now })
+        .set({ status: 'expired', completedAt: now, reservedBytes: BigInt(0) })
         .where(eq(resourceUploadReservations.id, locked.id));
     });
   }
@@ -404,6 +405,7 @@ export async function runResourceMaintenance(now = new Date()) {
     .where(
       and(
         sql`${resourceUploadReservations.status} <> 'pending'`,
+        sql`${resourceUploadReservations.status} <> 'cancelling'`,
         sql`COALESCE(${resourceUploadReservations.completedAt}, ${resourceUploadReservations.createdAt}) <= ${reservationRetention.toISOString()}::timestamptz`
       )
     );


### PR DESCRIPTION
## Summary
- keep cancelled reservation bytes charged until issued upload credentials expire
- derive finalize media metadata from the signed reservation manifest
- reject legacy direct-final manifests before refreshing credentials

## Validation
- `POSTGRESQL_URL=postgres://test:test@localhost:5432/rote_test bun test attachments/attachmentUpload.test.ts attachments/finalizeReservation.test.ts resources/worker.test.ts resources/service.test.ts`
- `bun run lint`
- `bun run build`