### PR TITLE
feat: add Rote Web Clipper to Explore community projects

### DIFF
--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -835,6 +835,10 @@
         "title": "Community Projects",
         "subtitle": "Tools and integrations built around Rote",
         "items": {
+          "roteWebClipper": {
+            "title": "Rote Web Clipper",
+            "description": "Save webpages, text and images to Rote"
+          },
           "raycast": {
             "title": "Raycast Extension",
             "description": "Raycast extension for Rote (by @aBER0724)"

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -839,6 +839,10 @@
         "title": "コミュニティ プロジェクト",
         "subtitle": "Rote を拡張するツールと統合",
         "items": {
+          "roteWebClipper": {
+            "title": "Rote Web Clipper",
+            "description": "ウェブページ、選択したテキスト、画像を Rote に保存"
+          },
           "raycast": {
             "title": "Raycast Extension",
             "description": "Rote 用 Raycast 拡張（by @aBER0724）"

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -825,6 +825,10 @@
         "title": "社区项目",
         "subtitle": "围绕 Rote 的工具与集成",
         "items": {
+          "roteWebClipper": {
+            "title": "Rote 网页收藏助手",
+            "description": "将网页、文字摘录和图片保存到 Rote"
+          },
           "raycast": {
             "title": "Raycast 插件",
             "description": "Rote 的 Raycast Extension（by @aBER0724）"

--- a/web/src/pages/explore/index.tsx
+++ b/web/src/pages/explore/index.tsx
@@ -44,6 +44,10 @@ function formatGithubCount(value: unknown) {
 
 const communityProjects = [
   {
+    key: 'roteWebClipper',
+    href: 'https://github.com/Rabithua/rote-extension',
+  },
+  {
     key: 'roteSkill',
     href: 'https://github.com/Rabithua/rote-skill',
   },


### PR DESCRIPTION
Add Rote Web Clipper at the top of Explore's community projects, linking to the new public repository. Include English, Chinese and Japanese titles and descriptions using the existing project-row styling.

Validation: frontend lint and production build passed; verified all three locale entries and git diff --check.
