### PR TITLE
fix(notes): require content for every note

### DIFF
--- a/server/utils/zod.test.ts
+++ b/server/utils/zod.test.ts
@@ -21,4 +21,11 @@ describe('note contract compatibility', () => {
     expect(input).toEqual({ title: 'updated title' });
     expect('type' in input).toBe(false);
   });
+
+  test('rejects empty note content on create and update', () => {
+    for (const content of ['', '   ']) {
+      expect(() => NoteCreateZod.parse({ content })).toThrow('Content cannot be empty');
+      expect(() => NoteUpdateZod.parse({ content })).toThrow('Content cannot be empty');
+    }
+  });
 });

--- a/server/utils/zod.ts
+++ b/server/utils/zod.ts
@@ -54,12 +54,15 @@ export const UsernameUpdateZod = z.object({
 });
 
 // 笔记相关验证
+const NoteContentZod = z
+  .string()
+  .min(1, 'Content cannot be empty')
+  .max(1000000, 'Content cannot exceed 1,000,000 characters')
+  .refine((content) => content.trim().length > 0, { message: 'Content cannot be empty' });
+
 export const NoteCreateZod = z.object({
   title: z.string().max(200, 'Title cannot exceed 200 characters').optional(),
-  content: z
-    .string()
-    .min(1, 'Content cannot be empty')
-    .max(1000000, 'Content cannot exceed 1,000,000 characters'), // 约 1MB 文本
+  content: NoteContentZod, // 约 1MB 文本
   tags: z
     .array(
       z.string().min(1, 'Tag cannot be empty').max(50, 'Single tag cannot exceed 50 characters')
@@ -78,7 +81,7 @@ export const NoteCreateZod = z.object({
 
 export const NoteUpdateZod = z.object({
   title: z.string().max(200, 'Title cannot exceed 200 characters').optional(),
-  content: z.string().max(1000000, 'Content cannot exceed 1,000,000 characters').optional(),
+  content: NoteContentZod.optional(),
   tags: z
     .array(
       z.string().min(1, 'Tag cannot be empty').max(50, 'Single tag cannot exceed 50 characters')

--- a/web/src/components/editor/RoteEditor.tsx
+++ b/web/src/components/editor/RoteEditor.tsx
@@ -4,7 +4,7 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import type { Article, Attachment, Rote } from '@/types/main';
 import { del } from '@/utils/api';
-import { isNoteDraftEmpty, NoteSubmission } from '@/features/attachments/noteSubmission';
+import { NoteSubmission } from '@/features/attachments/noteSubmission';
 import type { EditorDraft } from '@/state/editor';
 import { getUploadErrorMessage } from '@/utils/directUpload';
 import { useSiteStatus } from '@/hooks/useSiteStatus';
@@ -271,7 +271,7 @@ function RoteEditor({ roteAtom, callback }: { roteAtom: RoteAtomType; callback?:
 
   const submit = useCallback(async () => {
     if (submittingRef.current) return;
-    if (isNoteDraftEmpty({ content: localContent, attachments: rote.attachments })) {
+    if (!localContent.trim()) {
       toast.error(t('error.emptyContent'));
       return;
     }

--- a/web/src/features/attachments/noteSubmission.test.ts
+++ b/web/src/features/attachments/noteSubmission.test.ts
@@ -3,7 +3,7 @@ import type { Attachment, Rote } from '@/types/main';
 import { emptyRote } from '@/state/editor';
 import { get, post, put } from '@/utils/api';
 import { cancelUploadReservation, uploadToSignedUrl } from '@/utils/directUpload';
-import { isNoteDraftEmpty, NoteSubmission } from './noteSubmission';
+import { NoteSubmission } from './noteSubmission';
 
 vi.mock('@/utils/api', () => ({ get: vi.fn(), post: vi.fn(), put: vi.fn(), del: vi.fn() }));
 vi.mock('@/utils/directUpload', async (original) => ({
@@ -123,12 +123,6 @@ const submit = (session: NoteSubmission, note: Rote) =>
   session.submit(note, createId, capabilities, vi.fn(), vi.fn());
 
 describe('note-first attachment submission', () => {
-  it('accepts attachment-only notes while still rejecting completely empty drafts', () => {
-    expect(isNoteDraftEmpty({ content: '   ', attachments: [] })).toBe(true);
-    expect(isNoteDraftEmpty({ content: '   ', attachments: [existing] })).toBe(false);
-    expect(isNoteDraftEmpty({ content: 'note', attachments: [] })).toBe(false);
-  });
-
   it('saves identity before signing, uploads every part and binds the ordered batch', async () => {
     const onSaved = vi.fn(() => events.push('saved identity'));
     const session = new NoteSubmission();

--- a/web/src/features/attachments/noteSubmission.ts
+++ b/web/src/features/attachments/noteSubmission.ts
@@ -15,10 +15,6 @@ function noteFields(note: Rote) {
   };
 }
 
-export function isNoteDraftEmpty(note: Pick<Rote, 'content' | 'attachments'>): boolean {
-  return note.content.trim().length === 0 && note.attachments.length === 0;
-}
-
 /** Remote note identity is committed before starting any attachment requests. */
 export class NoteSubmission {
   private note?: Rote;


### PR DESCRIPTION
## Summary
- keep the editor rule that note text is required even when attachments are selected
- enforce the same invariant in both create and update server contracts
- reject whitespace-only content without trimming otherwise valid note text

## Validation
- server: `bun run lint`
- server: `bun run build`
- server: 16 targeted note/resource tests passed
- web: `bun run lint`
- web: `bun run build`
- web: all 212 Vitest tests passed

Follow-up to the late review on #367. This intentionally chooses the product rule that empty-content notes are unsupported.