### PR TITLE
Harden OpenKey validation and runtime request logs

### DIFF
--- a/server/middleware/recorder.test.ts
+++ b/server/middleware/recorder.test.ts
@@ -26,6 +26,8 @@ describe('request recorder path privacy', () => {
       expect(response.status).toBe(200);
       expect(messages).toHaveLength(1);
       expect(messages[0]).toContain('Path: /internal/billing/grants/:userId');
+      expect(messages[0]).toContain('Status: 200');
+      expect(messages[0]).toMatch(/DurationMs: \d+$/);
       expect(messages[0]).not.toContain(userId);
     } finally {
       log.mockRestore();
@@ -55,8 +57,53 @@ describe('request recorder path privacy', () => {
       expect(response.status).toBe(200);
       expect(messages).toHaveLength(1);
       expect(messages[0]).toContain('Path: /v2/api/billing/app-store/activate');
+      expect(messages[0]).toContain('Status: 200');
+      expect(messages[0]).toMatch(/DurationMs: \d+$/);
       expect(messages[0]).not.toContain(signedTransactionInfo);
       expect(messages[0]).not.toContain('signedTransactionInfo');
+    } finally {
+      log.mockRestore();
+    }
+  });
+
+  it('records the final error status returned by the application handler', async () => {
+    const messages: string[] = [];
+    const log = spyOn(console, 'log').mockImplementation((message) => {
+      messages.push(String(message));
+    });
+    const app = new Hono<{ Variables: HonoVariables }>();
+    app.use('*', recorderIpAndTime);
+    app.get('/failure', () => {
+      throw new Error('expected test failure');
+    });
+    app.onError((_error, c) => c.text('failed', 503));
+
+    try {
+      const response = await app.request('/failure');
+
+      expect(response.status).toBe(503);
+      expect(messages).toHaveLength(1);
+      expect(messages[0]).toContain('Path: /failure');
+      expect(messages[0]).toContain('Status: 503');
+    } finally {
+      log.mockRestore();
+    }
+  });
+
+  it('does not record routine health checks', async () => {
+    const messages: string[] = [];
+    const log = spyOn(console, 'log').mockImplementation((message) => {
+      messages.push(String(message));
+    });
+    const app = new Hono<{ Variables: HonoVariables }>();
+    app.use('*', recorderIpAndTime);
+    app.get('/v2/api/health', (c) => c.json({ ok: true }));
+
+    try {
+      const response = await app.request('/v2/api/health');
+
+      expect(response.status).toBe(200);
+      expect(messages).toHaveLength(0);
     } finally {
       log.mockRestore();
     }

--- a/server/middleware/recorder.ts
+++ b/server/middleware/recorder.ts
@@ -13,7 +13,7 @@ export function normalizeRecordedPath(path: string): string {
 // Request middleware, record IP and time
 export const recorderIpAndTime = async (c: HonoContext, next: () => Promise<void>) => {
   // Skip logging for specific endpoints
-  const ignoredPaths = ['/', '/v1/api/status'];
+  const ignoredPaths = ['/', '/v1/api/status', '/v2/api/health'];
   const path = normalizeRecordedPath(new URL(c.req.url).pathname);
 
   if (ignoredPaths.includes(path)) {
@@ -22,10 +22,13 @@ export const recorderIpAndTime = async (c: HonoContext, next: () => Promise<void
   }
 
   const ipAddress = getClientIp(c);
+  const startTime = performance.now();
 
+  await next();
+
+  const durationMs = Math.max(0, Math.round(performance.now() - startTime));
   const logMessage = `[${moment().format(
     'YYYY/MM/DD HH:mm:ss'
-  )}] IP: ${ipAddress} | Method: ${c.req.method} | Path: ${path}`;
+  )}] IP: ${ipAddress} | Method: ${c.req.method} | Path: ${path} | Status: ${c.res.status} | DurationMs: ${durationMs}`;
   console.log(logMessage);
-  await next();
 };

--- a/server/openKey/middleware.test.ts
+++ b/server/openKey/middleware.test.ts
@@ -17,10 +17,15 @@ beforeAll(async () => {
 
 type UsageAudit = { openKeyId: string; data: UsageLogData };
 
-function createTestApp(options?: { missingOpenKey?: boolean; routeThrows?: boolean }) {
+function createTestApp(options?: {
+  missingOpenKey?: boolean;
+  routeThrows?: boolean;
+  lookupDurationMs?: number;
+}) {
   const openKeyId = randomUUID();
   const audits: UsageAudit[] = [];
   let lookupCount = 0;
+  let currentTime = 1_000;
   const openKeyRouter = new Hono<{ Variables: HonoVariables }>();
 
   openKeyRouter.use(
@@ -28,6 +33,7 @@ function createTestApp(options?: { missingOpenKey?: boolean; routeThrows?: boole
     createOpenKeyMiddleware({
       async getOneOpenKey(id) {
         lookupCount += 1;
+        currentTime += options?.lookupDurationMs ?? 0;
         if (options?.missingOpenKey) throw new DatabaseError('Open key not found');
         return {
           id,
@@ -39,6 +45,9 @@ function createTestApp(options?: { missingOpenKey?: boolean; routeThrows?: boole
       },
       async logOpenKeyUsage(id, data) {
         audits.push({ openKeyId: id, data });
+      },
+      now() {
+        return currentTime;
       },
     })
   );
@@ -69,12 +78,31 @@ describe('OpenKey authentication middleware', () => {
       );
 
       expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({
+        code: 1,
+        message: 'openkey_invalid_credential',
+        data: null,
+      });
       expect(fixture.getLookupCount()).toBe(0);
       expect(fixture.audits).toHaveLength(0);
       expect(messages.join('\n')).not.toContain(credential);
     } finally {
       error.mockRestore();
     }
+  });
+
+  it('returns the same stable error code when the credential is missing', async () => {
+    const fixture = createTestApp();
+    const response = await fixture.app.request('/openkey/resource');
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      code: 1,
+      message: 'openkey_invalid_credential',
+      data: null,
+    });
+    expect(fixture.getLookupCount()).toBe(0);
+    expect(fixture.audits).toHaveLength(0);
   });
 
   it('does not write a foreign-key usage record for a missing credential', async () => {
@@ -97,13 +125,14 @@ describe('OpenKey authentication middleware', () => {
   });
 
   it('records the resolved credential and successful response status', async () => {
-    const fixture = createTestApp();
+    const fixture = createTestApp({ lookupDurationMs: 37 });
     const response = await fixture.app.request(`/openkey/resource?openkey=${fixture.openKeyId}`);
 
     expect(response.status).toBe(201);
     expect(fixture.audits).toHaveLength(1);
     expect(fixture.audits[0].openKeyId).toBe(fixture.openKeyId);
     expect(fixture.audits[0].data.statusCode).toBe(201);
+    expect(fixture.audits[0].data.responseTime).toBe(37);
     expect(fixture.audits[0].data.errorMessage).toBeUndefined();
   });
 

--- a/server/openKey/middleware.test.ts
+++ b/server/openKey/middleware.test.ts
@@ -1,0 +1,125 @@
+import { beforeAll, describe, expect, it, spyOn } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+import { Hono } from 'hono';
+import type { HonoVariables } from '../types/hono';
+import type { UsageLogData } from '../utils/dbMethods/apikey';
+
+let createOpenKeyMiddleware: typeof import('./middleware').createOpenKeyMiddleware;
+let DatabaseError: typeof import('../utils/dbMethods/common').DatabaseError;
+let errorHandler: typeof import('../utils/handlers').errorHandler;
+
+beforeAll(async () => {
+  process.env.POSTGRESQL_URL ||= 'postgres://test:test@127.0.0.1:5432/test';
+  ({ createOpenKeyMiddleware } = await import('./middleware'));
+  ({ DatabaseError } = await import('../utils/dbMethods/common'));
+  ({ errorHandler } = await import('../utils/handlers'));
+});
+
+type UsageAudit = { openKeyId: string; data: UsageLogData };
+
+function createTestApp(options?: { missingOpenKey?: boolean; routeThrows?: boolean }) {
+  const openKeyId = randomUUID();
+  const audits: UsageAudit[] = [];
+  let lookupCount = 0;
+  const openKeyRouter = new Hono<{ Variables: HonoVariables }>();
+
+  openKeyRouter.use(
+    '*',
+    createOpenKeyMiddleware({
+      async getOneOpenKey(id) {
+        lookupCount += 1;
+        if (options?.missingOpenKey) throw new DatabaseError('Open key not found');
+        return {
+          id,
+          userid: randomUUID(),
+          permissions: [],
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        };
+      },
+      async logOpenKeyUsage(id, data) {
+        audits.push({ openKeyId: id, data });
+      },
+    })
+  );
+  openKeyRouter.get('/resource', (c) => {
+    if (options?.routeThrows) throw new Error('expected route failure');
+    return c.json({ ok: true }, 201);
+  });
+
+  const app = new Hono<{ Variables: HonoVariables }>();
+  app.route('/openkey', openKeyRouter);
+  app.onError(errorHandler);
+
+  return { app, audits, getLookupCount: () => lookupCount, openKeyId };
+}
+
+describe('OpenKey authentication middleware', () => {
+  it('rejects malformed credentials before querying or writing usage records', async () => {
+    const credential = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx';
+    const messages: string[] = [];
+    const error = spyOn(console, 'error').mockImplementation((...args) => {
+      messages.push(args.map(String).join(' '));
+    });
+    const fixture = createTestApp();
+
+    try {
+      const response = await fixture.app.request(
+        `/openkey/resource?openkey=${encodeURIComponent(credential)}`
+      );
+
+      expect(response.status).toBe(400);
+      expect(fixture.getLookupCount()).toBe(0);
+      expect(fixture.audits).toHaveLength(0);
+      expect(messages.join('\n')).not.toContain(credential);
+    } finally {
+      error.mockRestore();
+    }
+  });
+
+  it('does not write a foreign-key usage record for a missing credential', async () => {
+    const messages: string[] = [];
+    const error = spyOn(console, 'error').mockImplementation((...args) => {
+      messages.push(args.map(String).join(' '));
+    });
+    const fixture = createTestApp({ missingOpenKey: true });
+
+    try {
+      const response = await fixture.app.request(`/openkey/resource?openkey=${fixture.openKeyId}`);
+
+      expect(response.status).toBe(404);
+      expect(fixture.getLookupCount()).toBe(1);
+      expect(fixture.audits).toHaveLength(0);
+      expect(messages.join('\n')).not.toContain(fixture.openKeyId);
+    } finally {
+      error.mockRestore();
+    }
+  });
+
+  it('records the resolved credential and successful response status', async () => {
+    const fixture = createTestApp();
+    const response = await fixture.app.request(`/openkey/resource?openkey=${fixture.openKeyId}`);
+
+    expect(response.status).toBe(201);
+    expect(fixture.audits).toHaveLength(1);
+    expect(fixture.audits[0].openKeyId).toBe(fixture.openKeyId);
+    expect(fixture.audits[0].data.statusCode).toBe(201);
+    expect(fixture.audits[0].data.errorMessage).toBeUndefined();
+  });
+
+  it('records the final status for a downstream exception', async () => {
+    const error = spyOn(console, 'error').mockImplementation(() => undefined);
+    const fixture = createTestApp({ routeThrows: true });
+
+    try {
+      const response = await fixture.app.request(`/openkey/resource?openkey=${fixture.openKeyId}`);
+
+      expect(response.status).toBe(500);
+      expect(fixture.audits).toHaveLength(1);
+      expect(fixture.audits[0].data.statusCode).toBe(500);
+      expect(fixture.audits[0].data.errorMessage).toBeUndefined();
+    } finally {
+      error.mockRestore();
+    }
+  });
+});

--- a/server/openKey/middleware.ts
+++ b/server/openKey/middleware.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod';
+import type { HonoContext, HonoVariables } from '../types/hono';
+import { getClientIp } from '../utils/main';
+import {
+  getOneOpenKey as getOneOpenKeyFromDatabase,
+  logOpenKeyUsage as logOpenKeyUsageToDatabase,
+  type UsageLogData,
+} from '../utils/dbMethods/apikey';
+
+const OpenKeyCredentialSchema = z.uuid();
+
+type OpenKeyRecord = NonNullable<HonoVariables['openKey']>;
+
+export interface OpenKeyMiddlewareDependencies {
+  getOneOpenKey(id: string): Promise<OpenKeyRecord>;
+  logOpenKeyUsage(openKeyId: string, data: UsageLogData): Promise<void>;
+}
+
+const defaultDependencies: OpenKeyMiddlewareDependencies = {
+  getOneOpenKey: getOneOpenKeyFromDatabase,
+  logOpenKeyUsage: logOpenKeyUsageToDatabase,
+};
+
+export function createOpenKeyMiddleware(
+  dependencies: OpenKeyMiddlewareDependencies = defaultDependencies
+) {
+  return async (c: HonoContext, next: () => Promise<void>) => {
+    const body = await c.req.json().catch(() => ({}));
+    const credential = OpenKeyCredentialSchema.parse(body?.openkey ?? c.req.query('openkey'));
+    const openKey = await dependencies.getOneOpenKey(credential);
+
+    c.set('openKey', openKey);
+
+    const startTime = Date.now();
+    await next();
+
+    void dependencies.logOpenKeyUsage(openKey.id, {
+      endpoint: c.req.path,
+      method: c.req.method,
+      clientIp: getClientIp(c),
+      userAgent: c.req.header('user-agent'),
+      statusCode: c.res.status,
+      responseTime: Date.now() - startTime,
+    });
+  };
+}
+
+export const isOpenKeyOk = createOpenKeyMiddleware();

--- a/server/openKey/middleware.ts
+++ b/server/openKey/middleware.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
+import { HTTPException } from 'hono/http-exception';
 import type { HonoContext, HonoVariables } from '../types/hono';
+import openKeyErrors from '../route/v2/openKey/errorCodes.json';
 import { getClientIp } from '../utils/main';
 import {
   getOneOpenKey as getOneOpenKeyFromDatabase,
@@ -14,11 +16,13 @@ type OpenKeyRecord = NonNullable<HonoVariables['openKey']>;
 export interface OpenKeyMiddlewareDependencies {
   getOneOpenKey(id: string): Promise<OpenKeyRecord>;
   logOpenKeyUsage(openKeyId: string, data: UsageLogData): Promise<void>;
+  now(): number;
 }
 
 const defaultDependencies: OpenKeyMiddlewareDependencies = {
   getOneOpenKey: getOneOpenKeyFromDatabase,
   logOpenKeyUsage: logOpenKeyUsageToDatabase,
+  now: Date.now,
 };
 
 export function createOpenKeyMiddleware(
@@ -26,12 +30,19 @@ export function createOpenKeyMiddleware(
 ) {
   return async (c: HonoContext, next: () => Promise<void>) => {
     const body = await c.req.json().catch(() => ({}));
-    const credential = OpenKeyCredentialSchema.parse(body?.openkey ?? c.req.query('openkey'));
+    const credentialResult = OpenKeyCredentialSchema.safeParse(
+      body?.openkey ?? c.req.query('openkey')
+    );
+    if (!credentialResult.success) {
+      throw new HTTPException(400, { message: openKeyErrors.invalidCredential });
+    }
+
+    const startTime = dependencies.now();
+    const credential = credentialResult.data;
     const openKey = await dependencies.getOneOpenKey(credential);
 
     c.set('openKey', openKey);
 
-    const startTime = Date.now();
     await next();
 
     void dependencies.logOpenKeyUsage(openKey.id, {
@@ -40,7 +51,7 @@ export function createOpenKeyMiddleware(
       clientIp: getClientIp(c),
       userAgent: c.req.header('user-agent'),
       statusCode: c.res.status,
-      responseTime: Date.now() - startTime,
+      responseTime: dependencies.now() - startTime,
     });
   };
 }

--- a/server/route/v2/openKey/errorCodes.json
+++ b/server/route/v2/openKey/errorCodes.json
@@ -1,3 +1,4 @@
 {
-  "invalidBooleanParameterPrefix": "invalid_boolean_parameter:"
+  "invalidBooleanParameterPrefix": "invalid_boolean_parameter:",
+  "invalidCredential": "openkey_invalid_credential"
 }

--- a/server/route/v2/openKeyAttachment.ts
+++ b/server/route/v2/openKeyAttachment.ts
@@ -11,8 +11,9 @@ import {
 } from '../../attachments/uploadMedia';
 import { getAttachmentUploadPolicy } from '../../attachments/uploadPolicy';
 import { requireStorageConfig } from '../../middleware/configCheck';
+import { isOpenKeyOk } from '../../openKey/middleware';
 import type { HonoContext, HonoVariables } from '../../types/hono';
-import { createResponse, isOpenKeyOk } from '../../utils/main';
+import { createResponse } from '../../utils/main';
 import { AttachmentPresignZod } from '../../utils/zod';
 
 const openKeyAttachmentRouter = new Hono<{ Variables: HonoVariables }>();

--- a/server/route/v2/openKeyRouter.ts
+++ b/server/route/v2/openKeyRouter.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import type { HonoVariables } from '../../types/hono';
-import { isOpenKeyOk } from '../../utils/main';
+import { isOpenKeyOk } from '../../openKey/middleware';
 import accountRouter from './openKey/account';
 import articlesRouter from './openKey/articles';
 import attachmentsRouter from './openKey/attachments';

--- a/server/tests/openkey-endpoints.test.ts
+++ b/server/tests/openkey-endpoints.test.ts
@@ -1130,13 +1130,7 @@ export class OpenKeyEndpointsTestSuite {
     try {
       const response = await this.openkeyClient.get('/notes?openkey=invalid-key-12345');
 
-      // 应该返回 401/400/403 或 500 (服务器行为)
-      if (
-        response.status === 401 ||
-        response.status === 400 ||
-        response.status === 403 ||
-        response.status === 500
-      ) {
+      if (response.status === 400) {
         const duration = Date.now() - startTime;
         this.resultManager.recordResult(
           'Error Test: Invalid OpenKey',
@@ -1145,7 +1139,7 @@ export class OpenKeyEndpointsTestSuite {
           duration
         );
       } else {
-        throw new Error(`Expected 401/400/403, got ${response.status}`);
+        throw new Error(`Expected 400, got ${response.status}`);
       }
     } catch (error: any) {
       const duration = Date.now() - startTime;

--- a/server/utils/dbMethods/apikey.ts
+++ b/server/utils/dbMethods/apikey.ts
@@ -84,7 +84,7 @@ export async function deleteMyOneOpenKey(userid: string, id: string): Promise<an
     if (error instanceof DatabaseError) {
       throw error;
     }
-    throw new DatabaseError(`Failed to delete open key: ${id}`, error);
+    throw new DatabaseError('Failed to delete open key', error);
   }
 }
 
@@ -114,7 +114,7 @@ export async function editMyOneOpenKey(
     if (error instanceof DatabaseError) {
       throw error;
     }
-    throw new DatabaseError(`Failed to update open key: ${id}`, error);
+    throw new DatabaseError('Failed to update open key', error);
   }
 }
 
@@ -131,7 +131,7 @@ export async function getOneOpenKey(id: string): Promise<any> {
     if (error instanceof DatabaseError) {
       throw error;
     }
-    throw new DatabaseError(`Failed to get open key: ${id}`, error);
+    throw new DatabaseError('Failed to get open key', error);
   }
 }
 
@@ -148,8 +148,8 @@ export async function logOpenKeyUsage(openKeyId: string, data: UsageLogData): Pr
       responseTime: data.responseTime,
       errorMessage: data.errorMessage,
     });
-  } catch (error) {
-    console.error('Failed to log open key usage:', error);
+  } catch (_error) {
+    console.error('Failed to persist OpenKey usage audit');
   }
 }
 

--- a/server/utils/main.ts
+++ b/server/utils/main.ts
@@ -3,7 +3,6 @@ import type { User } from '../drizzle/schema';
 import type { SiteConfig } from '../types/config';
 import type { HonoContext } from '../types/hono';
 import { getGlobalConfig } from './config';
-import { getOneOpenKey, logOpenKeyUsage } from './dbMethods';
 
 export function getApiUrl(c: HonoContext): string {
   const protocol = c.req.header('x-forwarded-proto') || 'http';
@@ -110,38 +109,6 @@ export async function bodyTypeCheck(c: HonoContext, next: () => Promise<void>) {
   }
 
   await next();
-}
-
-// OpenKey permission validation middleware
-export async function isOpenKeyOk(c: HonoContext, next: () => Promise<void>) {
-  const body = await c.req.json().catch(() => ({}));
-  const openkey = body?.openkey || c.req.query('openkey');
-
-  if (!openkey) {
-    throw new Error('Need openkey!');
-  }
-
-  const startTime = Date.now();
-  let errorMessage: string | undefined;
-  try {
-    const openKey = await getOneOpenKey(openkey.toString());
-    c.set('openKey', openKey);
-    await next();
-  } catch (e: any) {
-    errorMessage = e?.message || String(e);
-    throw e;
-  } finally {
-    // 记录使用日志（无论成功或失败）
-    void logOpenKeyUsage(openkey.toString(), {
-      endpoint: c.req.path,
-      method: c.req.method,
-      clientIp: getClientIp(c),
-      userAgent: c.req.header('user-agent'),
-      statusCode: c.res?.status,
-      responseTime: Date.now() - startTime,
-      errorMessage,
-    });
-  }
 }
 
 export async function injectDynamicUrls(c: HonoContext, next: () => Promise<void>) {

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -29,7 +29,7 @@ server {
     }
 
     # Share bearer paths must not appear in access logs or referrers.
-    location ^~ /s/ {
+    location /s/ {
         access_log off;
         add_header Cache-Control "no-store" always;
         add_header Referrer-Policy "no-referrer" always;
@@ -37,7 +37,7 @@ server {
         try_files /index.html =404;
     }
 
-    location ^~ /assets/ {
+    location /assets/ {
         try_files $uri =404;
         expires 1y;
         add_header Cache-Control "public, immutable";

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -9,6 +9,17 @@ server {
     # below may be immutable; this also covers HTML and manifest.json.
     add_header Cache-Control "no-store" always;
 
+    location = /healthz {
+        access_log off;
+        return 204;
+    }
+
+    # Never let SPA fallback turn probes for hidden files into false 200s.
+    # Keep the standard discovery namespace available for future use.
+    location ~ (^|/)\.(?!well-known(?:/|$)) {
+        return 404;
+    }
+
     location = /sw.js {
         try_files $uri =404;
     }


### PR DESCRIPTION
## Summary
- validate OpenKey credentials before UUID database queries and only audit resolved keys
- remove credential-bearing database errors and record final response status and duration
- suppress routine health logs and return 404 for hidden-file probes while adding a quiet /healthz endpoint

## Validation
- server: bun run lint
- server: bun run build
- server: 19 targeted Bun tests passed
- web: bun run lint
- web: bun run build
- web: 210 Vitest tests passed
- frontend Docker image built and verified: SPA routes 200, /healthz 204 without access logging, hidden files 404