### PR TITLE
feat: expand link preview providers

### DIFF
--- a/server/utils/linkPreview.test.ts
+++ b/server/utils/linkPreview.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from 'bun:test';
+import { extractUrlsFromContent, getProxyUrl, parseLinkPreview } from './linkPreview';
+
+function jsonResponse(value: unknown, status = 200) {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function htmlResponse(title = 'Fallback title') {
+  return new Response(
+    `<html><head><meta property="og:title" content="${title}"><meta property="og:description" content="Fallback description"></head></html>`,
+    { headers: { 'content-type': 'text/html; charset=utf-8' } }
+  );
+}
+
+describe('link preview parsing', () => {
+  test('extracts, normalizes, deduplicates, and limits note links', () => {
+    expect(
+      extractUrlsFromContent(
+        'https://example.com/a#one https://example.com/a#two, https://example.com/b! https://example.com/c https://example.com/d'
+      )
+    ).toEqual(['https://example.com/a', 'https://example.com/b', 'https://example.com/c']);
+  });
+
+  test('parses Bilibili video metadata into the existing preview fields', async () => {
+    const preview = await parseLinkPreview('https://www.bilibili.com/video/BV1xx411c7mD/', (async (
+      input
+    ) => {
+      expect(String(input)).toContain('api.bilibili.com/x/web-interface/view?bvid=BV1xx411c7mD');
+      return jsonResponse({
+        code: 0,
+        data: {
+          title: 'A video',
+          desc: 'Video description',
+          pic: 'http://i0.hdslb.com/cover.jpg',
+          owner: { name: 'Uploader' },
+        },
+      });
+    }) as typeof fetch);
+
+    expect(preview).toMatchObject({
+      title: 'A video',
+      description: 'Video description',
+      image: 'https://i0.hdslb.com/cover.jpg',
+      siteName: 'Bilibili · Uploader',
+    });
+  });
+
+  test('resolves a Bilibili short link before requesting video metadata', async () => {
+    const preview = await parseLinkPreview('https://b23.tv/example', (async (input) => {
+      const url = String(input);
+      if (url === 'https://b23.tv/example') {
+        const response = new Response(null, { status: 302 });
+        Object.defineProperty(response, 'url', {
+          value: 'https://www.bilibili.com/video/BV1example/',
+        });
+        return response;
+      }
+      expect(url).toContain('api.bilibili.com/x/web-interface/view?bvid=BV1example');
+      return jsonResponse({ code: 0, data: { title: 'Short-link video' } });
+    }) as typeof fetch);
+    expect(preview?.title).toBe('Short-link video');
+    expect(preview?.url).toBe('https://b23.tv/example');
+  });
+
+  test('parses Hacker News story metadata', async () => {
+    const preview = await parseLinkPreview('https://news.ycombinator.com/item?id=8863', (async (
+      input
+    ) => {
+      expect(String(input)).toBe('https://hacker-news.firebaseio.com/v0/item/8863.json');
+      return jsonResponse({ title: 'A launch', by: 'author', score: 104, descendants: 71 });
+    }) as typeof fetch);
+
+    expect(preview).toMatchObject({
+      title: 'A launch',
+      description: '104 ↑ · 71 💬',
+      siteName: 'Hacker News · author',
+    });
+  });
+
+  test('parses arXiv title, authors, and summary', async () => {
+    const preview = await parseLinkPreview('https://arxiv.org/pdf/1706.03762.pdf', (async (
+      input
+    ) => {
+      expect(String(input)).toBe('https://export.arxiv.org/api/query?id_list=1706.03762');
+      return new Response(
+        `<?xml version="1.0"?><feed><entry><title> Attention &amp; Models </title><summary> Paper summary. </summary><author><name>Alice</name></author><author><name>Bob</name></author></entry></feed>`,
+        { headers: { 'content-type': 'application/atom+xml' } }
+      );
+    }) as typeof fetch);
+
+    expect(preview).toMatchObject({
+      title: 'Attention & Models',
+      description: 'Paper summary.',
+      siteName: 'arXiv · Alice, Bob',
+    });
+  });
+
+  test('keeps the existing Bluesky proxy behavior', async () => {
+    const original = 'https://bsky.app/profile/example.com/post/abc';
+    expect(getProxyUrl(original)).toBe('https://fxbsky.app/profile/example.com/post/abc');
+    const preview = await parseLinkPreview(original, (async (input) => {
+      expect(String(input)).toBe('https://fxbsky.app/profile/example.com/post/abc');
+      return htmlResponse('A Bluesky post');
+    }) as typeof fetch);
+    expect(preview?.title).toBe('A Bluesky post');
+    expect(preview?.url).toBe(original);
+  });
+
+  test('omits the Bluesky card when its existing proxy cannot provide metadata', async () => {
+    const preview = await parseLinkPreview(
+      'https://bsky.app/profile/example.com/post/missing',
+      (async (input) => {
+        expect(String(input)).toBe('https://fxbsky.app/profile/example.com/post/missing');
+        return new Response(null, { status: 503 });
+      }) as typeof fetch
+    );
+    expect(preview).toBeNull();
+  });
+
+  test.each([
+    'https://www.bilibili.com/video/BV1xx411c7mD/',
+    'https://news.ycombinator.com/item?id=8863',
+    'https://arxiv.org/abs/1706.03762',
+  ])('falls back to ordinary page metadata when special parsing fails: %s', async (url) => {
+    const preview = await parseLinkPreview(url, (async (input) =>
+      String(input) === url ? htmlResponse() : jsonResponse({}, 503)) as typeof fetch);
+    expect(preview).toMatchObject({
+      url,
+      title: 'Fallback title',
+      description: 'Fallback description',
+    });
+  });
+});

--- a/server/utils/linkPreview.ts
+++ b/server/utils/linkPreview.ts
@@ -1,4 +1,5 @@
 import { upsertRoteLinkPreview } from './dbMethods/linkPreview';
+import { parseSpecialLinkPreview, type LinkPreviewDraft } from './linkPreviewProviders';
 
 const MAX_LINK_PREVIEWS = 3;
 const FETCH_TIMEOUT_MS = 8000;
@@ -70,7 +71,7 @@ function calculateScore(data: {
   return score;
 }
 
-function getProxyUrl(originalUrl: string): string {
+export function getProxyUrl(originalUrl: string): string {
   try {
     const url = new URL(originalUrl);
     if (url.hostname === 'twitter.com' || url.hostname === 'www.twitter.com') {
@@ -86,12 +87,12 @@ function getProxyUrl(originalUrl: string): string {
   }
 }
 
-async function fetchHtml(url: string): Promise<string | null> {
+async function fetchHtml(url: string, fetcher: typeof fetch): Promise<string | null> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
   try {
     const proxyUrl = getProxyUrl(url);
-    const response = await fetch(proxyUrl, {
+    const response = await fetcher(proxyUrl, {
       signal: controller.signal,
       headers: {
         'User-Agent': 'Bot', // FxEmbed requires a bot-like UA or they might redirect normal users
@@ -113,9 +114,41 @@ async function fetchHtml(url: string): Promise<string | null> {
   }
 }
 
+export async function parseLinkPreview(
+  url: string,
+  fetcher: typeof fetch = fetch
+): Promise<LinkPreviewDraft | null> {
+  const specialPreview = await parseSpecialLinkPreview(url, fetcher);
+  if (specialPreview) return specialPreview;
+
+  const html = await fetchHtml(url, fetcher);
+  if (!html) return null;
+
+  const title = extractMetaContent(html, 'og:title') || extractTitle(html);
+  const description = extractDescription(html);
+  const image = resolveUrl(url, extractMetaContent(html, 'og:image'));
+  const siteName = extractMetaContent(html, 'og:site_name');
+  const score = calculateScore({ title, description, image, siteName });
+  if (score < MIN_SCORE) return null;
+
+  return {
+    url,
+    title,
+    description,
+    image,
+    siteName,
+    contentExcerpt: description || title || null,
+    score,
+  };
+}
+
 export async function parseAndStoreRoteLinkPreviews(
   roteid: string,
-  content: string
+  content: string,
+  dependencies: {
+    fetcher?: typeof fetch;
+    upsert?: typeof upsertRoteLinkPreview;
+  } = {}
 ): Promise<void> {
   const urls = extractUrlsFromContent(content);
   if (urls.length === 0) {
@@ -124,28 +157,11 @@ export async function parseAndStoreRoteLinkPreviews(
 
   await Promise.allSettled(
     urls.map(async (url) => {
-      const html = await fetchHtml(url);
-      if (!html) return;
-
-      const title = extractMetaContent(html, 'og:title') || extractTitle(html);
-      const description = extractDescription(html);
-      const image = resolveUrl(url, extractMetaContent(html, 'og:image'));
-      const siteName = extractMetaContent(html, 'og:site_name');
-      const score = calculateScore({ title, description, image, siteName });
-
-      if (score < MIN_SCORE) {
-        return;
-      }
-
-      await upsertRoteLinkPreview({
+      const preview = await parseLinkPreview(url, dependencies.fetcher);
+      if (!preview) return;
+      await (dependencies.upsert || upsertRoteLinkPreview)({
         roteid,
-        url,
-        title,
-        description,
-        image,
-        siteName,
-        contentExcerpt: description || title || null,
-        score,
+        ...preview,
       });
     })
   );

--- a/server/utils/linkPreview.ts
+++ b/server/utils/linkPreview.ts
@@ -1,4 +1,4 @@
-import { upsertRoteLinkPreview } from './dbMethods/linkPreview';
+import type { upsertRoteLinkPreview } from './dbMethods/linkPreview';
 import { parseSpecialLinkPreview, type LinkPreviewDraft } from './linkPreviewProviders';
 
 const MAX_LINK_PREVIEWS = 3;
@@ -155,11 +155,14 @@ export async function parseAndStoreRoteLinkPreviews(
     return;
   }
 
+  const upsert =
+    dependencies.upsert || (await import('./dbMethods/linkPreview')).upsertRoteLinkPreview;
+
   await Promise.allSettled(
     urls.map(async (url) => {
       const preview = await parseLinkPreview(url, dependencies.fetcher);
       if (!preview) return;
-      await (dependencies.upsert || upsertRoteLinkPreview)({
+      await upsert({
         roteid,
         ...preview,
       });

--- a/server/utils/linkPreviewProviders.ts
+++ b/server/utils/linkPreviewProviders.ts
@@ -1,0 +1,196 @@
+export type LinkPreviewDraft = {
+  url: string;
+  title: string | null;
+  description: string | null;
+  image: string | null;
+  siteName: string | null;
+  contentExcerpt: string | null;
+  score: number;
+};
+
+type Fetcher = typeof fetch;
+
+function safeUrl(rawUrl: string): URL | null {
+  try {
+    return new URL(rawUrl);
+  } catch {
+    return null;
+  }
+}
+
+function secureImageUrl(value: unknown): string | null {
+  if (typeof value === 'string' && value.trim()) {
+    return value.trim().replace(/^http:\/\//i, 'https://');
+  }
+  return null;
+}
+
+async function fetchJson(url: string, fetcher: Fetcher): Promise<unknown> {
+  try {
+    const response = await fetcher(url, {
+      headers: { Accept: 'application/json', 'User-Agent': 'Rote-LinkPreview/1.0' },
+      signal: AbortSignal.timeout(8000),
+    });
+    if (!response.ok) return null;
+    return await response.json();
+  } catch {
+    return null;
+  }
+}
+
+function directBilibiliVideoReference(url: URL): { key: 'aid' | 'bvid'; value: string } | null {
+  if (!/(^|\.)bilibili\.com$/i.test(url.hostname)) return null;
+  const match = url.pathname.match(/^\/video\/(BV[0-9A-Za-z]+|av(\d+))/i);
+  if (!match) return null;
+  return match[2] ? { key: 'aid', value: match[2] } : { key: 'bvid', value: match[1] };
+}
+
+async function bilibiliVideoReference(
+  url: URL,
+  fetcher: Fetcher
+): Promise<{ key: 'aid' | 'bvid'; value: string } | null> {
+  const direct = directBilibiliVideoReference(url);
+  if (direct) return direct;
+  if (!/(^|\.)b23\.tv$/i.test(url.hostname)) return null;
+  try {
+    const response = await fetcher(url, {
+      headers: { 'User-Agent': 'Rote-LinkPreview/1.0' },
+      signal: AbortSignal.timeout(8000),
+    });
+    await response.body?.cancel();
+    const resolved = safeUrl(response.url);
+    return resolved ? directBilibiliVideoReference(resolved) : null;
+  } catch {
+    return null;
+  }
+}
+
+async function parseBilibili(url: URL, fetcher: Fetcher): Promise<LinkPreviewDraft | null> {
+  const reference = await bilibiliVideoReference(url, fetcher);
+  if (!reference) return null;
+  const endpoint = new URL('https://api.bilibili.com/x/web-interface/view');
+  endpoint.searchParams.set(reference.key, reference.value);
+  const payload = (await fetchJson(endpoint.toString(), fetcher)) as {
+    code?: number;
+    data?: {
+      title?: unknown;
+      desc?: unknown;
+      pic?: unknown;
+      owner?: { name?: unknown };
+    };
+  } | null;
+  const data = payload?.code === 0 ? payload.data : null;
+  if (!data || typeof data.title !== 'string' || !data.title.trim()) return null;
+  const owner = typeof data.owner?.name === 'string' ? data.owner.name.trim() : '';
+  const description = typeof data.desc === 'string' ? data.desc.trim() : '';
+  return {
+    url: url.toString(),
+    title: data.title.trim(),
+    description: description || null,
+    image: secureImageUrl(data.pic),
+    siteName: owner ? `Bilibili · ${owner}` : 'Bilibili',
+    contentExcerpt: description || data.title.trim(),
+    score: 100,
+  };
+}
+
+async function parseHackerNews(url: URL, fetcher: Fetcher): Promise<LinkPreviewDraft | null> {
+  if (url.hostname.toLowerCase() !== 'news.ycombinator.com' || url.pathname !== '/item')
+    return null;
+  const id = url.searchParams.get('id');
+  if (!id || !/^\d+$/.test(id)) return null;
+  const payload = (await fetchJson(
+    `https://hacker-news.firebaseio.com/v0/item/${id}.json`,
+    fetcher
+  )) as {
+    title?: unknown;
+    by?: unknown;
+    score?: unknown;
+    descendants?: unknown;
+  } | null;
+  if (!payload || typeof payload.title !== 'string' || !payload.title.trim()) return null;
+  const author = typeof payload.by === 'string' ? payload.by.trim() : '';
+  const score = typeof payload.score === 'number' ? payload.score : 0;
+  const comments = typeof payload.descendants === 'number' ? payload.descendants : 0;
+  const summary = `${score} ↑ · ${comments} 💬`;
+  return {
+    url: url.toString(),
+    title: payload.title.trim(),
+    description: summary,
+    image: null,
+    siteName: author ? `Hacker News · ${author}` : 'Hacker News',
+    contentExcerpt: summary,
+    score: 90,
+  };
+}
+
+function decodeXml(value: string): string {
+  return value
+    .replace(/&#(\d+);/g, (_match, code) => String.fromCodePoint(Number(code)))
+    .replace(/&#x([0-9a-f]+);/gi, (_match, code) => String.fromCodePoint(Number.parseInt(code, 16)))
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&');
+}
+
+function xmlText(xml: string, tag: string): string | null {
+  const match = xml.match(new RegExp(`<${tag}[^>]*>([\\s\\S]*?)<\\/${tag}>`, 'i'));
+  return match ? decodeXml(match[1]).replace(/\s+/g, ' ').trim() || null : null;
+}
+
+async function parseArxiv(url: URL, fetcher: Fetcher): Promise<LinkPreviewDraft | null> {
+  if (!/(^|\.)arxiv\.org$/i.test(url.hostname)) return null;
+  const match = url.pathname.match(/^\/(?:abs|pdf)\/([^?#]+?)(?:\.pdf)?$/i);
+  if (!match) return null;
+  const id = match[1];
+  let response: Response;
+  try {
+    response = await fetcher(
+      `https://export.arxiv.org/api/query?id_list=${encodeURIComponent(id)}`,
+      {
+        headers: { Accept: 'application/atom+xml', 'User-Agent': 'Rote-LinkPreview/1.0' },
+        signal: AbortSignal.timeout(8000),
+      }
+    );
+  } catch {
+    return null;
+  }
+  if (!response.ok) return null;
+  const xml = await response.text();
+  const entry = xml.match(/<entry>([\s\S]*?)<\/entry>/i)?.[1];
+  if (!entry) return null;
+  const title = xmlText(entry, 'title');
+  if (!title) return null;
+  const description = xmlText(entry, 'summary');
+  const authors = Array.from(entry.matchAll(/<author>([\s\S]*?)<\/author>/gi))
+    .map((author) => xmlText(author[1], 'name'))
+    .filter((author): author is string => Boolean(author));
+  return {
+    url: url.toString(),
+    title,
+    description,
+    image: null,
+    siteName: authors.length ? `arXiv · ${authors.slice(0, 3).join(', ')}` : 'arXiv',
+    contentExcerpt: description || title,
+    score: 90,
+  };
+}
+
+export async function parseSpecialLinkPreview(
+  rawUrl: string,
+  fetcher: Fetcher = fetch
+): Promise<LinkPreviewDraft | null> {
+  const url = safeUrl(rawUrl);
+  if (!url) return null;
+  try {
+    return (
+      (await parseBilibili(url, fetcher)) ||
+      (await parseHackerNews(url, fetcher)) ||
+      (await parseArxiv(url, fetcher))
+    );
+  } catch {
+    return null;
+  }
+}

--- a/web/src/components/rote/roteItem.tsx
+++ b/web/src/components/rote/roteItem.tsx
@@ -264,16 +264,13 @@ function RoteItem({
           </div>
         )}
 
-        {!rote.articleId &&
-          !rote.article &&
-          (rote.attachments?.length || 0) === 0 &&
-          (rote.linkPreviews?.length || 0) > 0 && (
-            <div className="flex flex-col gap-2">
-              {rote.linkPreviews?.map((preview) => (
-                <LinkPreviewCard key={preview.id} preview={preview} />
-              ))}
-            </div>
-          )}
+        {!rote.articleId && !rote.article && (rote.linkPreviews?.length || 0) > 0 && (
+          <div className="flex flex-col gap-2">
+            {rote.linkPreviews?.map((preview) => (
+              <LinkPreviewCard key={preview.id} preview={preview} />
+            ))}
+          </div>
+        )}
 
         {/* Attachments */}
         {rote.attachments?.length > 0 && (

--- a/web/src/features/note-sharing/SharedNotePage.test.tsx
+++ b/web/src/features/note-sharing/SharedNotePage.test.tsx
@@ -138,6 +138,41 @@ describe('anonymous share reader', () => {
     expect(await screen.findByText('Shared by author')).toBeInTheDocument();
   });
 
+  it('shows a link preview together with an attachment when no article is referenced', async () => {
+    vi.mocked(getSharedNote).mockResolvedValueOnce({
+      ...note,
+      article: null,
+      attachments: [
+        {
+          id: 'attachment-1',
+          url: 'https://cdn.example.com/photo.jpg',
+          compressUrl: 'https://cdn.example.com/photo-small.jpg',
+          posterUrl: null,
+          sortIndex: 0,
+          details: { mediaKind: 'image' },
+        },
+      ],
+      linkPreviews: [
+        {
+          id: 'preview-1',
+          url: 'https://example.com/story',
+          title: 'Example story',
+          description: 'Story description',
+          image: null,
+          contentExcerpt: null,
+        },
+      ],
+    });
+    renderPage();
+    expect(await screen.findByRole('link', { name: /Example story/ })).toHaveAttribute(
+      'href',
+      'https://example.com/story'
+    );
+    expect(
+      document.querySelector('img[src="https://cdn.example.com/photo-small.jpg"]')
+    ).not.toBeNull();
+  });
+
   it('refreshes changed content on focus and clears already-read content after revocation', async () => {
     renderPage();
     await screen.findByText(note.content);

--- a/web/src/features/note-sharing/SharedNotePage.tsx
+++ b/web/src/features/note-sharing/SharedNotePage.tsx
@@ -109,7 +109,6 @@ function SharedNoteReader({ token }: { token: string }) {
             <AttachmentsGrid attachments={state.note.attachments} />
           )}
           {!state.note.article &&
-            state.note.attachments.length === 0 &&
             state.note.linkPreviews.map((preview) => (
               <LinkPreviewCard key={preview.id} preview={preview} />
             ))}


### PR DESCRIPTION
## Summary
- add focused Bilibili, Hacker News, and arXiv metadata parsers before the existing generic page parser
- keep the existing Bluesky proxy flow and generic fallback behavior
- allow link previews to render alongside attachments while article references remain exclusive

## Validation
- `server`: `bun test utils/linkPreview.test.ts` (10 passed)
- `server`: `bun run lint`
- `server`: `bun run build`
- `web`: `bun run lint`
- `web`: `bun run build`
- `web`: `bun run test` (45 files, 213 tests passed)
- live read-only smoke checks against Bilibili, Hacker News, and arXiv

Full unfiltered server `bun test` also runs environment-dependent integration suites and could not complete locally because their dedicated PostgreSQL databases and localhost API were not running. The focused tests plus server lint/build passed.