### PR TITLE
fix(openkey): make capture creation safely retryable

### DIFF
--- a/server/route/v2/openKey/account.ts
+++ b/server/route/v2/openKey/account.ts
@@ -50,7 +50,14 @@ function validateDateRange(startDate: string | undefined, endDate: string | unde
 
 router.get('/permissions', async (c: HonoContext) => {
   const openKey = requireOpenKey(c);
-  return c.json(createResponse({ permissions: openKey.permissions }), 200);
+  return c.json(
+    createResponse({
+      permissions: openKey.permissions,
+      ownerId: openKey.userid,
+      capabilities: { noteCreateIdempotency: 1 },
+    }),
+    200
+  );
 });
 
 router.get('/profile', requireOpenKeyPerm('EDITPROFILE'), async (c: HonoContext) => {

--- a/server/route/v2/openKey/notes.integration.test.ts
+++ b/server/route/v2/openKey/notes.integration.test.ts
@@ -89,6 +89,53 @@ databaseDescribe('OpenKey note routes', () => {
     await closeDatabase();
   });
 
+  it('advertises authenticated ownership without profile permissions', async () => {
+    const response = await request(`/permissions?openkey=${openKeyId}`);
+    expect(await response.json()).toMatchObject({
+      data: {
+        ownerId: userId,
+        capabilities: { noteCreateIdempotency: 1 },
+      },
+    });
+  });
+
+  it('replays concurrent and lost-response creates with one CREATE event', async () => {
+    const id = randomUUID();
+    const create = (content: string) =>
+      request('/notes', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'Idempotency-Key': id },
+        body: JSON.stringify({ openkey: openKeyId, content }),
+      });
+    const responses = await Promise.all([create('original'), create('original')]);
+    for (const response of responses) {
+      expect(response.status).toBe(201);
+      expect(await response.json()).toMatchObject({ data: { id, content: 'original' } });
+    }
+    // Discard a committed response, then replay with the original identity.
+    await create('must not overwrite');
+    expect(await (await create('again')).json()).toMatchObject({
+      data: { id, content: 'original' },
+    });
+    const events = await database
+      .select()
+      .from(schema.roteChanges)
+      .where(operators.eq(schema.roteChanges.originid, id));
+    expect(events.map((event) => event.action)).toEqual(['CREATE']);
+    const deleted = await request(`/notes/${id}?openkey=${openKeyId}`, { method: 'DELETE' });
+    expect(deleted.status).toBe(200);
+    expect((await create('stale')).status).toBe(409);
+  });
+
+  it('rejects invalid creation identities before creating', async () => {
+    const response = await request('/notes', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'Idempotency-Key': 'invalid' },
+      body: JSON.stringify({ openkey: openKeyId, content: 'invalid identity' }),
+    });
+    expect(response.status).toBe(400);
+  });
+
   it('creates notes through the recommended route without deprecation headers', async () => {
     const response = await post('/notes', {
       content: `modern-${randomUUID()}`,

--- a/server/route/v2/openKey/notes.ts
+++ b/server/route/v2/openKey/notes.ts
@@ -1,10 +1,11 @@
 import { Hono } from 'hono';
+import { HTTPException } from 'hono/http-exception';
 import { z } from 'zod';
 import { createUserNote, deleteUserNote, updateUserNote } from '../../../notes/actions';
 import type { HonoContext, HonoVariables } from '../../../types/hono';
 import { findMyRote, findRoteById, findRotesByIds, searchMyRotes } from '../../../utils/dbMethods';
 import { MAX_BATCH_SIZE } from '../../../utils/fileValidation';
-import { createResponse } from '../../../utils/main';
+import { createResponse, isValidUUID } from '../../../utils/main';
 import { NoteCreateZod, NoteUpdateZod, SearchKeywordZod } from '../../../utils/zod';
 import {
   assertUuid,
@@ -38,7 +39,10 @@ function parsedArchived(value: string | undefined): boolean | undefined {
 async function createNoteFromBody(c: HonoContext) {
   const openKey = requireOpenKey(c);
   const input = NoteCreateZod.parse(await c.req.json());
-  const note = await createUserNote(openKey.userid, input);
+  const identity = c.req.header('Idempotency-Key')?.toLowerCase();
+  if (identity !== undefined && !isValidUUID(identity))
+    throw new HTTPException(400, { message: 'invalid_note_create_identity' });
+  const note = await createUserNote(openKey.userid, input, identity);
   return c.json(createResponse(note), 201);
 }
 
@@ -130,7 +134,7 @@ router.get('/notes/:id', requireOpenKeyPerm('GETROTE'), async (c: HonoContext) =
   const openKey = requireOpenKey(c);
   const id = assertUuid(c.req.param('id'), 'Invalid or missing ID');
   const note = await findRoteById(id, openKey.userid);
-  if (!note) throw new Error('Note not found');
+  if (!note) throw new HTTPException(404, { message: 'Note not found' });
   if (note.state !== 'public' && note.authorid !== openKey.userid) {
     throw new Error('Access denied: note is private');
   }


### PR DESCRIPTION
OpenKey 创建笔记未传递幂等身份，导致扩展在服务器已经提交但响应丢失时无法安全重试。创建接口现在复用现有事务去重机制，`/permissions` 返回账号身份与协议能力，重放返回原笔记且不会复活已删除内容。无效创建身份返回 400，缺失笔记查询返回 404。

验证：服务端 lint/build 通过；独立 PostgreSQL 17 实际执行 OpenKey 路由集成测试 10 项、笔记事务集成测试 8 项，覆盖并发及丢失响应后重放、单一 CREATE 事件、跨账号冲突和删除后重放。
