### PR TITLE
fix(openkey): enforce read scope on idempotent replay

### DIFF
--- a/server/route/v2/openKey/account.ts
+++ b/server/route/v2/openKey/account.ts
@@ -54,7 +54,7 @@ router.get('/permissions', async (c: HonoContext) => {
     createResponse({
       permissions: openKey.permissions,
       ownerId: openKey.userid,
-      capabilities: { noteCreateIdempotency: 1 },
+      capabilities: openKey.permissions.includes('GETROTE') ? { noteCreateIdempotency: 1 } : {},
     }),
     200
   );

--- a/server/route/v2/openKey/notes.integration.test.ts
+++ b/server/route/v2/openKey/notes.integration.test.ts
@@ -99,6 +99,42 @@ databaseDescribe('OpenKey note routes', () => {
     });
   });
 
+  it('does not let a send-only key read existing notes through replay identities', async () => {
+    const secret = `private-note-${randomUUID()}`;
+    const original = (await (await post('/notes', { content: secret })).json()) as NoteResponse;
+    await database
+      .update(schema.userOpenKeys)
+      .set({ permissions: ['SENDROTE'] })
+      .where(operators.eq(schema.userOpenKeys.id, openKeyId));
+    try {
+      const permissions = await request(`/permissions?openkey=${openKeyId}`);
+      expect(await permissions.json()).toMatchObject({ data: { capabilities: {} } });
+      for (const path of ['/notes', '/notes/create']) {
+        for (const identity of [original.data.id, randomUUID()]) {
+          const response = await request(path, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json', 'Idempotency-Key': identity },
+            body: JSON.stringify({ openkey: openKeyId, content: 'unrelated input' }),
+          });
+          expect(response.status).toBe(403);
+          expect(await response.text()).not.toContain(secret);
+        }
+      }
+      // Existing write-only integrations can still create normally without a replay identity.
+      expect((await post('/notes', { content: 'send-only new note' })).status).toBe(201);
+      const originalRows = await database
+        .select()
+        .from(schema.rotes)
+        .where(operators.eq(schema.rotes.id, original.data.id));
+      expect(originalRows[0]?.content).toBe(secret);
+    } finally {
+      await database
+        .update(schema.userOpenKeys)
+        .set({ permissions: ['SENDROTE', 'GETROTE', 'EDITROTE', 'DELETEROTE'] })
+        .where(operators.eq(schema.userOpenKeys.id, openKeyId));
+    }
+  });
+
   it('replays concurrent and lost-response creates with one CREATE event', async () => {
     const id = randomUUID();
     const create = (content: string) =>

--- a/server/route/v2/openKey/notes.ts
+++ b/server/route/v2/openKey/notes.ts
@@ -42,6 +42,11 @@ async function createNoteFromBody(c: HonoContext) {
   const identity = c.req.header('Idempotency-Key')?.toLowerCase();
   if (identity !== undefined && !isValidUUID(identity))
     throw new HTTPException(400, { message: 'invalid_note_create_identity' });
+  // A replay can return a note created by another client of this account.
+  // It therefore needs the same read permission as GET /notes/:id.
+  if (identity !== undefined && !openKey.permissions.includes('GETROTE')) {
+    throw new HTTPException(403, { message: 'Missing required permission: GETROTE' });
+  }
   const note = await createUserNote(openKey.userid, input, identity);
   return c.json(createResponse(note), 201);
 }


### PR DESCRIPTION
修复 #373 的权限审查反馈：仅有 SENDROTE 的密钥可以把同账号已有笔记 UUID 当作创建身份，间接读到笔记内容。携带 Idempotency-Key 的 OpenKey 创建请求现在同时要求 GETROTE，能力公告也按读取权限返回；不带身份的普通新建仍只要求 SENDROTE。扩展已有 GETROTE 权限要求，无需增加权限。

验证：lint/build 通过；独立 PostgreSQL 17 上 11 项 OpenKey 路由测试和 8 项事务测试实际通过。新增测试覆盖两个 POST 路由、已有和随机 UUID 均返回 403、响应不包含私密正文，以及普通只写新建继续成功。#373 的自动部署已在部署步骤前取消。
