### PR TITLE
docs: link the new Rote Web Clipper repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ For more deployment options and configuration instructions, please check the doc
 
 ### Community Projects
 
+- [Rote Web Clipper](https://github.com/Rabithua/rote-extension) - Browser extension for saving webpages, selected text and supported-site content to Rote, with image attachments, default tags and visibility settings.
 - [Raycast Extension](https://github.com/aBER0724/rote-raycast) - Raycast extension for Rote, developed by [@aBER0724](https://github.com/aBER0724)
 - [Rerote](https://github.com/Rabithua/Rerote) - Data conversion tool that transforms data from other platforms (currently Memos) into Rote format
 - [Rotefeeder](https://github.com/Rabithua/Rotefeeder) - Deno-based RSS/Atom feeder that periodically forwards feed items to Rote via OpenKey

--- a/doc/README.zh.md
+++ b/doc/README.zh.md
@@ -127,6 +127,7 @@ iOS App 支持连接到你自部署的后端。
 
 ### 社区项目
 
+- [Rote 网页收藏助手](https://github.com/Rabithua/rote-extension) - 将网页、选中文字和支持站点的内容保存到 Rote，支持图片附件、默认标签和可见性设置。
 - [Raycast 插件](https://github.com/aBER0724/rote-raycast) - Rote 的 Raycast 插件，由 [@aBER0724](https://github.com/aBER0724) 开发
 - [Rerote](https://github.com/Rabithua/Rerote) - 将其他平台（当前支持 Memos）的数据转换为 Rote 格式的数据转换工具
 - [Rotefeeder](https://github.com/Rabithua/Rotefeeder) - 基于 Deno 的 RSS/Atom 订阅转发服务，通过 OpenKey 定时将内容发送到 Rote


### PR DESCRIPTION
Add the new Rote Web Clipper repository to the English and Chinese README community-project lists, with a short description of webpage, text and image capture. The obsolete extension repository has been retired.

Validation: documentation-only change; checked both links and git diff --check.